### PR TITLE
feat(imagery/aerial): adding new processed copy of christchurch_urban_2015-2016_0-075m

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -45,7 +45,7 @@
       "id": "01ED88T9RVGXKGCK18MYDD2KTE", "name": "chatham-islands_digital-globe_2014-2019_0-5m",
       "maxZoom": 8
     },
-    {"id": "01EDA3FT891AGG62BNH4JDVMVQ", "name": "christchurch_urban_2015-2016_0-075m_RGBA"},
+    {"id": "01EWEQ49T0SC2N4T1VXC8W2ZYS", "name": "christchurch_urban_2015-2016_0-075m_RGBA"},
     {"id": "01EDA3H4RZBMYCWP24HPSA75EB", "name": "christchurch_urban_2018_0-075m"},
     {"id": "01EMFSD0PPZ5WQ318J2V6S2E2G", "name": "christchurch_urban_2018-2019_0-075m_RGB"},
     {"id": "01EDA3HDWP06KMW74MRTZGA8FW", "name": "dunedin_rural_2013_0-40m_RGBA"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -49,7 +49,7 @@
       "id": "01ED849PJ44FA7S612QAXN9P11", "name": "chatham-islands_digital-globe_2014-2019_0-5m",
       "maxZoom": 12
     },
-    {"id": "01ED8247MCZAFRW0KGWYKNWDQ6", "name": "christchurch_urban_2015-2016_0-075m_RGBA"},
+    {"id": "01EWEQ26HDCMDQKTZ1RHSXPBEW", "name": "christchurch_urban_2015-2016_0-075m_RGBA"},
     {"id": "01ED825VGXM6K9YX52DP7SMXQE", "name": "christchurch_urban_2018_0-075m"},
     {"id": "01EMFHZ28DMWDCJ7VEE15HTYPZ", "name": "christchurch_urban_2018-2019_0-075m_RGB"},
     {"id": "01ED8265AEHZM2DHB43GBFE5BG", "name": "dunedin_rural_2013_0-40m_RGBA"},


### PR DESCRIPTION
**These are still processing and should be ready in about 30minutes**

Christchurch urban (`christchurch_urban_2015-2016_0-075m_RGBA`) had a collection of giant white squares inside the imagery as some of the source imagery had not been processed into a transparent layer.

![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3562393566363664336361333763353733653337356133352f62646130346661302d383032642d343663382d393866642d396239373630386239653632](https://user-images.githubusercontent.com/1082761/105117559-8fdbbd80-5b31-11eb-9992-c6ecd6e0e588.png)

Vs the reprocessed

![image](https://user-images.githubusercontent.com/1082761/105117703-d3362c00-5b31-11eb-81aa-39f573dd6992.png)


**EPSG:3857 - WebMercator** [01EWEQ26HDCMDQKTZ1RHSXPBEW](https://basemaps.linz.govt.nz/?i=01EWEQ26HDCMDQKTZ1RHSXPBEW&v=head#@-43.79524854,172.93885027,z13.4734) [aerial](https://basemaps.linz.govt.nz/?v=pr-16#@-43.79524854,172.93885027,z13.4734)
**EPSG:2193 - NZTM** [01EWEQ49T0SC2N4T1VXC8W2ZYS](https://basemaps.linz.govt.nz/?i=01EWEQ49T0SC2N4T1VXC8W2ZYS&v=head&p=2193#@-43.65859654,172.84111169,z6.3906) [aerial](https://basemaps.linz.govt.nz/?v=pr-16&p=2193#)

