### PR TITLE
feat(aerial): Reprocess the Auckland rurual 2020 imagery to add new tiles.

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -808,8 +808,8 @@
       "minZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01FXP9YHEQM6XA6DDEGNKMEE7H",
-      "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01FXPA0F9WZS0MMABYHRCFYMV0",
+      "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
+      "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",
       "minZoom": 13
     },


### PR DESCRIPTION
NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G4XPNP9JTGGPABCFRWC4N21E&p=NZTM2000Quad&debug=true#@-36.6929361,175.5201417,z6.0564
WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G4XPQKF6VB9SXCQ93R2XC1W8&debug=true#@-36.8511386,175.1625004,z8.2268

![image](https://user-images.githubusercontent.com/12163920/172278661-bb9bc58f-a158-4167-a390-f53682108e69.png)

