### PR TITLE
feat(aerial): Config imagery waikato_urban_2021_0.1m_RGB into Aerial Map. BM-621

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -808,6 +808,12 @@
       "minZoom": 14
     },
     {
+      "2193": "s3://basemaps-cog-test/2193/waikato_urban_2021_0-1m_RGB/01G75Y3WYR9QW510HQ0J6TZ0AH",
+      "3857": "s3://basemaps-cog-test/3857/waikato_urban_2021_0-1m_RGB/01G75Y4KKXNT3X5JRV814GGJ8E",
+      "name": "waikato_urban_2021_0-1m_RGB",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for waikato_urban_2021_0.1m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G75Y3WYR9QW510HQ0J6TZ0AH&p=NZTM2000Quad&debug#@-37.538530,175.050941,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G75Y4KKXNT3X5JRV814GGJ8E&p=WebMercatorQuad&debug#@-37.527154,175.056152,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-575#@-37.538530,175.050941,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-575#@-37.527154,175.056152,z12

