### PR TITLE
feat(aerial): Config imagery kermadec-islands_satellite_2020-2021_0.5m_RGB into Aerial Map. BM-511

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -27,6 +27,12 @@
       "name": "nz_satellite_2020-2021_10m_RGB"
     },
     {
+      "2193": "s3://linz-basemaps/2193/kermadec-islands_satellite_2020-2021_0-5m_RGB/01FZYCK7YYWR4CP4AYCSKYMZDS",
+      "3857": "s3://linz-basemaps/3857/kermadec-islands_satellite_2020-2021_0-5m_RGB/01FZYCKG1C4DJFY9VMHEKA8M55",
+      "name": "kermadec-islands_satellite_2020-2021_0-5m_RGB",
+      "minZoom": 10
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",


### PR DESCRIPTION
Imagery imported for kermadec-islands_satellite_2020-2021_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FZYCK7YYWR4CP4AYCSKYMZDS&p=NZTM2000Quad&debug#@-30.285724,-178.334960,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FZYCKG1C4DJFY9VMHEKA8M55&p=WebMercatorQuad&debug#@-30.306503,-178.341064,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-477#@-30.285724,-178.334960,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-477#@-30.306503,-178.341064,z12

