### PR TITLE
feat(aerial): Config imagery auckland-islands_satellite_2014-2021_0.5m_RGB into Aerial Map. BM-508

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -27,6 +27,12 @@
       "name": "nz_satellite_2020-2021_10m_RGB"
     },
     {
+      "2193": "s3://linz-basemaps/2193/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYCRNFJBB5YJGT2JTWZV1N3",
+      "3857": "s3://linz-basemaps/3857/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYCS0KZQ4FV5EN3S3RYH975",
+      "name": "auckland-islands_satellite_2014-2021_0-5m_RGB",
+      "minZoom": 10
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",


### PR DESCRIPTION
Imagery imported for auckland-islands_satellite_2014-2021_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FZYCRNFJBB5YJGT2JTWZV1N3&p=NZTM2000Quad&debug#@-50.685864,166.100465,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FZYCS0KZQ4FV5EN3S3RYH975&p=WebMercatorQuad&debug#@-50.719069,166.063843,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-478#@-50.685864,166.100465,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-478#@-50.719069,166.063843,z12

