### PR TITLE
feat(imagery/aerial): gisborne_rural_2017-2019_0.3m_RGB

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -56,6 +56,7 @@
     },
     {"id": "01EDMTX2V21CHFNB517ZC9KC6E", "name": "gisborne_rural_2012-2013_0-40m_RGBA"},
     {"id": "01EDA3JXYMT46H99ZJT62BFR90", "name": "gisborne_rural_2017-18_0-3m"},
+    {"id": "01EYPQVF9PRVJY03DES7C5JD9F", "name": "gisborne_rural_2017-2019_0.3m_RGBA"},
     {"id": "01ECTWQ56NF2AZQESNW0NSJ12W", "name": "gisborne_urban_2017-18_0-1m"},
     {"id": "01EDA3KPC6XV5TDHC5MWR95B20", "name": "hamilton_urban_2016-17_0-1m"},
     {"id": "01EDA3M70TPA4H32K7KKDXDRV6", "name": "hamilton_urban_2019_0-1m"},

--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -56,7 +56,7 @@
     },
     {"id": "01EDMTX2V21CHFNB517ZC9KC6E", "name": "gisborne_rural_2012-2013_0-40m_RGBA"},
     {"id": "01EDA3JXYMT46H99ZJT62BFR90", "name": "gisborne_rural_2017-18_0-3m"},
-    {"id": "01EYPQVF9PRVJY03DES7C5JD9F", "name": "gisborne_rural_2017-2019_0.3m_RGBA"},
+    {"id": "01EZWZF16E9AH34KRXVGY4DN1C", "name": "gisborne_rural_2017-2019_0.3m_RGB"},
     {"id": "01ECTWQ56NF2AZQESNW0NSJ12W", "name": "gisborne_urban_2017-18_0-1m"},
     {"id": "01EDA3KPC6XV5TDHC5MWR95B20", "name": "hamilton_urban_2016-17_0-1m"},
     {"id": "01EDA3M70TPA4H32K7KKDXDRV6", "name": "hamilton_urban_2019_0-1m"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -60,7 +60,7 @@
     },
     {"id": "01EDMTSQF19FQB09MS46ZFWWRM", "name": "gisborne_rural_2012-2013_0-40m_RGBA"},
     {"id": "01ECTS06BSSHA626JHSDTNSC97", "name": "gisborne_rural_2017-18_0-3m"},
-    {"id": "01EYPQSWDJ397DRFPWQJHMPF3P", "name": "gisborne_rural_2017-2019_0.3m_RGBA"},
+    {"id": "01EZWZGMW2Q53VNC65X2X4VFRZ", "name": "gisborne_rural_2017-2019_0.3m_RGB"},
     {"id": "01ECTS33A3VYA5A8ZBHCDFYFR8", "name": "gisborne_urban_2017-18_0-1m"},
     {"id": "01EDAN1CYCXAEMG21PB6VCD0KX", "name": "hamilton_urban_2016-17_0-1m"},
     {"id": "01ED8284FFT9RYZ0F7XTKD64D4", "name": "hamilton_urban_2019_0-1m"},

--- a/config/imagery/aerial-3857.json
+++ b/config/imagery/aerial-3857.json
@@ -60,6 +60,7 @@
     },
     {"id": "01EDMTSQF19FQB09MS46ZFWWRM", "name": "gisborne_rural_2012-2013_0-40m_RGBA"},
     {"id": "01ECTS06BSSHA626JHSDTNSC97", "name": "gisborne_rural_2017-18_0-3m"},
+    {"id": "01EYPQSWDJ397DRFPWQJHMPF3P", "name": "gisborne_rural_2017-2019_0.3m_RGBA"},
     {"id": "01ECTS33A3VYA5A8ZBHCDFYFR8", "name": "gisborne_urban_2017-18_0-1m"},
     {"id": "01EDAN1CYCXAEMG21PB6VCD0KX", "name": "hamilton_urban_2016-17_0-1m"},
     {"id": "01ED8284FFT9RYZ0F7XTKD64D4", "name": "hamilton_urban_2019_0-1m"},


### PR DESCRIPTION
Gisborne bay Rural 2020

EPSG:2193 - NZTM
id: 01EZWZF16E9AH34KRXVGY4DN1C
imagery - https://basemaps.linz.govt.nz/?i=01EZWZF16E9AH34KRXVGY4DN1C&v=head&debug=true&p=2193#@-38.07428027,177.99312564,z7.2496
pull request - https://basemaps.linz.govt.nz/?v=pr-20&p=2193#@-38.07428027,177.99312564,z7.2496

EPSG:3857 - WebMercator
id: 01EZWZGMW2Q53VNC65X2X4VFRZ
imagery - https://basemaps.linz.govt.nz/?i=01EZWZGMW2Q53VNC65X2X4VFRZ&v=head&debug=true#@-38.05410487,177.8364418,z9.1751
pull request - https://basemaps.linz.govt.nz/?v=pr-20#@-38.05410487,177.8364418,z9.1751

Ref
linz/topo-roadmap#36