### PR TITLE
feat(aerial): Config imagery waimate_2021_0.075m into Aerial Map. 

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1224,7 +1224,7 @@
       "2193": "s3://linz-basemaps/2193/waimate_2021_0.075m/01GKSQ99D3KZ2NN9H7MWSABMNM",
       "3857": "s3://linz-basemaps/3857/waimate_2021_0.075m/01GKSQ9HMFNF4Z55QXCJ2Y2X0X",
       "name": "waimate_2021_0.075m",
-      "minZoom": 32,
+      "minZoom": 14,
       "title": "Waimate 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1257,6 +1257,14 @@
       "minZoom": 32,
       "title": "Top of the South 0.15m Flood Aerial Photos (2022)",
       "category": "Event"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/waimate_2021_0.075m/01GKSQ99D3KZ2NN9H7MWSABMNM",
+      "3857": "s3://linz-basemaps/3857/waimate_2021_0.075m/01GKSQ9HMFNF4Z55QXCJ2Y2X0X",
+      "name": "waimate_2021_0.075m",
+      "title": "Waimate 2021 0.075m",
+      "minZoom": 32,
+      "category": "New Aerial Photos"
     }
   ]
 }

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -936,7 +936,7 @@
       "2193": "s3://linz-basemaps/2193/waimate_urban_2018_0-075m_RGB/01F6P20H4Y55WG0SW5RXNP6Y9J",
       "3857": "s3://linz-basemaps/3857/waimate_urban_2018_0-075m_RGB/01ESF5HA3BXN5E50Z0608KJGTG",
       "name": "waimate_urban_2018_0-075m_RGB",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Waimate 0.075m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos"
     },
@@ -1080,7 +1080,7 @@
       "2193": "s3://linz-basemaps/2193/waimate_urban_2020_0-075m_RGB/01FJB8FDBCP2R3VT7TJC1NWGFD",
       "3857": "s3://linz-basemaps/3857/waimate_urban_2020_0-075m_RGB/01FJB8KPXHR48ZVDHE7M9PK6RH",
       "name": "waimate_urban_2020_0-075m_RGB",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Waimate 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
     },
@@ -1221,6 +1221,14 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/waimate_2021_0.075m/01GKSQ99D3KZ2NN9H7MWSABMNM",
+      "3857": "s3://linz-basemaps/3857/waimate_2021_0.075m/01GKSQ9HMFNF4Z55QXCJ2Y2X0X",
+      "name": "waimate_2021_0.075m",
+      "minZoom": 32,
+      "title": "Waimate 0.075m Urban Aerial Photos (2021)",
+      "category": "Urban Aerial Photos"
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",
@@ -1257,14 +1265,6 @@
       "minZoom": 32,
       "title": "Top of the South 0.15m Flood Aerial Photos (2022)",
       "category": "Event"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/waimate_2021_0.075m/01GKSQ99D3KZ2NN9H7MWSABMNM",
-      "3857": "s3://linz-basemaps/3857/waimate_2021_0.075m/01GKSQ9HMFNF4Z55QXCJ2Y2X0X",
-      "name": "waimate_2021_0.075m",
-      "title": "Waimate 2021 0.075m",
-      "minZoom": 32,
-      "category": "New Aerial Photos"
     }
   ]
 }


### PR DESCRIPTION
# New Layers
### waimate_2021_0.075m
 - [NZTM200Quad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-CEcZPQAQE1qQ6jgyj9fn8VZDSHqni9KkaxfqhhhfywN.json.gz&i=waimate-2021-0.075m&p=NZTM2000Quad&debug#@-44.718672,170.832915,z9) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-CEcZPQAQE1qQ6jgyj9fn8VZDSHqni9KkaxfqhhhfywN.json.gz&p=NZTM2000Quad&debug#@-44.718672,170.832915,z9)
 - [WebMercatorQuad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-CEcZPQAQE1qQ6jgyj9fn8VZDSHqni9KkaxfqhhhfywN.json.gz&i=waimate-2021-0.075m&p=WebMercatorQuad&debug#@-44.725272,170.837402,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-CEcZPQAQE1qQ6jgyj9fn8VZDSHqni9KkaxfqhhhfywN.json.gz&p=WebMercatorQuad&debug#@-44.725272,170.837402,z12)
# Updates
### waimate_urban_2018_0-075m_RGB
 - Zoom level updated. min zoom 14 -> 32
### waimate_urban_2020_0-075m_RGB
 - Zoom level updated. min zoom 14 -> 32
