### PR TITLE
feat(aerial): Config imagery campbell-island-motu-ihupuku_satellite_2015-2020_0.5m_RGB into Aerial Map. BM-510

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -27,6 +27,12 @@
       "name": "nz_satellite_2020-2021_10m_RGB"
     },
     {
+      "2193": "s3://linz-basemaps/2193/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01FZYCX24HPP164KW21SRQXSP4",
+      "3857": "s3://linz-basemaps/3857/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01FZYCXAVYAFAWPR1TSYJ1AS7B",
+      "name": "campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB",
+      "minZoom": 10
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",


### PR DESCRIPTION
Imagery imported for campbell-island-motu-ihupuku_satellite_2015-2020_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FZYCX24HPP164KW21SRQXSP4&p=NZTM2000Quad&debug#@-52.544712,169.196903,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FZYCXAVYAFAWPR1TSYJ1AS7B&p=WebMercatorQuad&debug#@-52.549636,169.123535,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-480#@-52.544712,169.196903,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-480#@-52.549636,169.123535,z12

