### PR TITLE
feat(aerial): Config imagery bounty-islands_satellite_2020_0.5m_RGB into Aerial Map. BM-509

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -33,6 +33,12 @@
       "minZoom": 5
     },
     {
+      "2193": "s3://linz-basemaps/2193/bounty-islands_satellite_2020_0-5m_RGB/01FZYK75PS5DM0BKGZ885RZ94D",
+      "3857": "s3://linz-basemaps/3857/bounty-islands_satellite_2020_0-5m_RGB/01FZYK7C7Y9GHSPRKM4B4C5RSY",
+      "name": "bounty-islands_satellite_2020_0-5m_RGB",
+      "minZoom": 5
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",


### PR DESCRIPTION
Imagery imported for bounty-islands_satellite_2020_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01FZYK75PS5DM0BKGZ885RZ94D&p=NZTM2000Quad&debug#@-47.761324,179.033890,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01FZYK7C7Y9GHSPRKM4B4C5RSY&p=WebMercatorQuad&debug#@-47.761484,179.033203,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-483#@-47.761324,179.033890,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-483#@-47.761484,179.033203,z12

