### PR TITLE
feat(aerial): Config imagery snares-islands-tini-heke_satellite_2019-2020_0.5m_RGB into Aerial Map. BM-512

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -63,6 +63,12 @@
       "minZoom": 13
     },
     {
+      "2193": "s3://linz-basemaps/2193/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01G011MVHNRWAMSQSPBKXVAEC3",
+      "3857": "s3://linz-basemaps/3857/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01G011N3MVQVYP0Q1025R45219",
+      "name": "snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB",
+      "minZoom": 5
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",


### PR DESCRIPTION
Imagery imported for snares-islands-tini-heke_satellite_2019-2020_0.5m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G011MVHNRWAMSQSPBKXVAEC3&p=NZTM2000Quad&debug#@-48.042018,166.560930,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G011N3MVQVYP0Q1025R45219&p=WebMercatorQuad&debug#@-48.034019,166.552734,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-488#@-48.042018,166.560930,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-488#@-48.034019,166.552734,z12

