### PR TITLE
fix(scripts): remove the pbf after the invalidate path.

### DIFF
--- a/src/tileset.config.ts
+++ b/src/tileset.config.ts
@@ -149,6 +149,6 @@ export class TileSetUpdater extends Updater<TileSetConfigSchema, ConfigTileSet> 
   invalidatePath(): string {
     const name = Config.unprefix(this.db.prefix, this.config.id);
     if (this.config.type === TileSetType.Raster) return `/v1/tiles/${name}/*`;
-    return `/v1/tiles/${name}/*.pbf`;
+    return `/v1/tiles/${name}/*`;
   }
 }


### PR DESCRIPTION
add `.pdf` at the end of invalidate path seems not working very well and also we need to clear the cache for other format.