### PR TITLE
feat(imagery/aerial): adding Selwyn imagery selwyn_urban_2018-2019_0.075m_RGB to aerial layer

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -91,6 +91,7 @@
     {"id": "01EDA4CRY0DE139B21GJAPW35H", "name": "porirua_urban_2016_0-075m"},
     {"id": "01ESJAYEBZ8WT8M81X6SB1F09W", "name": "porirua_urban_2020_0-10m"},
     {"id": "01EDA4D8YAHVHQ99GRCEXKD64M", "name": "selwyn_urban_2012-2013_0-125m_RGBA"},
+    {"id": "01ESPW1197CY4JXEMVES99GZFA", "name": "selwyn_urban_2018-2019_0.075m_RGB"},
     {"id": "01EDA4DYEJ4ER2EH497S8BVZ2Y", "name": "southland_rural_2005-2011_0-75m_RGBA"},
     {"id": "01EDA4FKM3Z5J5D193ZQPX186X", "name": "southland-central-otago_rural_2013-2014_0-40m_RGBA"},
     {"id": "01EDA4GZ292ZNFHBSGPFNJK49Y", "name": "southland-central-otago_rural_2015-2017_0-40m_RGB"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -95,6 +95,7 @@
     {"id": "01ED834RYVP97AYQVDDQ6MJECY", "name": "porirua_urban_2016_0-075m"},
     {"id": "01ESM35CSPVJD54ZMT4T5FVV29", "name": "porirua_urban_2020_0-10m"},
     {"id": "01ED8355C00DRTSNAQ04AHJDDZ", "name": "selwyn_urban_2012-2013_0-125m_RGBA"},
+    {"id": "01ESPVY6HBS1SH79ZH24RW7ZSQ", "name": "selwyn_urban_2018-2019_0.075m_RGB"},
     {"id": "01ED835ZSP0MQ3W55QEMVZKNR1", "name": "southland_rural_2005-2011_0-75m_RGBA"},
     {"id": "01ED83886J46GSSZP6GKCCYGH1", "name": "southland-central-otago_rural_2013-2014_0-40m_RGBA"},
     {"id": "01ED83A271YNKAW0KRH17RPMMV", "name": "southland-central-otago_rural_2015-2017_0-40m_RGB"},


### PR DESCRIPTION
Selwyn Urban 2018-2019

EPSG:2193 - NZTM
id: 01ESPW1197CY4JXEMVES99GZFA
https://basemaps.linz.govt.nz/?i=01ESPW1197CY4JXEMVES99GZFA&v=head&debug=true&p=2193#@-43.56781819,172.04286922,z6.4089
aerial - https://basemaps.linz.govt.nz/?v=pr-14&p=2193#@-43.48527635,172.11765846,z11.8225

EPSG:3857 - WebMercator

id: 01ESPVY6HBS1SH79ZH24RW7ZSQ
https://basemaps.linz.govt.nz/?i=01ESPVY6HBS1SH79ZH24RW7ZSQ&v=head&debug=true#@-43.50496578,172.11616193,z9.9985
aerial - https://basemaps.linz.govt.nz/?v=pr-14#@-43.60151651,172.37221051,z14.7161

Ref
linz/topo-roadmap#1