### PR TITLE
feat(imagery/aerial): add Waimate urban 2018

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -110,6 +110,7 @@
     {"id": "01EDA4VRGC5FDK4ZJ12PG3WQ0J", "name": "waikato_urban_2014_0-10m_RGBA"},
     {"id": "01EDA4WARXEH674S1STR101SZJ", "name": "waimakariri_urban_2013-2014_0-075m_RGBA"},
     {"id": "01EDA4WWKTPSFCNDWVW6Y5VS9P", "name": "waimakariri_urban_2015-2016_0-075m_RGBA"},
+    {"id": "01ESF5GRYSF8FD8GJ8C5MBK8H4", "name": "waimate_urban_2018_0-075m_RGB"},
     {"id": "01EDA4XE30ZTT20KTV5AHZH92A", "name": "wairoa_urban_2014-2015_0-10m_RGBA"},
     {"id": "01EDA4XXHW66CF4PFFK8MX379C", "name": "wellington_rural_2016-17_0-3m"},
     {"id": "01EDA4YKQ1H8M5NH9B0GQE4BHK", "name": "wellington_urban_2017_0-10m"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -114,6 +114,7 @@
     {"id": "01ED83NZS98MYTMWM4D1EVZ07T", "name": "waikato_urban_2014_0-10m_RGBA"},
     {"id": "01ED83PPQFH8Z8HNY1WV7W4SS5", "name": "waimakariri_urban_2013-2014_0-075m_RGBA"},
     {"id": "01ED83QD75BDF3D46932B3ZKZD", "name": "waimakariri_urban_2015-2016_0-075m_RGBA"},
+    {"id": "01ESF5HA3BXN5E50Z0608KJGTG", "name": "waimate_urban_2018_0-075m_RGB"},
     {"id": "01ED83R64ZX665P14R805CJVE2", "name": "wairoa_urban_2014-2015_0-10m_RGBA"},
     {"id": "01ED83RWC1W924PXSGA9179Q96", "name": "wellington_rural_2016-17_0-3m"},
     {"id": "01ED83SQ85A7B1MJ42BK13EGCQ", "name": "wellington_urban_2017_0-10m"},


### PR DESCRIPTION
Adds `waimate_urban_2018_0-075m_RGB`

**EPSG:3857**
https://basemaps.linz.govt.nz/?i=01ESF5HA3BXN5E50Z0608KJGTG&v=head&debug=true#@-44.7381474,171.07032214,z11.0294
All Aerial: https://basemaps.linz.govt.nz/?v=pr-10&debug=true#@-44.63374882,171.14429427,z11.4941

**EPSG:2193** 
https://basemaps.linz.govt.nz/?i=01ESF5GRYSF8FD8GJ8C5MBK8H4&p=2193&v=head&debug=true#@-44.73543572,171.16672083,z5.9987
All Aerial: https://basemaps.linz.govt.nz/?v=pr-10&debug=true&p=2193#@-44.63374882,171.14429427,z11.4941


