### PR TITLE
feat(aerial): Config imagery auckland-islands_satellite_2014-2021_0.5m_RGB into Aerial Map. BM-508

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -35,7 +35,7 @@
     {
       "2193": "s3://linz-basemaps/2193/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5MYGMYCH5WPDCP1DMYHZ8",
       "3857": "s3://linz-basemaps/3857/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5N4E6Q4P2TV3MP94BKTMB",
-      "name": "antipodes-islands_satellite_2019-2020_0-5m_RGB",      
+      "name": "antipodes-islands_satellite_2019-2020_0-5m_RGB",
       "minZoom": 5
     },
     {

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -27,6 +27,12 @@
       "name": "nz_satellite_2020-2021_10m_RGB"
     },
     {
+      "2193": "s3://linz-basemaps/2193/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8BB9EBP892F3JQSSSHQG",
+      "3857": "s3://linz-basemaps/3857/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8NX9DE6ZA3Y5VK1QAHNK",
+      "name": "auckland-islands_satellite_2014-2021_0-5m_RGB",
+      "minZoom": 5
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",


### PR DESCRIPTION
Imagery imported for auckland-islands_satellite_2014-2021_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FZYE8BB9EBP892F3JQSSSHQG&p=NZTM2000Quad&debug#@-50.685864,166.100465,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FZYE8NX9DE6ZA3Y5VK1QAHNK&p=WebMercatorQuad&debug#@-50.708634,166.069336,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-482#@-50.685864,166.100465,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-482#@-50.708634,166.069336,z12

