### PR TITLE
feat(aerial): Config imagery ashburton_urban_2021-2022_0.075m into Aerial Map. 

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1205,6 +1205,14 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/ashburton_urban_2021-2022_0.075m/01GM796A98A5WRYAKBJXRN57Z4",
+      "3857": "s3://linz-basemaps/3857/ashburton_urban_2021-2022_0.075m/01GM79743023G6STTDG08J4GV8",
+      "name": "ashburton_urban_2021-2022_0.075m",
+      "title": "Ashburton urban 2021-2022 0.075m",
+      "minZoom": 14,
+      "category": "Urban Aerial Photos"
+    },
+    {
       "2193": "s3://linz-basemaps/2193/invercargill_2022_0.05m/01GJ3WD5DCSRF0QN7JKN82GPCF",
       "3857": "s3://linz-basemaps/3857/invercargill_2022_0.05m/01GJ3WDN7PTMGZ14AH56GPX39G",
       "name": "invercargill_2022_0.05m",

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -984,7 +984,7 @@
       "2193": "s3://linz-basemaps/2193/ashburton_urban_2020_0-075m_RGB/01FPV7HMJN6RQNSANMZ2SRY0BK",
       "3857": "s3://linz-basemaps/3857/ashburton_urban_2020_0-075m_RGB/01FPV7ABAWS4ZCWN91VR7SDK0A",
       "name": "ashburton_urban_2020_0-075m_RGB",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Ashburton 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
     },
@@ -1208,8 +1208,8 @@
       "2193": "s3://linz-basemaps/2193/ashburton_urban_2021-2022_0.075m/01GM796A98A5WRYAKBJXRN57Z4",
       "3857": "s3://linz-basemaps/3857/ashburton_urban_2021-2022_0.075m/01GM79743023G6STTDG08J4GV8",
       "name": "ashburton_urban_2021-2022_0.075m",
-      "title": "Ashburton urban 2021-2022 0.075m",
       "minZoom": 14,
+      "title": "Ashburton 0.075m Urban Aerial Photos (2021-2022)",
       "category": "Urban Aerial Photos"
     },
     {


### PR DESCRIPTION
# New Layers
### ashburton_urban_2021-2022_0.075m
 - [NZTM2000Quad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-Ared7eYB2Psc2MmcFNYTJcBb3AiTTQvmX6TaJ2XAYFiG.json.gz&i=ashburton-urban-2021-2022-0.075m&p=NZTM2000Quad&debug#@-43.851402,171.617772,z9) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-Ared7eYB2Psc2MmcFNYTJcBb3AiTTQvmX6TaJ2XAYFiG.json.gz&p=NZTM2000Quad&debug#@-43.851402,171.617772,z9)
 - [WebMercatorQuad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-Ared7eYB2Psc2MmcFNYTJcBb3AiTTQvmX6TaJ2XAYFiG.json.gz&i=ashburton-urban-2021-2022-0.075m&p=WebMercatorQuad&debug#@-43.851365,171.622925,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-Ared7eYB2Psc2MmcFNYTJcBb3AiTTQvmX6TaJ2XAYFiG.json.gz&p=WebMercatorQuad&debug#@-43.851365,171.622925,z12)
# Updates
### ashburton_urban_2020_0-075m_RGB
 - Zoom level updated. min zoom 14 -> 32
