### PR TITLE
feat(aerial): Config imagery taranaki_urban_2022_0.1m_RGB into Aerial Map. BM-684

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -768,7 +768,7 @@
       "2193": "s3://linz-basemaps/2193/new-plymouth_urban_2017_0-10m/01F6P1FPAFD6D8SRHZX3GFJFWY",
       "3857": "s3://linz-basemaps/3857/new-plymouth_urban_2017_0-10m/01ED82VQR8M1STH3EPMF3E8KFQ",
       "name": "new-plymouth_urban_2017_0-10m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "New Plymouth 0.10m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos"
     },
@@ -1168,7 +1168,9 @@
       "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.1m_RGB/01GDM79KSKKCZ4FQCX5S2Q4BDQ",
       "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.1m_RGB/01GDM7ACWGP9QZP7V3MF4MPKH8",
       "name": "taranaki_urban_2022_0.1m_RGB",
-      "minZoom": 14
+      "minZoom": 14,
+      "title": "Taranaki 0.1m Urban Aerial Photos (2022)",
+      "category": "Urban Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1165,6 +1165,12 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.1m_RGB/01GDM79KSKKCZ4FQCX5S2Q4BDQ",
+      "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.1m_RGB/01GDM7ACWGP9QZP7V3MF4MPKH8",
+      "name": "taranaki_urban_2022_0.1m_RGB",
+      "minZoom": 14
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",


### PR DESCRIPTION
Imagery imported for taranaki_urban_2022_0.1m_RGB, please use the following QA url once the aws job finished.

Individual Imagery NZTM2000Quad: https://basemaps.linz.govt.nz/?i=01GDM79KSKKCZ4FQCX5S2Q4BDQ&p=NZTM2000Quad&debug#@-39.225137,174.234935,z9

Individual Imagery WebMercatorQuad: https://basemaps.linz.govt.nz/?i=01GDM7ACWGP9QZP7V3MF4MPKH8&p=WebMercatorQuad&debug#@-39.227998,174.226685,z12

Tagged Aerial Map NZTM2000Quad: https://basemaps.linz.govt.nz/?p=NZTM2000Quad&config=s3://linz-basemaps/config/config-5wEKoMbMdvnAzSua1LYM72N6e1veu8kwoFgGZJzD1Br1.json.gz#@-39.225137,174.234935,z9

Tagged Aerial Map WebMercatorQuad: https://basemaps.linz.govt.nz/?p=WebMercatorQuad&config=s3://linz-basemaps/config/config-5wEKoMbMdvnAzSua1LYM72N6e1veu8kwoFgGZJzD1Br1.json.gz#@-39.227998,174.226685,z12

