### PR TITLE
feat(imagery/aerial): add Palmerston North urban 2018-2019

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -87,6 +87,7 @@
     {"id": "01EDA4B6N4GRQ7X9TV09XDRF9P", "name": "otago_urban_2018_0-1m"},
     {"id": "01EDA4BVS53B7TJFPZNKZ05GEV", "name": "palmerston-north_urban_2016-17_1-125m"},
     {"id": "01EDA4CA5AKM9AXCS6TWHBCBZ1", "name": "palmerston-north-city_urban_2014-15_0-125m"},
+    {"id": "01ESF5PJSKPV8JVA3E4MA96W5H", "name": "palmerston-north_urban_2018-2019_0-125m"},
     {"id": "01EDA4CRY0DE139B21GJAPW35H", "name": "porirua_urban_2016_0-075m"},
     {"id": "01EDA4D8YAHVHQ99GRCEXKD64M", "name": "selwyn_urban_2012-2013_0-125m_RGBA"},
     {"id": "01EDA4DYEJ4ER2EH497S8BVZ2Y", "name": "southland_rural_2005-2011_0-75m_RGBA"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -91,6 +91,7 @@
     {"id": "01ED832ZRP7TDQEX5WMVHCP3VM", "name": "otago_urban_2018_0-1m"},
     {"id": "01ED833N7FD05YRW6ZR5799SAZ", "name": "palmerston-north_urban_2016-17_1-125m"},
     {"id": "01ED8346J2H15Z24G6P9SZ7S0P", "name": "palmerston-north-city_urban_2014-15_0-125m"},
+    {"id": "01ESF5MHFP5RCKQW94Z2947CES", "name": "palmerston-north_urban_2018-2019_0-125m"},
     {"id": "01ED834RYVP97AYQVDDQ6MJECY", "name": "porirua_urban_2016_0-075m"},
     {"id": "01ED8355C00DRTSNAQ04AHJDDZ", "name": "selwyn_urban_2012-2013_0-125m_RGBA"},
     {"id": "01ED835ZSP0MQ3W55QEMVZKNR1", "name": "southland_rural_2005-2011_0-75m_RGBA"},


### PR DESCRIPTION
Adding `palmerston-north_urban_2018-2019_0-125m`

**EPSG:2193**
https://basemaps.linz.govt.nz/?i=01ESF5PJSKPV8JVA3E4MA96W5H&v=head&debug=true&p=2193#@-40.38731729,175.63053027,z8.6442
All Imagery: https://basemaps.linz.govt.nz/?v=pr-11&p=2193&debug=true#@-40.38731729,175.63053027,z8.6442

**EPSG:3857**
https://basemaps.linz.govt.nz/?i=01ESF5MHFP5RCKQW94Z2947CES&v=head&debug=true#@-40.32861751,175.65765567,z11.9747 
All Imagery: https://basemaps.linz.govt.nz/?v=pr-11&debug=true#@-40.32861751,175.65765567,z11.9747 