### PR TITLE
feat(imagery/aerial): add improved gebco for nztm2000quad

### DIFF
--- a/config/imagery/aerial-2193.json
+++ b/config/imagery/aerial-2193.json
@@ -51,7 +51,7 @@
     {"id": "01EDA3HDWP06KMW74MRTZGA8FW", "name": "dunedin_rural_2013_0-40m_RGBA"},
     {"id": "01EDA3J3JQGR5DX5XY8T7PANHV", "name": "dunedin_urban_2018-19_0-1m"},
     {
-      "id": "01EDD8XJZ5TPY1SKPC26B1CQNW", "name": "gebco_2020_305-75m",
+      "id": "01F1BFJN8R8P7BXN3XTHC5MT5G", "name": "gebco_2020_305-75m",
       "priority": 0, "maxZoom": 10
     },
     {"id": "01EDMTX2V21CHFNB517ZC9KC6E", "name": "gisborne_rural_2012-2013_0-40m_RGBA"},


### PR DESCRIPTION
This switches the NZTM2000 gebco layer for one that has a greater area so that it works better in NZTM2000Quad

Gebco Layer
[2193](https://basemaps.linz.govt.nz/?p=2193&i=01F1BFJN8R8P7BXN3XTHC5MT5G&v=head#@-42.16233885,175.6359337,z2.1827)
[NZTM2000Quad](https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=01F1BFJN8R8P7BXN3XTHC5MT5G&v=head#@-38.50439414,174.70639941,z2.5952)

Aerial Layer

[2193](https://basemaps.linz.govt.nz/?v=pr-21&p=nztm2000#@-39.74595895,176.50860833,z4.9545)
[NZTM2000Quad](https://basemaps.linz.govt.nz/?v=pr-21&p=nztm2000quad#@-39.74595895,176.50860833,z4.9545)


Old Coverage area
![index](https://user-images.githubusercontent.com/1082761/111935736-fc226f80-8b28-11eb-9cd2-6f5fe312e9d8.png)


New Coverage Aera
![image](https://user-images.githubusercontent.com/1082761/111935699-e614af00-8b28-11eb-8268-0839f20af027.png)
