### PR TITLE
feat(aerial): Config imagery waipa_urban_2021_0.1m_RGB into Aerial Map. BM-557

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -802,6 +802,12 @@
       "minZoom": 14
     },
     {
+      "2193": "s3://linz-basemaps/2193/waipa_urban_2021_0-1m_RGB/01G28WB9GKP01A8DPYWG9CBMN1",
+      "3857": "s3://linz-basemaps/3857/waipa_urban_2021_0-1m_RGB/01G28WC5349Y0J3CGWGTZ796DD",
+      "name": "waipa_urban_2021_0-1m_RGB",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01FXP9YHEQM6XA6DDEGNKMEE7H",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01FXPA0F9WZS0MMABYHRCFYMV0",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for waipa_urban_2021_0.1m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G28WB9GKP01A8DPYWG9CBMN1&p=NZTM2000Quad&debug#@-37.984133,175.383542,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G28WC5349Y0J3CGWGTZ796DD&p=WebMercatorQuad&debug#@-37.978845,175.385742,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-517#@-37.984133,175.383542,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-517#@-37.978845,175.385742,z12

