### PR TITLE
feat(aerial): Config imagery marlborough_rural_2021-2022_0.25m_RGB into Aerial Map. BM-658

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -264,7 +264,7 @@
       "2193": "s3://linz-basemaps/2193/marlborough_rural_2015-2016_0-20m_RGBA/01F6P1D8DJGBN4QNAB2Y64DVV3",
       "3857": "s3://linz-basemaps/3857/marlborough_rural_2015-2016_0-20m_RGBA/01ED82MG0Q6A8VFAJSY7Q543N5",
       "name": "marlborough_rural_2015-2016_0-20m_RGBA",
-      "minZoom": 13,
+      "minZoom": 32,
       "title": "Marlborough 0.2m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -502,8 +502,8 @@
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_rural_2021-2022_0-25m_RGB/01GAJ7W0H208Z83JE0R10M4J87",
-      "3857": "s3://linz-basemaps/3857/marlborough_rural_2021-2022_0-25m_RGB/01GAJ7XDT7D61JPCYRRYB58PDW",
+      "2193": "s3://linz-basemaps/2193/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ84DPHCND4PG6BD0W999A",
+      "3857": "s3://linz-basemaps/3857/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ9988GKX5JF0F0EW2R9Q3",
       "name": "marlborough_rural_2021-2022_0-25m_RGB",
       "minZoom": 13
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -502,6 +502,12 @@
       "category": "Rural Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/marlborough_rural_2021-2022_0-25m_RGB/01GAJ7W0H208Z83JE0R10M4J87",
+      "3857": "s3://linz-basemaps/3857/marlborough_rural_2021-2022_0-25m_RGB/01GAJ7XDT7D61JPCYRRYB58PDW",
+      "name": "marlborough_rural_2021-2022_0-25m_RGB",
+      "minZoom": 13
+    },
+    {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ",
       "name": "selwyn_urban_2012-2013_0-125m_RGBA",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -505,7 +505,9 @@
       "2193": "s3://linz-basemaps/2193/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ84DPHCND4PG6BD0W999A",
       "3857": "s3://linz-basemaps/3857/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ9988GKX5JF0F0EW2R9Q3",
       "name": "marlborough_rural_2021-2022_0-25m_RGB",
-      "minZoom": 13
+      "minZoom": 13,
+      "title": "Marlborough 0.25m Rural Aerial Photos (2021-2022)",
+      "category": "Rural Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",


### PR DESCRIPTION
Imagery imported for marlborough_rural_2021-2022_0.25m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01GAMZ84DPHCND4PG6BD0W999A&p=NZTM2000Quad&debug#@-41.929973,173.496536,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01GAMZ9988GKX5JF0F0EW2R9Q3&p=WebMercatorQuad&debug#@-41.926803,173.496094,z12


