### PR TITLE
feat(aerial): Import kapiti-coast_urban_2021_0.075m_RGB config into basemaps.

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -78,7 +78,7 @@
     { "2193": "im_01F6P168K626GCA0RY790XHRVY", "3857": "im_01ECTS33A3VYA5A8ZBHCDFYFR8", "name": "gisborne_urban_2017-18_0-1m", "minZoom": 14 },
     { "2193": "im_01F6P17PSJ1SWNYV2V28922WKY", "3857": "im_01ED82A7KFS8RMNPRYDQ60MCQ1", "name": "hastings-district_urban_2017-18_0-1m", "minZoom": 14 },
     { "2193": "im_01F6P19XT96PPWHAABTAGXGV3N", "3857": "im_01ED82D0F9NBGVM9WRRT46AV1V", "name": "hutt-city_urban_2017_0-10m", "minZoom": 14 },
-    { "2193": "im_01F6P1AY3301N4H0F7694CZ4N5", "3857": "im_01ED82FXR5R33KER1D48S11RHC", "name": "kapity-coast_urban_2017_0-10m", "minZoom": 14 },
+    { "2193": "im_01FC1XYXHBADGNDYM36SH8D1XY", "3857": "im_01FC1Y20KQZQDJESGSR97G9SSW", "name": "kapiti-coast_urban_2021_0.075m_RGB", "minZoom": 14 },
     { "2193": "im_01F6P1EM0AK6GZN9TG913VB6CH", "3857": "im_01ED82QS0GBHX38Z6B1YHQNZM0", "name": "marlborough_urban_2017-18_0-1m", "minZoom": 14 },
     { "2193": "im_01F6P1F7BT85M2T5S01FXWAPPD", "3857": "im_01ED82S7R88B0CGQWZKH4V7R2H", "name": "napier-city_urban_2017-18_0-05m", "minZoom": 14 },
     { "2193": "im_01F6P1FCJZWD8JY7DJEDEB45K7", "3857": "im_01ED82SKPVV12M4RYHRK08DWG4", "name": "napier-city_urban_2017-18_0-1m", "minZoom": 14 },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -78,7 +78,7 @@
     { "2193": "im_01F6P168K626GCA0RY790XHRVY", "3857": "im_01ECTS33A3VYA5A8ZBHCDFYFR8", "name": "gisborne_urban_2017-18_0-1m", "minZoom": 14 },
     { "2193": "im_01F6P17PSJ1SWNYV2V28922WKY", "3857": "im_01ED82A7KFS8RMNPRYDQ60MCQ1", "name": "hastings-district_urban_2017-18_0-1m", "minZoom": 14 },
     { "2193": "im_01F6P19XT96PPWHAABTAGXGV3N", "3857": "im_01ED82D0F9NBGVM9WRRT46AV1V", "name": "hutt-city_urban_2017_0-10m", "minZoom": 14 },
-    { "2193": "im_01FC1XYXHBADGNDYM36SH8D1XY", "3857": "im_01FC1Y20KQZQDJESGSR97G9SSW", "name": "kapiti-coast_urban_2021_0.075m_RGB", "minZoom": 14 },
+    { "2193": "im_01FC1XYXHBADGNDYM36SH8D1XY", "3857": "im_01FC1Y20KQZQDJESGSR97G9SSW", "name": "kapiti-coast_urban_2021_0-075m_RGB", "minZoom": 14 },
     { "2193": "im_01F6P1EM0AK6GZN9TG913VB6CH", "3857": "im_01ED82QS0GBHX38Z6B1YHQNZM0", "name": "marlborough_urban_2017-18_0-1m", "minZoom": 14 },
     { "2193": "im_01F6P1F7BT85M2T5S01FXWAPPD", "3857": "im_01ED82S7R88B0CGQWZKH4V7R2H", "name": "napier-city_urban_2017-18_0-05m", "minZoom": 14 },
     { "2193": "im_01F6P1FCJZWD8JY7DJEDEB45K7", "3857": "im_01ED82SKPVV12M4RYHRK08DWG4", "name": "napier-city_urban_2017-18_0-1m", "minZoom": 14 },


### PR DESCRIPTION
WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FC1Y20KQZQDJESGSR97G9SSW&debug=true#@-40.8697146,175.1265201,z10.2799

NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FC1XYXHBADGNDYM36SH8D1XY&p=NZTM2000Quad&debug=true#@-40.8689122,175.1528513,z8.5632

New Images
![image](https://user-images.githubusercontent.com/12163920/127935646-a4bbc25c-d70a-4770-aaf3-d99319ca3c2a.png)

Old Images
![image](https://user-images.githubusercontent.com/12163920/127935595-ac0221f0-c40b-4b4a-8279-deff13378257.png)
