### PR TITLE
perf: use the same bucket for all of the assets

### DIFF
--- a/config/tileset/topographic.json
+++ b/config/tileset/topographic.json
@@ -1,5 +1,5 @@
 {
   "type": "vector",
   "id": "ts_topographic",
-  "layers": [{ "3857": "s3://linz-basemaps-vector/3857/01F8E735464ZMVGRAQD7RNMEHF/topographic.covt", "name": "topographic" }]
+  "layers": [{ "3857": "s3://linz-basemaps/vector/3857/01F8E735464ZMVGRAQD7RNMEHF/topographic.covt", "name": "topographic" }]
 }


### PR DESCRIPTION
After some performance testing splitting the buckets between imagery and vector data has caused the number of initial TLS connection delays to double.

An initial TLS connection to S3 generally takes 200-300ms and every subsequent request generally 10-30ms. by using two buckets we doubled the number of initial TLS connections.