### PR TITLE
feat(aerial): Config imagery nelson_urban_2022_0.075m_RGB into Aerial Map. BM-630

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1100,6 +1100,12 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/nelson_urban_2022_0-075m_RGB/01G87CWVWSG7KWE3DHC6R18BCX",
+      "3857": "s3://linz-basemaps/3857/nelson_urban_2022_0-075m_RGB/01G87CXGF81D5CVT22B038BCM1",
+      "name": "nelson_urban_2022_0-075m_RGB",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for nelson_urban_2022_0.075m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01G87CWVWSG7KWE3DHC6R18BCX&p=NZTM2000Quad&debug#@-41.258470,173.374624,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01G87CXGF81D5CVT22B038BCM1&p=WebMercatorQuad&debug#@-41.253032,173.380737,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&i=aerial@pr-587#@-41.258470,173.374624,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&i=aerial@pr-587#@-41.253032,173.380737,z12

