### PR TITLE
vector(basic): use the transportation layer for names

### DIFF
--- a/config/style/basic.json
+++ b/config/style/basic.json
@@ -916,7 +916,7 @@
       },
       "id": "road_major_label",
       "source": "openmaptiles",
-      "source-layer": "transportation_name",
+      "source-layer": "transportation",
       "type": "symbol",
       "minzoom": 13
     },


### PR DESCRIPTION
We do not use a transportation_name layer for our road names so get the names directly from the transportation layer
