### PR TITLE
feat(aerial): Config imagery campbell-island-motu-ihupuku_satellite_2015-2020_0.5m_RGB into Aerial Map. BM-510

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -48,7 +48,7 @@
       "2193": "s3://linz-basemaps/2193/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E8Y3HSN66NDDKP89H2VTT",
       "3857": "s3://linz-basemaps/3857/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E9728953QMD6NY7BVDGSN",
       "name": "campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB",
-      "minZoom": 5
+      "minZoom": 2
     },
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -45,6 +45,12 @@
       "minZoom": 5
     },
     {
+      "2193": "s3://linz-basemaps/2193/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E8Y3HSN66NDDKP89H2VTT",
+      "3857": "s3://linz-basemaps/3857/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E9728953QMD6NY7BVDGSN",
+      "name": "campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB",
+      "minZoom": 5
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",


### PR DESCRIPTION
Imagery imported for campbell-island-motu-ihupuku_satellite_2015-2020_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G00E8Y3HSN66NDDKP89H2VTT&p=NZTM2000Quad&debug#@-52.544712,169.196903,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G00E9728953QMD6NY7BVDGSN&p=WebMercatorQuad&debug#@-52.549636,169.101562,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-485#@-52.544712,169.196903,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-485#@-52.549636,169.101562,z12

