### PR TITLE
feat(aerial): Config imagery hawkes-bay_urban_2022_0.1m_RGB into Aerial Map. BM-676

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -561,7 +561,7 @@
       "2193": "s3://linz-basemaps/2193/hastings-district_urban_2014-2015_0-10m_RGB/01F6P172EQ3JF930CN3XNVVVJ9",
       "3857": "s3://linz-basemaps/3857/hastings-district_urban_2014-2015_0-10m_RGB/01EDN0YH2TM1B5NWHR4RHGBMPF",
       "name": "hastings-district_urban_2014-2015_0-10m_RGB",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Hastings District 0.1m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos"
     },
@@ -697,7 +697,7 @@
       "2193": "s3://linz-basemaps/2193/central-hawkes-bay_urban_2017-18_0-1m/01F66EDQC993D73W17EG40HJ2N",
       "3857": "s3://linz-basemaps/3857/central-hawkes-bay_urban_2017-18_0-1m/01ED823PTAVX9DQ7GE9WBACX8C",
       "name": "central-hawkes-bay_urban_2017-18_0-1m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Central Hawke's Bay 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos"
     },
@@ -713,7 +713,7 @@
       "2193": "s3://linz-basemaps/2193/hastings-district_urban_2017-18_0-1m/01F6P17PSJ1SWNYV2V28922WKY",
       "3857": "s3://linz-basemaps/3857/hastings-district_urban_2017-18_0-1m/01ED82A7KFS8RMNPRYDQ60MCQ1",
       "name": "hastings-district_urban_2017-18_0-1m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Hastings 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos"
     },
@@ -753,7 +753,7 @@
       "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-05m/01F6P1F7BT85M2T5S01FXWAPPD",
       "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-05m/01ED82S7R88B0CGQWZKH4V7R2H",
       "name": "napier-city_urban_2017-18_0-05m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Napier 0.05m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos"
     },
@@ -761,7 +761,7 @@
       "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-1m/01F6P1FCJZWD8JY7DJEDEB45K7",
       "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-1m/01ED82SKPVV12M4RYHRK08DWG4",
       "name": "napier-city_urban_2017-18_0-1m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Napier 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1134,8 +1134,8 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ",
-      "3857": "s3://linz-basemaps/3857/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546",
       "name": "hawkes-bay_urban_2022_0.1m_RGB",
       "minZoom": 14,
       "title": "Hawke's Bay 0.1m Urban Aerial Photos (2022)",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1136,8 +1136,10 @@
     {
       "2193": "s3://linz-basemaps/2193/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ",
       "3857": "s3://linz-basemaps/3857/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546",
-      "name": "s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.1m_RGB/",
-      "minZoom": 14
+      "name": "hawkes-bay_urban_2022_0.1m_RGB",
+      "minZoom": 14,
+      "title": "Hawke's Bay 0.1m Urban Aerial Photos (2022)",
+      "category": "Urban Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1134,6 +1134,12 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ",
+      "3857": "s3://linz-basemaps/3857/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546",
+      "name": "s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.1m_RGB/",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for hawkes-bay_urban_2022_0.1m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01GD1TW8AFTNCGHNG97P9MDFYZ&p=NZTM2000Quad&debug#@-39.866450,176.669721,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01GD1TXCTKWJ2TKJR8ZVKNA546&p=WebMercatorQuad&debug#@-39.857046,176.682129,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&config=s3://linz-basemaps/config/config-AuXga7zCok1JAkEvrJbfa8SHhwpnqPANLnrbTs4Y8A9N.json.gz#@-39.866450,176.669721,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&config=s3://linz-basemaps/config/config-AuXga7zCok1JAkEvrJbfa8SHhwpnqPANLnrbTs4Y8A9N.json.gz#@-39.857046,176.682129,z12

