### PR TITLE
feat(imagery/aerial): adding hawkes-bay_rural_2018-2019_0.3m_RGB

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -62,6 +62,7 @@
     {"id": "01EDN10VAW9TEEKNMHXV4N8VA4", "name": "hastings-district_urban_2014-2015_0-10m_RGB"},
     {"id": "01EDA3NK57VHJZG9RHWT87H9TJ", "name": "hastings-district_urban_2017-18_0-1m"},
     {"id": "01EDA3P4927YE3DB786NA1CD0E", "name": "hawkes-bay_rural_2014-2015_0-30m_RGBA"},
+    {"id": "01EYH1E63CY2QJSVBM9GMT2E7H", "name": "hawkes-bay_rural_2018-2019_0.3m_RGB"},
     {"id": "01EDA3Q5B993AAW8PX7MR54RDH", "name": "hurunui_urban_2013_0-125m_RGBA"},
     {"id": "01ESPMM6AZW0GH43NRYD7ARR1M", "name": "hurunui_urban_2018-2019_0.075m_RGB"},
     {"id": "01EDA3QGKBF70HBEZJPRJ5WKP3", "name": "hutt-city_urban_2017_0-10m"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -66,6 +66,7 @@
     {"id": "01EDN0YH2TM1B5NWHR4RHGBMPF", "name": "hastings-district_urban_2014-2015_0-10m_RGB"},
     {"id": "01ED82A7KFS8RMNPRYDQ60MCQ1", "name": "hastings-district_urban_2017-18_0-1m"},
     {"id": "01ED82B3R581HMXNDS7HP3ATQ2", "name": "hawkes-bay_rural_2014-2015_0-30m_RGBA"},
+    {"id": "01EYH18XFNJM0E7WNYDVK9KGGD", "name": "hawkes-bay_rural_2018-2019_0.3m_RGB"},
     {"id": "01ED82CK977V2ZJ095QZDGSME6", "name": "hurunui_urban_2013_0-125m_RGBA"},
     {"id": "01ESPMPK1H0CH2G5K839WN1BT9", "name": "hurunui_urban_2018-2019_0.075m_RGB"},
     {"id": "01ED82D0F9NBGVM9WRRT46AV1V", "name": "hutt-city_urban_2017_0-10m"},


### PR DESCRIPTION
Hawkes bay Rural 2020

EPSG:2193 - NZTM
id: 01EYH1E63CY2QJSVBM9GMT2E7H
imagery - https://basemaps.linz.govt.nz/?i=01EYH1E63CY2QJSVBM9GMT2E7H&v=head&debug=true&p=2193#@-39.74595895,176.50860833,z4.9545
pull request -  https://basemaps.linz.govt.nz/?v=pr-19&p=2193#@-39.74595895,176.50860833,z4.9545

EPSG:3857 - WebMercator
id: 01EYH18XFNJM0E7WNYDVK9KGGD
imagery - https://basemaps.linz.govt.nz/?i=01EYH18XFNJM0E7WNYDVK9KGGD&v=head&debug=true#@-39.74193239,176.92391278,z8.6266
pull request - https://basemaps.linz.govt.nz/?v=pr-19#@-39.74193239,176.92391278,z8.6266

Ref
linz/topo-roadmap#31