### PR TITLE
feat(aerial): Config imagery tasman_rural_2022_0.3m_RGB into Aerial Map. BM-620

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -364,6 +364,12 @@
       "minZoom": 13
     },
     {
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2022_0-3m_RGB/01G75YD43EBA980HFWVF6ZFV6B",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2022_0-3m_RGB/01G75YDG4KFEZ5BAGTPHMEAPP7",
+      "name": "tasman_rural_2022_0-3m_RGB",
+      "minZoom": 13
+    },
+    {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ",
       "name": "selwyn_urban_2012-2013_0-125m_RGBA",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -487,7 +487,9 @@
       "2193": "s3://linz-basemaps/2193/tasman_rural_2022_0-3m_RGB/01G75YD43EBA980HFWVF6ZFV6B",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2022_0-3m_RGB/01G75YDG4KFEZ5BAGTPHMEAPP7",
       "name": "tasman_rural_2022_0-3m_RGB",
-      "minZoom": 13
+      "minZoom": 13,
+      "title": "Tasman 0.3m Rural Aerial Photos (2022)",
+      "category": "Rural Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",


### PR DESCRIPTION
Imagery imported for tasman_rural_2022_0.3m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G75YD43EBA980HFWVF6ZFV6B&p=NZTM2000Quad&debug#@-40.983623,172.907840,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G75YDG4KFEZ5BAGTPHMEAPP7&p=WebMercatorQuad&debug#@-41.013066,172.880859,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-576#@-40.983623,172.907840,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-576#@-41.013066,172.880859,z12

