### PR TITLE
feat(aerial): Config imagery ōtorohanga_urban_2021_0.1m_RGB into Aerial Map. BM-489

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -754,6 +754,12 @@
       "minZoom": 14
     },
     {
+      "2193": "s3://linz-basemaps/2193/ōtorohanga_urban_2021_0-1m_RGB/01FYWKAJ86W9P7RWM1VB62KD0H",
+      "3857": "s3://linz-basemaps/3857/ōtorohanga_urban_2021_0-1m_RGB/01FYWKATAEK2ZTJQ2PX44Y0XNT",
+      "name": "ōtorohanga_urban_2021_0-1m_RGB",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01FXP9YHEQM6XA6DDEGNKMEE7H",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01FXPA0F9WZS0MMABYHRCFYMV0",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for ōtorohanga_urban_2021_0.1m_RGB, please use the following QA url once the aws job finished.
NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FYWKAJ86W9P7RWM1VB62KD0H&p=NZTM2000Quad&debug#@-38.112026,175.028521,z9
WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FYWKATAEK2ZTJQ2PX44Y0XNT&p=WebMercatorQuad&debug#@-38.104305,175.025940,z12
Tagged Aerial URL: https://basemaps.linz.govt.nz/?i=aerial@pr-465