### PR TITLE
fix: push version commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,4 +67,5 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: |
           yarn version --patch
+          git push
           git push --tags

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basemaps-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "LINZ specific configuration and delployment of basemaps",
   "repository": "github:linz/basemaps-config",


### PR DESCRIPTION
`git push --tags` does not push the commit