### PR TITLE
feat(aerial): update tasman rural to new larger tasman rural

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -49,7 +49,7 @@
     { "2193": "im_01F6P1VDEYFR0XB5XJMN9X6V1C", "3857": "im_01ED83DSMR8N1FQFVXM8JASBV2", "name": "tasman_rural_2018-19_0-3m", "minZoom": 13 },
     { "2193": "im_01F66E7K4ESMSWZ1CNMCQ8B700", "3857": "im_01ED81W4KDQQRW9PEQ9KS7T8DV", "name": "bay-of-plenty_urban_2018-19_0-1m", "minZoom": 13, "maxZoom": 13 },
     { "2193": "im_01F66E4BR5XTJENFTSACWB55DM", "3857": "im_01ED81R5BX4EB3W7TB3Z8ZE89S", "name": "bay-of-plenty_rural_2019_0-3m", "minZoom": 13 },
-    { "2193": "im_01F6P1VP3MR21HRWWRXW0XC252", "3857": "im_01EXJV4VZ22G163H5565R2D04R", "name": "tasman_rural_2020_0-3m_RGB", "minZoom": 13 },
+    { "2193": "im_01FBGB1QN859XRGNNWT6ZBHEN8", "3857": "im_01FBGB0T73562VAZBEBHZ7E84T", "name": "tasman_rural_2020_0-3m_RGB", "minZoom": 13 },
     { "2193": "im_01F6P1Q0MQC2FXNDVZJGT88CC2", "3857": "im_01ED8355C00DRTSNAQ04AHJDDZ", "name": "selwyn_urban_2012-2013_0-125m_RGBA", "minZoom": 14 },
     { "2193": "im_01F6P1XAGNDZVM0DH9JCFSE7QB", "3857": "im_01ED83HWB82K047N1KYK9A5SKD", "name": "timaru_urban_2012-2013_0-075m_RGBA", "minZoom": 14 },
     { "2193": "im_01F6P1965MX7W515NM9VR90V67", "3857": "im_01ED82CK977V2ZJ095QZDGSME6", "name": "hurunui_urban_2013_0-125m_RGBA", "minZoom": 14 },

--- a/src/cli.import.config.ts
+++ b/src/cli.import.config.ts
@@ -49,7 +49,8 @@ export class CommandImport extends Command {
     }
 
     if (flags.commit) {
-      for (const invalidate of this.invalidates) {
+      // Limit invalidations
+      for (const invalidate of this.invalidates.slice(0, 10)) {
         logger.warn(`FlushCache: ${invalidate}`);
         await invalidateCache(invalidate, flags.commit);
       }


### PR DESCRIPTION
Massive increase in coverage after a new delivery of imagery.

EPSG:2193
id: 01FBGB1QN859XRGNNWT6ZBHEN8
https://basemaps.linz.govt.nz/?i=01FBGB1QN859XRGNNWT6ZBHEN8&p=nztm2000quad&debug=true#@-41.8020714,172.9271309,z6.9065
EPSG:3857
id: 01FBGB0T73562VAZBEBHZ7E84T
https://basemaps.linz.govt.nz/?i=01FBGB0T73562VAZBEBHZ7E84T&debug=true#@-41.7483813,172.6836625,z8.182

ref: linz/topo-roadmap#30

**Old imagery** - [Basemaps](https://basemaps.linz.govt.nz/?i=01EXJV4VZ22G163H5565R2D04R) - [2193](https://basemaps.linz.govt.nz/?i=01F6P1VP3MR21HRWWRXW0XC252&p=nztm2000quad)


![tasman_rural_2020](https://user-images.githubusercontent.com/1082761/127412217-49f3038e-c8d9-4ea7-be32-1f34749ec42f.png)


**New imagery** - [Basemaps](https://basemaps.linz.govt.nz/?i=01FBGB0T73562VAZBEBHZ7E84T) - [2193](https://basemaps.linz.govt.nz/?i=01FBGB1QN859XRGNNWT6ZBHEN8&p=nztm2000quad)

![tasman_rural_2021](https://user-images.githubusercontent.com/1082761/127412212-3211f774-186a-4131-af08-0bd504b2a8a7.png)
