### PR TITLE
feat(aerial): Config imagery hamilton_urban_2020-2021_0.05m_RGB into Aerial Map. BM-660

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -913,7 +913,7 @@
       "2193": "s3://linz-basemaps/2193/hamilton_urban_2019_0-1m/01F6P16V72XPFJK2X5V68YYM0X",
       "3857": "s3://linz-basemaps/3857/hamilton_urban_2019_0-1m/01ED8284FFT9RYZ0F7XTKD64D4",
       "name": "hamilton_urban_2019_0-1m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Hamilton 0.1m Urban Aerial Photos (2019)",
       "category": "Urban Aerial Photos"
     },
@@ -1121,7 +1121,9 @@
       "2193": "s3://linz-basemaps/2193/hamilton_urban_2020-2021_0-05m_RGB/01GASE5J7NJSZRVD92X9J655TQ",
       "3857": "s3://linz-basemaps/3857/hamilton_urban_2020-2021_0-05m_RGB/01GASE6HES5VTVKV66G5S82KV3",
       "name": "hamilton_urban_2020-2021_0-05m_RGB",
-      "minZoom": 14
+      "minZoom": 14,
+      "title": "Hamilton 0.05m Urban Aerial Photos (2020-2021)",
+      "category": "Urban Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1118,6 +1118,12 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/hamilton_urban_2020-2021_0-05m_RGB/01GASE5J7NJSZRVD92X9J655TQ",
+      "3857": "s3://linz-basemaps/3857/hamilton_urban_2020-2021_0-05m_RGB/01GASE6HES5VTVKV66G5S82KV3",
+      "name": "hamilton_urban_2020-2021_0-05m_RGB",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for hamilton_urban_2020-2021_0.05m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01GASE5J7NJSZRVD92X9J655TQ&p=NZTM2000Quad&debug#@-37.777067,175.265795,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01GASE6HES5VTVKV66G5S82KV3&p=WebMercatorQuad&debug#@-37.770715,175.264893,z12

Tagged Aerial Map NZTM2000Quad: https://dev.basemaps.linz.govt.nz/?config=s3://linz-basemaps/config/config-2RLMcERykfYiawLek9bQ8NdHeSzU8VwjjweANR2mwa5P.json.gz&tileMatrix=NZTM2000Quad#@-37.7669740,175.2726161,z10.7316


