### PR TITLE
feat(aerial): Config imagery antipodes-islands_satellite_2019-2020_0.5m_RGB into Aerial Map. BM-507

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -27,6 +27,12 @@
       "name": "nz_satellite_2020-2021_10m_RGB"
     },
     {
+      "2193": "s3://linz-basemaps/2193/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5MYGMYCH5WPDCP1DMYHZ8",
+      "3857": "s3://linz-basemaps/3857/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5N4E6Q4P2TV3MP94BKTMB",
+      "name": "antipodes-islands_satellite_2019-2020_0-5m_RGB",
+      "minZoom": 10
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -30,7 +30,7 @@
       "2193": "s3://linz-basemaps/2193/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5MYGMYCH5WPDCP1DMYHZ8",
       "3857": "s3://linz-basemaps/3857/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5N4E6Q4P2TV3MP94BKTMB",
       "name": "antipodes-islands_satellite_2019-2020_0-5m_RGB",
-      "minZoom": 10
+      "minZoom": 5
     },
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",


### PR DESCRIPTION
Imagery imported for antipodes-islands_satellite_2019-2020_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FZY5MYGMYCH5WPDCP1DMYHZ8&p=NZTM2000Quad&debug#@-49.668296,178.775313,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FZY5N4E6Q4P2TV3MP94BKTMB&p=WebMercatorQuad&debug#@-49.678293,178.769531,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-476#@-49.668296,178.775313,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-476#@-49.678293,178.769531,z12

