### PR TITLE
feat(aerial): Config Bay of Plenty Rural 2021-2022 into Aerial Map.

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -424,7 +424,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2019_0-3m/01F66E4BR5XTJENFTSACWB55DM",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2019_0-3m/01ED81R5BX4EB3W7TB3Z8ZE89S",
       "name": "bay-of-plenty_rural_2019_0-3m",
-      "minZoom": 13,
+      "minZoom": 32,
       "title": "Bay of Plenty 0.3m Rural Aerial Photos (2019)",
       "category": "Rural Aerial Photos"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -533,6 +533,14 @@
       "category": "Rural Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_2021-2022_0.2m/01GHW1Y474AHB191P8SRKENK7Y",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_2021-2022_0.2m/01GHW1ZWNS4N0GP9TAM09WHPBC",
+      "name": "bay-of-plenty_2021-2022_0.2m",
+      "minZoom": 13,
+      "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021-2022)",
+      "category": "Rural Aerial Photos"
+    },
+    {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ",
       "name": "selwyn_urban_2012-2013_0-125m_RGBA",


### PR DESCRIPTION
# New Layers
### bay-of-plenty_2021-2022_0.2m
 - [NZTM200Quad](https://basemaps.linz.govt.nz/?i=01GHW1Y474AHB191P8SRKENK7Y&p=NZTM2000Quad&debug#@-38.173173,177.266888,z9) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps/config/config-A1AndnQSPSPRFMFgdqonVq4UM6RCqTnZgdauo3Q8mRqv.json.gz&p=NZTM2000Quad&debug#@-38.173173,177.266888,z9)
 - [WebMercatorQuad](https://basemaps.linz.govt.nz/?i=01GHW1ZWNS4N0GP9TAM09WHPBC&p=WebMercatorQuad&debug#@-38.199339,177.297363,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps/config/config-A1AndnQSPSPRFMFgdqonVq4UM6RCqTnZgdauo3Q8mRqv.json.gz&p=WebMercatorQuad&debug#@-38.199339,177.297363,z12)
# Updates
### bay-of-plenty_rural_2019_0-3m
 - Zoom level updated. min zoom 13 -> 32
