### PR TITLE
config(aerial): Config Invercargill rural imagery into aerial map. BM-698

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -656,7 +656,7 @@
       "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-1m/01F6P1A7YH7JXE247G85F25WG6",
       "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-1m/01ED82E60KN099T9A8V11KCSK0",
       "name": "invercargill_urban_2016_0-1m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Invercargill 0.1m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos"
     },
@@ -664,7 +664,7 @@
       "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-05m/01F6P1A2VKHHFQW764DRW93G4Y",
       "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-05m/01ED82DPKVVWA818DY9QQ9GS0J",
       "name": "invercargill_urban_2016_0-05m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Invercargill 0.05m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -525,6 +525,14 @@
       "category": "Rural Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/invercargill_rural_2022_0.1m/01GG8G03K4N284BJ7Q0DFTRW6P",
+      "3857": "s3://linz-basemaps/3857/invercargill_rural_2022_0.1m/01GG8G0NQDH4F6XPCMQS312DRK",
+      "name": "invercargill_rural_2022_0.1m",
+      "minZoom": 13,
+      "title": "Invercargill 0.1m Rural Aerial Photos (2022)",
+      "category": "Rural Aerial Photos"
+    },
+    {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ",
       "name": "selwyn_urban_2012-2013_0-125m_RGBA",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -525,14 +525,6 @@
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/invercargill_rural_2022_0.1m/01GG8G03K4N284BJ7Q0DFTRW6P",
-      "3857": "s3://linz-basemaps/3857/invercargill_rural_2022_0.1m/01GG8G0NQDH4F6XPCMQS312DRK",
-      "name": "invercargill_rural_2022_0.1m",
-      "minZoom": 13,
-      "title": "Invercargill 0.1m Rural Aerial Photos (2022)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ",
       "name": "selwyn_urban_2012-2013_0-125m_RGBA",
@@ -1186,6 +1178,14 @@
       "name": "taranaki_urban_2022_0.05m_RGB",
       "minZoom": 14,
       "title": "Taranaki 0.05m Urban Aerial Photos (2022)",
+      "category": "Urban Aerial Photos"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/invercargill_rural_2022_0.1m/01GG8G03K4N284BJ7Q0DFTRW6P",
+      "3857": "s3://linz-basemaps/3857/invercargill_rural_2022_0.1m/01GG8G0NQDH4F6XPCMQS312DRK",
+      "name": "invercargill_urban_2022_0.1m",
+      "minZoom": 14,
+      "title": "Invercargill 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1181,8 +1181,8 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/invercargill_rural_2022_0.1m/01GG8G03K4N284BJ7Q0DFTRW6P",
-      "3857": "s3://linz-basemaps/3857/invercargill_rural_2022_0.1m/01GG8G0NQDH4F6XPCMQS312DRK",
+      "2193": "s3://linz-basemaps/2193/invercargill_2022_0.1m/01GG8G03K4N284BJ7Q0DFTRW6P",
+      "3857": "s3://linz-basemaps/3857/invercargill_2022_0.1m/01GG8G0NQDH4F6XPCMQS312DRK",
       "name": "invercargill_urban_2022_0.1m",
       "minZoom": 14,
       "title": "Invercargill 0.1m Urban Aerial Photos (2022)",


### PR DESCRIPTION
# New Layers
### invercargill_urban_2022_0.1m
 - [NZTM200Quad](https://basemaps.linz.govt.nz/?i=01GG8G03K4N284BJ7Q0DFTRW6P&p=NZTM2000Quad&debug#@-46.451003,168.376325,z9) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps/config/config-xu4uP4JMqJDVeR2bEUAWWkHFy6vyFADHqC1DRgu8anN.json.gz&p=NZTM2000Quad&debug#@-46.451003,168.376325,z9)
 - [WebMercatorQuad](https://basemaps.linz.govt.nz/?i=01GG8G0NQDH4F6XPCMQS312DRK&p=WebMercatorQuad&debug#@-46.460566,168.365479,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps/config/config-xu4uP4JMqJDVeR2bEUAWWkHFy6vyFADHqC1DRgu8anN.json.gz&p=WebMercatorQuad&debug#@-46.460566,168.365479,z12)
# Updates
### invercargill_urban_2016_0-1m
 - Zoom level updated. min zoom 14 -> 32
### invercargill_urban_2016_0-05m
 - Zoom level updated. min zoom 14 -> 32
