### PR TITLE
feat(style): use relative local paths for glyphs and sprites

### DIFF
--- a/config/style/aerialhybrid.json
+++ b/config/style/aerialhybrid.json
@@ -20,7 +20,7 @@
     }
   },
   "sprite": "https://maputnik.github.io/osm-liberty/sprites/osm-liberty",
-  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+  "glyphs": "/glyphs/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "Aerial-Imagery",

--- a/config/style/basic.json
+++ b/config/style/basic.json
@@ -1034,7 +1034,7 @@
     "source": "https://github.com/openmaptiles/maptiler-basic-gl-style",
     "license": "https://github.com/openmaptiles/maptiler-basic-gl-style/blob/master/LICENSE.md"
   },
-  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+  "glyphs": "/glyphs/{fontstack}/{range}.pbf",
   "sprite": "",
   "id": "st_basic"
 }

--- a/config/style/topographic.json
+++ b/config/style/topographic.json
@@ -7,8 +7,8 @@
     "LINZ Basemaps": { "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json", "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0" },
     "LINZ-Texture-Relief": { "type": "raster", "tiles": ["/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp"], "tileSize": 256, "minzoom": 0, "maxzoom": 20 }
   },
-  "sprite": "https://basemaps.linz.govt.nz/sprites/topographic",
-  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+  "sprite": "/sprites/topographic",
+  "glyphs": "/glyphs/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "Background",


### PR DESCRIPTION
This moves fonts/glyphs across to basemaps.linz.govt.nz
