### PR TITLE
feat(aerial): Config imagery hawkes-bay_urban_2022_0.05m_RGB into Aerial Map. BM-675

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1134,8 +1134,8 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK",
-      "3857": "s3://linz-basemaps/3857/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94",
       "name": "hawkes-bay_urban_2022_0.05m_RGB",
       "minZoom": 14,
       "title": "Hawkes's Bay 0.05m Urban Aerial Photos (2022)",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1136,8 +1136,10 @@
     {
       "2193": "s3://linz-basemaps/2193/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK",
       "3857": "s3://linz-basemaps/3857/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94",
-      "name": "s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.05m_RGB/",
-      "minZoom": 14
+      "name": "hawkes-bay_urban_2022_0.05m_RGB",
+      "minZoom": 14,
+      "title": "Hawkes's Bay 0.05m Urban Aerial Photos (2022)",
+      "category": "Urban Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1134,6 +1134,12 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK",
+      "3857": "s3://linz-basemaps/3857/s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94",
+      "name": "s3://linz-data-lake-raster-prod/aerial-imagery/new-zealand/hawkes-bay_urban_2022_0.05m_RGB/",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for hawkes-bay_urban_2022_0.05m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01GD1VBBC9BX6YD2BZYN0S00YK&p=NZTM2000Quad&debug#@-39.481069,176.876791,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01GD1VBRXY4647H7ATEXNSNZ94&p=WebMercatorQuad&debug#@-39.479666,176.871643,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&config=s3://linz-basemaps/config/config-aWmVEQHXpjBPh3XsyZpKdYjpR8UZR27AzsazCx3zqRN.json.gz#@-39.481069,176.876791,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&config=s3://linz-basemaps/config/config-aWmVEQHXpjBPh3XsyZpKdYjpR8UZR27AzsazCx3zqRN.json.gz#@-39.479666,176.871643,z12

