### PR TITLE
feat(imagery/aerial): adding hurunui_urban_2018-2019_0.075m_RGB to aerial layer

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -63,6 +63,7 @@
     {"id": "01EDA3NK57VHJZG9RHWT87H9TJ", "name": "hastings-district_urban_2017-18_0-1m"},
     {"id": "01EDA3P4927YE3DB786NA1CD0E", "name": "hawkes-bay_rural_2014-2015_0-30m_RGBA"},
     {"id": "01EDA3Q5B993AAW8PX7MR54RDH", "name": "hurunui_urban_2013_0-125m_RGBA"},
+    {"id": "01ESPMM6AZW0GH43NRYD7ARR1M", "name": "hurunui_urban_2018-2019_0.075m_RGB"},
     {"id": "01EDA3QGKBF70HBEZJPRJ5WKP3", "name": "hutt-city_urban_2017_0-10m"},
     {"id": "01EDA3R5H9DBQM784J9G0KF4FX", "name": "invercargill_urban_2016_0-05m"},
     {"id": "01EDA3RGB0CBEJY4KNM82B53WX", "name": "invercargill_urban_2016_0-1m"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -67,6 +67,7 @@
     {"id": "01ED82A7KFS8RMNPRYDQ60MCQ1", "name": "hastings-district_urban_2017-18_0-1m"},
     {"id": "01ED82B3R581HMXNDS7HP3ATQ2", "name": "hawkes-bay_rural_2014-2015_0-30m_RGBA"},
     {"id": "01ED82CK977V2ZJ095QZDGSME6", "name": "hurunui_urban_2013_0-125m_RGBA"},
+    {"id": "01ESPMPK1H0CH2G5K839WN1BT9", "name": "hurunui_urban_2018-2019_0.075m_RGB"},
     {"id": "01ED82D0F9NBGVM9WRRT46AV1V", "name": "hutt-city_urban_2017_0-10m"},
     {"id": "01ED82DPKVVWA818DY9QQ9GS0J", "name": "invercargill_urban_2016_0-05m"},
     {"id": "01ED82E60KN099T9A8V11KCSK0", "name": "invercargill_urban_2016_0-1m"},


### PR DESCRIPTION
Hurunui Urban 2018-2019

EPSG:2193 - NZTM
id: 01ESPMM6AZW0GH43NRYD7ARR1M
https://basemaps.linz.govt.nz/?i=01ESPMM6AZW0GH43NRYD7ARR1M&v=head&debug=true&p=2193#@-42.81000461,173.19871741,z6.3459
aerial - https://basemaps.linz.govt.nz/?v=pr-13&p=2193#@-42.56077863,172.80310804,z9.1033

EPSG:3857 - WebMercator

id: 01ESPMPK1H0CH2G5K839WN1BT9
https://basemaps.linz.govt.nz/?i=01ESPMPK1H0CH2G5K839WN1BT9&v=head&debug=true#@-42.87383585,173.13812338,z9.9734
aerial - https://basemaps.linz.govt.nz/?v=pr-13&p=2193#@-42.56077863,172.80310804,z9.1033

Ref
linz/topo-roadmap#19