### PR TITLE
feat(aerial): Config imagery taranaki_rural_2021-2022_0.25m_RGB into Aerial Map. BM-682

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -517,6 +517,12 @@
       "category": "Rural Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/taranaki_rural_2021-2022_0.25m_RGB/01GDKFTY5BPAHMSKKVC336J9Y2",
+      "3857": "s3://linz-basemaps/3857/taranaki_rural_2021-2022_0.25m_RGB/01GDKFVY7VZ7CVYGYG02FXSEMJ",
+      "name": "taranaki_rural_2021-2022_0.25m_RGB",
+      "minZoom": 13
+    },
+    {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ",
       "name": "selwyn_urban_2012-2013_0-125m_RGBA",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -520,7 +520,9 @@
       "2193": "s3://linz-basemaps/2193/taranaki_rural_2021-2022_0.25m_RGB/01GDKFTY5BPAHMSKKVC336J9Y2",
       "3857": "s3://linz-basemaps/3857/taranaki_rural_2021-2022_0.25m_RGB/01GDKFVY7VZ7CVYGYG02FXSEMJ",
       "name": "taranaki_rural_2021-2022_0.25m_RGB",
-      "minZoom": 13
+      "minZoom": 13,
+      "title": "Taranaki 0.25m Rural Aerial Photos (2021-2022)",
+      "category": "Rural Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",


### PR DESCRIPTION
Imagery imported for taranaki_rural_2021-2022_0.25m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01GDKFTY5BPAHMSKKVC336J9Y2&p=NZTM2000Quad&debug#@-39.262026,174.384423,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01GDKFVY7VZ7CVYGYG02FXSEMJ&p=WebMercatorQuad&debug#@-39.300299,174.396973,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&config=s3://linz-basemaps/config/config-2v6sDmUwaCkkL6NPavr6oznkaUKvNB1vfDVKAjB9yS4i.json.gz#@-39.262026,174.384423,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&config=s3://linz-basemaps/config/config-2v6sDmUwaCkkL6NPavr6oznkaUKvNB1vfDVKAjB9yS4i.json.gz#@-39.300299,174.396973,z12

