### PR TITLE
feat(aerial): Config imagery wellington-city_urban_2021_0.075m_RGB into Aerial Map. BM-668

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -966,8 +966,8 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington-city_urban_2021_0-075m_RGB/01GBRR1A3CFNPE6R2BSRP1Z3PH",
-      "3857": "s3://linz-basemaps/3857/wellington-city_urban_2021_0-075m_RGB/01GBRR1QNCDV572WESKWQ7QE8X",
+      "2193": "s3://linz-basemaps/2193/wellington-city_urban_2021_0-075m_RGB/01GBRRFSNR0V1N50WP0H1E7SDP",
+      "3857": "s3://linz-basemaps/3857/wellington-city_urban_2021_0-075m_RGB/01GBRRG6Z6Q8SJNECE7K49M88R",
       "name": "wellington-city_urban_2021_0-075m_RGB",
       "minZoom": 14,
       "title": "Wellington City 0.075m Urban Aerial Photos (2021)",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -966,8 +966,8 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington-city_urban_2021_0-075m_RGB/01FBNEW6V1D5GWRG1RZMVVW6Y3",
-      "3857": "s3://linz-basemaps/3857/wellington-city_urban_2021_0-075m_RGB/01FBNERWAX2XVCKQ4AACWGP2K5",
+      "2193": "s3://linz-basemaps/2193/wellington-city_urban_2021_0-075m_RGB/01GBRR1A3CFNPE6R2BSRP1Z3PH",
+      "3857": "s3://linz-basemaps/3857/wellington-city_urban_2021_0-075m_RGB/01GBRR1QNCDV572WESKWQ7QE8X",
       "name": "wellington-city_urban_2021_0-075m_RGB",
       "minZoom": 14,
       "title": "Wellington City 0.075m Urban Aerial Photos (2021)",
@@ -1132,12 +1132,6 @@
       "minZoom": 14,
       "title": "Hamilton 0.05m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://basemaps-cog-test/2193/wellington-city_urban_2021_0-075m_RGB/01GBRR1A3CFNPE6R2BSRP1Z3PH",
-      "3857": "s3://basemaps-cog-test/3857/wellington-city_urban_2021_0-075m_RGB/01GBRR1QNCDV572WESKWQ7QE8X",
-      "name": "wellington-city_urban_2021_0-075m_RGB",
-      "minZoom": 14
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1134,6 +1134,12 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://basemaps-cog-test/2193/wellington-city_urban_2021_0-075m_RGB/01GBRR1A3CFNPE6R2BSRP1Z3PH",
+      "3857": "s3://basemaps-cog-test/3857/wellington-city_urban_2021_0-075m_RGB/01GBRR1QNCDV572WESKWQ7QE8X",
+      "name": "wellington-city_urban_2021_0-075m_RGB",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for wellington-city_urban_2021_0.075m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01GBRRFSNR0V1N50WP0H1E7SDP&p=NZTM2000Quad&debug#@-41.256395,174.776038,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01GBRRG6Z6Q8SJNECE7K49M88R&p=WebMercatorQuad&debug#@-41.261291,174.776001,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&config=s3://linz-basemaps/config/config-3RPVdxmo9kjoBHB8VBzr8YDjFRZSHQvNh2j7x2Mt6gL2.json.gz#@-41.256395,174.776038,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&config=s3://linz-basemaps/config/config-3RPVdxmo9kjoBHB8VBzr8YDjFRZSHQvNh2j7x2Mt6gL2.json.gz#@-41.261291,174.776001,z12

