### PR TITLE
fix(vector): remove maxzoom: 24 from topolite style

### DIFF
--- a/config/style/topolite.json
+++ b/config/style/topolite.json
@@ -24,7 +24,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
       "minzoom": 8,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "sand"]],
       "layout": { "visibility": "visible" },
       "paint": { "fill-color": "rgba(220, 205, 177, 0.3)" }
@@ -45,7 +44,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "coastline",
       "minzoom": 0,
-      "maxzoom": 24,
       "filter": ["all"],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -114,7 +112,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
       "minzoom": 0,
-      "maxzoom": 24,
       "filter": ["all", ["==", "tree", "native"]],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -154,7 +151,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "landuse", "orchard"]],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -169,7 +165,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "landuse", "vineyard"]],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -184,7 +179,6 @@
       "type": "fill",
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -419,7 +413,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "water",
       "minzoom": 0,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "lake"]],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -721,7 +714,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
       "minzoom": 8,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "residential"]],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -796,7 +788,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "poi",
       "minzoom": 0,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "storage_tank"], ["!has", "store_item"]],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -830,7 +821,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "poi",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "storage_tank_pt"], ["!has", "store_item"]],
       "layout": { "visibility": "visible" },
       "paint": {
@@ -929,7 +919,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "building",
       "minzoom": 16,
-      "maxzoom": 24,
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
@@ -950,7 +939,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "building",
       "minzoom": 16,
-      "maxzoom": 24,
       "layout": { "visibility": "visible" },
       "paint": {
         "line-width": {
@@ -968,7 +956,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 13,
-      "maxzoom": 24,
       "filter": ["all", ["==", "brunnel", "bridge"], ["==", "use_1", "foot traffic"]],
       "layout": {
         "visibility": "visible",
@@ -992,7 +979,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 13,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
       "layout": {
         "visibility": "visible",
@@ -1016,7 +1002,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 13,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "vehicle"]],
       "layout": {
         "visibility": "visible",
@@ -1111,7 +1096,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 11,
-      "maxzoom": 24,
       "filter": ["all", ["==", "surface", "unmetalled"], ["==", "lane_count", 1]],
       "layout": {
         "visibility": "visible",
@@ -1141,7 +1125,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "surface", "metalled"], ["==", "lane_count", 1]],
       "layout": {
         "visibility": "visible",
@@ -1171,7 +1154,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"], ["==", "status", "under construction"]],
       "layout": {
         "visibility": "visible",
@@ -1200,7 +1182,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 11,
-      "maxzoom": 24,
       "filter": ["all", ["==", "surface", "sealed"], ["==", "lane_count", 1], ["!=", "class", "motorway"]],
       "layout": {
         "visibility": "visible",
@@ -1236,7 +1217,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "surface", "unmetalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7], ["!=", "staus", "under construction"]],
       "layout": {
         "visibility": "visible",
@@ -1266,7 +1246,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "surface", "metalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
       "layout": {
         "visibility": "visible",
@@ -1296,7 +1275,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "status", "under construction"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
       "layout": {
         "visibility": "visible",
@@ -1327,7 +1305,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "surface", "sealed"], ["in", "lane_count", 2, 3, 4, 5, 6, 7], ["!=", "class", "motorway"]],
       "layout": {
         "visibility": "visible",
@@ -1358,7 +1335,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 11,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "rail"], ["has", "rway_use"]],
       "layout": {
         "visibility": "visible",
@@ -1373,7 +1349,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 11,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "rail"], ["==", "track_type", "single"], ["!has", "rway_use"]],
       "layout": {
         "visibility": "visible",
@@ -1388,7 +1363,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 11,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "rail"], ["==", "track_type", "multiple"]],
       "layout": {
         "visibility": "visible",
@@ -1568,7 +1542,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 13,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
       "layout": {
         "visibility": "visible",
@@ -1597,7 +1570,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 13,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 1]],
       "layout": {
         "visibility": "visible",
@@ -1626,7 +1598,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 13,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
       "layout": {
         "visibility": "visible",
@@ -1655,7 +1626,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 8,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
       "layout": {
         "visibility": "visible",
@@ -1685,7 +1655,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 8,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["==", "lane_count", 1]],
       "layout": {
         "visibility": "visible",
@@ -1714,7 +1683,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 8,
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
       "layout": {
         "visibility": "visible",
@@ -1743,7 +1711,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 11,
-      "maxzoom": 24,
       "filter": ["all", ["==", "brunnel", "bridge"], ["in", "use_1", "train", "vehicle"]],
       "layout": {
         "visibility": "visible",
@@ -1769,7 +1736,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 11,
-      "maxzoom": 24,
       "filter": ["all", ["==", "brunnel", "bridge"], ["in", "use_1", "train", "vehicle"]],
       "layout": {
         "visibility": "visible",
@@ -1838,7 +1804,6 @@
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 10,
-      "maxzoom": 24,
       "filter": ["all", ["==", "brunnel", "tunnel"]],
       "layout": {
         "visibility": "visible",


### PR DESCRIPTION
Many layers in this style have maxzoom set to 24. This causes a problem because when zooming past 24, instead of just magnifying, the layers get hidden. With the maxzoom removed, the client can zoom in as far as desired and the layers will remain visible, which I think is the intent of the style.