### PR TITLE
feat(scripts): add script to import imagery configuration from folder of tiffs

### DIFF
--- a/src/commands/imagery.ts
+++ b/src/commands/imagery.ts
@@ -1,0 +1,36 @@
+import { TileMatrixSets } from '@basemaps/geo';
+import { LogConfig } from '@basemaps/shared';
+import { Command, Flags } from '@oclif/core';
+import { ImageryCache } from '../config/imagery.config.js';
+import { TileSetUpdater } from '../config/tileset.updater.js';
+
+export class CommandImportImagery extends Command {
+  static description = 'Import imagery';
+
+  static flags = {
+    version: Flags.version(),
+    help: Flags.help(),
+    commit: Flags.boolean({ description: 'Actually import fonts' }),
+    verbose: Flags.boolean({ description: 'Verbose logging', default: false }),
+    name: Flags.string({ description: 'Imagery set name', required: true }),
+    'tile-matrix-set': Flags.string({ description: 'Imagery tile matrix set [WebMercatorQuad | NZTM2000Quad]', required: true }),
+  };
+
+  static args = [{ name: 'uri', required: true }];
+
+  async run(): Promise<void> {
+    const logger = LogConfig.get();
+
+    const { flags, args } = await this.parse(CommandImportImagery);
+    if (flags.verbose) logger.level = 'trace';
+
+    const tms = TileMatrixSets.find(flags['tile-matrix-set']);
+    if (tms == null) throw new Error('Cannot find tile-matrix-set: ' + flags['tile-matrix-set']);
+
+    if (!args.uri.startsWith('s3://')) throw new Error('URI must start with s3://');
+
+    const imageryConfig = await ImageryCache.toImageryConfig(args.uri, flags.name, tms, logger);
+
+    await TileSetUpdater.ensureImageryConfig([imageryConfig], flags.commit, logger);
+  }
+}


### PR DESCRIPTION
Example


```bash
./bin/bmc.js imagery  \
  s3://linz-basemaps/2193/ashburton-urban_2022_7.5cm/01G20Y1MS9826TJ53XND1DNZP6  \
  --name ashburton-urban_2022_7.5cm  \
  --tile-matrix-set NZTM2000Quad
```

This is a temporary script until the COG creation process imports the configuration for us.