### PR TITLE
feat(aerial): Config imagery nz-nearshore-islands_satellite_2010-2021_0.5m_RGB into Aerial Map. BM-513

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -57,6 +57,12 @@
       "minZoom": 5
     },
     {
+      "2193": "s3://linz-basemaps/2193/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XY0TVJJ4QVJ7988TCKGWS",
+      "3857": "s3://linz-basemaps/3857/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XYQ8YKAZC7P5QJ4BPCX22",
+      "name": "nz-nearshore-islands_satellite_2010-2021_0-5m_RGB",
+      "minZoom": 5
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -60,7 +60,7 @@
       "2193": "s3://linz-basemaps/2193/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XY0TVJJ4QVJ7988TCKGWS",
       "3857": "s3://linz-basemaps/3857/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XYQ8YKAZC7P5QJ4BPCX22",
       "name": "nz-nearshore-islands_satellite_2010-2021_0-5m_RGB",
-      "minZoom": 5
+      "minZoom": 10
     },
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -60,7 +60,7 @@
       "2193": "s3://linz-basemaps/2193/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XY0TVJJ4QVJ7988TCKGWS",
       "3857": "s3://linz-basemaps/3857/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XYQ8YKAZC7P5QJ4BPCX22",
       "name": "nz-nearshore-islands_satellite_2010-2021_0-5m_RGB",
-      "minZoom": 10
+      "minZoom": 13
     },
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",


### PR DESCRIPTION
Imagery imported for nz-nearshore-islands_satellite_2010-2021_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G00XY0TVJJ4QVJ7988TCKGWS&p=NZTM2000Quad&debug#@-40.517192,172.071141,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G00XYQ8YKAZC7P5QJ4BPCX22&p=WebMercatorQuad&debug#@-40.780541,171.710815,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-487#@-40.517192,172.071141,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-487#@-40.780541,171.710815,z12

