### PR TITLE
feat(aerial): Config imagery nz_satellite_2021-2022_10m_RGB into Aerial Map. BM-615

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -91,6 +91,12 @@
       "category": "Satellite Imagery"
     },
     {
+      "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G731JZC9H7MPRKGK9K5T39AZ",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G731KXCKZDTDG0MSDN1V06DJ",
+      "name": "nz_satellite_2021-2022_10m_RGB",
+      "minZoom": 5
+    },
+    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -31,7 +31,7 @@
       "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
       "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J",
       "name": "nz_satellite_2020-2021_10m_RGB",
-      "maxZoom": -1,
+      "minZoom": 32,
       "title": "New Zealand 10m Satellite Imagery (2020-2021)",
       "category": "Satellite Imagery"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -31,7 +31,7 @@
       "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
       "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J",
       "name": "nz_satellite_2020-2021_10m_RGB",
-      "maxZoom": 0,
+      "maxZoom": -1,
       "title": "New Zealand 10m Satellite Imagery (2020-2021)",
       "category": "Satellite Imagery"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -28,11 +28,9 @@
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J",
-      "name": "nz_satellite_2020-2021_10m_RGB",
-      "title": "New Zealand 10m Satellite Imagery (2020-2021)",
-      "category": "Satellite Imagery"
+      "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G731JZC9H7MPRKGK9K5T39AZ",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G731KXCKZDTDG0MSDN1V06DJ",
+      "name": "nz_satellite_2021-2022_10m_RGB"
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8BB9EBP892F3JQSSSHQG",
@@ -89,12 +87,6 @@
       "minZoom": 5,
       "title": "Snares Islands/Tini Heke 0.5m Satellite Imagery (2019-2020)",
       "category": "Satellite Imagery"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G731JZC9H7MPRKGK9K5T39AZ",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G731KXCKZDTDG0MSDN1V06DJ",
-      "name": "nz_satellite_2021-2022_10m_RGB",
-      "minZoom": 5
     },
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -28,9 +28,19 @@
       "category": "Satellite Imagery"
     },
     {
+      "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J",
+      "name": "nz_satellite_2020-2021_10m_RGB",
+      "maxZoom": 0,
+      "title": "New Zealand 10m Satellite Imagery (2020-2021)",
+      "category": "Satellite Imagery"
+    },
+    {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G73E4AMSQ91TXQ3KC90NNPA0",
       "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G73E5DZKE9NSW6E41QQRT28T",
-      "name": "nz_satellite_2021-2022_10m_RGB"
+      "name": "nz_satellite_2021-2022_10m_RGB",
+      "title": "New Zealand 10m Satellite Imagery (2021-2022)",
+      "category": "Satellite Imagery"
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8BB9EBP892F3JQSSSHQG",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -28,8 +28,8 @@
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G731JZC9H7MPRKGK9K5T39AZ",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G731KXCKZDTDG0MSDN1V06DJ",
+      "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G73E4AMSQ91TXQ3KC90NNPA0",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G73E5DZKE9NSW6E41QQRT28T",
       "name": "nz_satellite_2021-2022_10m_RGB"
     },
     {


### PR DESCRIPTION
Imagery imported for nz_satellite_2021-2022_10m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G73E4AMSQ91TXQ3KC90NNPA0&p=NZTM2000Quad&debug#@-41.108460,174.305964,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G73E5DZKE9NSW6E41QQRT28T&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-572#@-41.108460,174.305964,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-572#@-41.376809,172.968750,z12

