### PR TITLE
feat(aerial): Config imagery snares-islands-tini-heke_satellite_2019-2020_0.5m_RGB into Aerial Map. BM-512

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -27,6 +27,12 @@
       "name": "nz_satellite_2020-2021_10m_RGB"
     },
     {
+      "2193": "s3://linz-basemaps/2193/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01FZYD0RX6GX3CVS4ZZTYPFY03",
+      "3857": "s3://linz-basemaps/3857/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01FZYD10ATW1YM1MPJB9B2VFV8",
+      "name": "snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB",
+      "minZoom": 10
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",


### PR DESCRIPTION
Imagery imported for snares-islands-tini-heke_satellite_2019-2020_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FZYD0RX6GX3CVS4ZZTYPFY03&p=NZTM2000Quad&debug#@-48.042018,166.560930,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FZYD10ATW1YM1MPJB9B2VFV8&p=WebMercatorQuad&debug#@-48.030346,166.563721,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-481#@-48.042018,166.560930,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-481#@-48.030346,166.563721,z12

