### PR TITLE
feat(aerial): Config imagery taranaki_urban_2022_0.05m_RGB into Aerial Map. BM-683

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1168,7 +1168,9 @@
       "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.05m_RGB/01GDM781KPM27STN22MDPWC57Y",
       "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.05m_RGB/01GDM7896HY2KQG4K3ESSZMPH6",
       "name": "taranaki_urban_2022_0.05m_RGB",
-      "minZoom": 14
+      "minZoom": 14,
+      "title": "Tauranga 0.05m Urban Aerial Photos (2022)",
+      "category": "Urban Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1165,6 +1165,12 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.05m_RGB/01GDM781KPM27STN22MDPWC57Y",
+      "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.05m_RGB/01GDM7896HY2KQG4K3ESSZMPH6",
+      "name": "taranaki_urban_2022_0.05m_RGB",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1165,19 +1165,19 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.05m_RGB/01GDM781KPM27STN22MDPWC57Y",
-      "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.05m_RGB/01GDM7896HY2KQG4K3ESSZMPH6",
-      "name": "taranaki_urban_2022_0.05m_RGB",
-      "minZoom": 14,
-      "title": "Tauranga 0.05m Urban Aerial Photos (2022)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.1m_RGB/01GDM79KSKKCZ4FQCX5S2Q4BDQ",
       "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.1m_RGB/01GDM7ACWGP9QZP7V3MF4MPKH8",
       "name": "taranaki_urban_2022_0.1m_RGB",
       "minZoom": 14,
       "title": "Taranaki 0.1m Urban Aerial Photos (2022)",
+      "category": "Urban Aerial Photos"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.05m_RGB/01GDM781KPM27STN22MDPWC57Y",
+      "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.05m_RGB/01GDM7896HY2KQG4K3ESSZMPH6",
+      "name": "taranaki_urban_2022_0.05m_RGB",
+      "minZoom": 14,
+      "title": "Taranaki 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {


### PR DESCRIPTION
Imagery imported for taranaki_urban_2022_0.05m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01GDM781KPM27STN22MDPWC57Y&p=NZTM2000Quad&debug#@-39.747709,174.536838,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01GDM7896HY2KQG4K3ESSZMPH6&p=WebMercatorQuad&debug#@-39.747322,174.539795,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&config=s3://linz-basemaps/config/config-4T2tSBxKVrrFWRMterRfv4AxbRWvncvWJW7dLdpgZyss.json.gz#@-39.747709,174.536838,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&config=s3://linz-basemaps/config/config-4T2tSBxKVrrFWRMterRfv4AxbRWvncvWJW7dLdpgZyss.json.gz#@-39.747322,174.539795,z12

