### PR TITLE
feat(imagery/aerial): adding tasman_rural_2020_0.3m_RGB.

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -103,6 +103,7 @@
     {"id": "01EDA4KRS61NBDJT66681TRB35", "name": "tasman_rural_2015-16_0-3m"},
     {"id": "01EDA4M6Q1XV8QMHYWKTSH1E52", "name": "tasman_rural_2016-17_0-3m"},
     {"id": "01EDA4MQPTX3K90SBVCA97JJEX", "name": "tasman_rural_2018-19_0-3m"},
+    {"id": "01EXJVE1W1D93VA0PVD3T5TXB6", "name": "tasman_rural_2020_0.3m_RGB"},
     {"id": "01EDA4NB1NQCEH1Y9F26XB77C1", "name": "tasman_urban_2017_0-075m"},
     {"id": "01EDA4NKP819M06YJXFX076DZ8", "name": "tasman_urban_2017_0-1m"},
     {"id": "01EDA4P8QKZM6PVDBMAPQS81YD", "name": "tauranga_urban_2017_0-1m"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -107,6 +107,7 @@
     {"id": "01ED83CXGMGPXTF67SETE7YBWP", "name": "tasman_rural_2015-16_0-3m"},
     {"id": "01ED83DC7MCMBCRNN45E07HCHH", "name": "tasman_rural_2016-17_0-3m"},
     {"id": "01ED83DSMR8N1FQFVXM8JASBV2", "name": "tasman_rural_2018-19_0-3m"},
+    {"id": "01EXJV4VZ22G163H5565R2D04R", "name": "tasman_rural_2020_0.3m_RGB"},
     {"id": "01ED83ENCYFX7KFVKH0S7SK92W", "name": "tasman_urban_2017_0-075m"},
     {"id": "01ED83F2SBS02QP80KSQ3GRR92", "name": "tasman_urban_2017_0-1m"},
     {"id": "01ED83FS8PC1YC7Y7WKJ90P5TN", "name": "tauranga_urban_2017_0-1m"},


### PR DESCRIPTION
Tasman Rural 2020

EPSG:2193 - NZTM
id: 01EXJVE1W1D93VA0PVD3T5TXB6
https://basemaps.linz.govt.nz/?i=01EXJVE1W1D93VA0PVD3T5TXB6&v=head&debug=true&p=2193#@-41.71757294,172.89603213,z9.8928
aerial - https://basemaps.linz.govt.nz/?v=pr-18&p=2193#@-41.71757294,172.89603213,z9.8928

EPSG:3857 - WebMercator
id: 01EXJV4VZ22G163H5565R2D04R
https://basemaps.linz.govt.nz/?i=01EXJV4VZ22G163H5565R2D04R&v=head&debug=true#@-41.71757294,172.89603213,z9.8928
aerial - https://basemaps.linz.govt.nz/?v=pr-18#@-41.71757294,172.89603213,z9.8928

Ref
linz/topo-roadmap#30