### PR TITLE
feat(aerial): Config auckland rural 2020 into basemaps.

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -129,6 +129,7 @@
     { "2193": "im_01FPXB0T4ZCASWGX1X1GVEHDQZ", "3857": "im_01FPXB36CCAK3FC6FWCMK1D156", "name": "christchurch_urban_2020-2021_0.075m_RGB", "minZoom": 14 },
     { "2193": "im_01FPXAY15VB9MES5WQ0N2SPEG6", "3857": "im_01FPXB6TVAQZV4W9KXWQ7H5ZQA", "name": "christchurch_urban_2021_0-05m_RGB", "minZoom": 14 },
     { "2193": "im_01FSWMVSKCNWK9H4J3JP6RAQ0S", "3857": "im_01FSWMXCT9AF67HW8BQKV9WM0K", "name": "waitaki_urban_2020-2021_0-075m_RGB", "minZoom": 14 },
+    { "2193": "im_01FXP9YHEQM6XA6DDEGNKMEE7H", "3857": "im_01FXPA0F9WZS0MMABYHRCFYMV0", "name": "auckland_rural_2020_0-075m_RGB", "minZoom": 13 },
     { "3857": "im_01FM8DEN1XG1QGNT229A4T3KZ6", "name": "geographx_nz_dem_2012_8-0m", "maxZoom": 14 },
     { "3857": "im_01FMK5CJHR30YG9A0JDNVXYCKN", "name": "geographx_nz_texture_2012_8-0m", "maxZoom": 14 }
   ]

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -66,7 +66,6 @@
     { "2193": "im_01F6P1P22165F058BN82D3ZY8Q", "3857": "im_01ED8346J2H15Z24G6P9SZ7S0P", "name": "palmerston-north-city_urban_2014-15_0-125m", "minZoom": 14 },
     { "2193": "im_01F6P1ZQZ4X5GHHX544CJJ3NNH", "3857": "im_01ED83NZS98MYTMWM4D1EVZ07T", "name": "waikato_urban_2014_0-10m_RGBA", "minZoom": 14 },
     { "2193": "im_01F6P20PT6TN7XVJGPSA7NPQ93", "3857": "im_01ED83R64ZX665P14R805CJVE2", "name": "wairoa_urban_2014-2015_0-10m_RGBA", "minZoom": 14 },
-    { "2193": "im_01F66DTSZM8AZ85YZMRY7ZA3AV", "3857": "im_01ED81CFNWK9R75S0277SW972N", "name": "auckland_urban_2015-16_0-075m", "minZoom": 14 },
     { "2193": "im_01F66E63QY3BR3W3ARXRBPK1NP", "3857": "im_01ED81TJP9G5Q6VJKG921RT0QS", "name": "bay-of-plenty_urban_2015-16_0-125m", "minZoom": 14 },
     { "2193": "im_01F66E757Y78C33NKN50W9PW5C", "3857": "im_01ED81VN7AJ586W5HK2BSPHAPH", "name": "bay-of-plenty_urban_2015-16_0-1m", "minZoom": 14 },
     { "2193": "im_01F6P0KPJJK4MJ3JZVS0DJK0Q7", "3857": "im_01EWEQ26HDCMDQKTZ1RHSXPBEW", "name": "christchurch_urban_2015-2016_0-075m_RGBA", "minZoom": 14 },


### PR DESCRIPTION
As discussed, we want to put this above the all the Auckland urban layers. 