### PR TITLE
feat(aerial): Config imagery gebco_2021_305.75m into Aerial Map. BM-118

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -5,12 +5,8 @@
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/gebco_2021_Nztm2000Quad_305-75m/01G14ZABTXES5EEVZJQ0CJAX5N",
+      "3857": "s3://linz-basemaps/2193/gebco_2021_Nztm2000Quad_305-75m/01G1735WKA6J8M24914Y16MSWY",
       "name": "gebco_2021_305-75m",
-      "maxZoom": 15
-    },
-    {
-      "3857": "s3://linz-basemaps/3857/gebco_2020_305-75m/01EDMTM3P563P06TWYQAZRA9F6",
-      "name": "gebco_2020_305-75m",
       "maxZoom": 15
     },
     {

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -5,7 +5,7 @@
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/gebco_2021_Nztm2000Quad_305-75m/01G14ZABTXES5EEVZJQ0CJAX5N",
-      "3857": "s3://linz-basemaps/2193/gebco_2021_Nztm2000Quad_305-75m/01G1735WKA6J8M24914Y16MSWY",
+      "3857": "s3://linz-basemaps/3857/gebco_2021_305-75m/01G1735WKA6J8M24914Y16MSWY",
       "name": "gebco_2021_305-75m",
       "maxZoom": 15
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -4,7 +4,11 @@
   "background": "dce9edff",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gebco_2020_Nztm2000Quad_305-75m/01F1BFJN8R8P7BXN3XTHC5MT5G",
+      "2193": "s3://linz-basemaps/2193/gebco_2021_Nztm2000Quad_305-75m/01G14ZABTXES5EEVZJQ0CJAX5N",
+      "name": "gebco_2021_305-75m",
+      "maxZoom": 15
+    },
+    {
       "3857": "s3://linz-basemaps/3857/gebco_2020_305-75m/01EDMTM3P563P06TWYQAZRA9F6",
       "name": "gebco_2020_305-75m",
       "maxZoom": 15


### PR DESCRIPTION
Imagery imported for gebco_2021_305.75m, please use the following QA url once the aws job finished.

Individual Imagery 

NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G14ZABTXES5EEVZJQ0CJAX5N&p=NZTM2000Quad&debug#@-41.278417,174.776635,z9

WebMercatorQuad:  https://basemaps.linz.govt.nz/?i=01G1735WKA6J8M24914Y16MSWY&debug

Aerial Imagery Preview: https://basemaps.linz.govt.nz/?i=aerial@pr-500#@-40.9930772,172.8144304,z4.835