### PR TITLE
feat(aerial): Config imagery palmerston_north_2022_0.125m into Aerial Map. 

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1265,6 +1265,14 @@
       "minZoom": 32,
       "title": "Top of the South 0.15m Flood Aerial Photos (2022)",
       "category": "Event"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMC9M29APG7DC863QWQKB2SM",
+      "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMC9MMCG7F5XB8T43SD6F88R",
+      "name": "palmerston_north_2022_0.125m",
+      "title": "Palmerston north 2022 0.125m",
+      "minZoom": 32,
+      "category": "New Aerial Photos"
     }
   ]
 }

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1229,8 +1229,8 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMC9M29APG7DC863QWQKB2SM",
-      "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMC9MMCG7F5XB8T43SD6F88R",
+      "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMPDNDV54KMKAS2RQH4A3WNE",
+      "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMPDP0B72W5VKH15PRD5DGYC",
       "name": "palmerston_north_2022_0.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2022)",
       "minZoom": 14,

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -896,7 +896,7 @@
       "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2018-2019_0-125m_RGB/01F6P1PF375AH4BPQ9PTQA7GYD",
       "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2018-2019_0-125m_RGB/01ESF5MHFP5RCKQW94Z2947CES",
       "name": "palmerston-north_urban_2018-2019_0-125m_RGB",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Palmerston North 0.125m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos"
     },
@@ -1232,7 +1232,7 @@
       "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMC9M29APG7DC863QWQKB2SM",
       "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMC9MMCG7F5XB8T43SD6F88R",
       "name": "palmerston_north_2022_0.125m",
-      "title": "Palmerston north 2022 0.125m",
+      "title": "Palmerston North 0.125m Urban Aerial Photos (2022)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -1229,6 +1229,14 @@
       "category": "Urban Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMC9M29APG7DC863QWQKB2SM",
+      "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMC9MMCG7F5XB8T43SD6F88R",
+      "name": "palmerston_north_2022_0.125m",
+      "title": "Palmerston north 2022 0.125m",
+      "minZoom": 14,
+      "category": "Urban Aerial Photos"
+    },
+    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
       "name": "auckland_rural_2020_0-075m_RGB",
@@ -1265,14 +1273,6 @@
       "minZoom": 32,
       "title": "Top of the South 0.15m Flood Aerial Photos (2022)",
       "category": "Event"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMC9M29APG7DC863QWQKB2SM",
-      "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMC9MMCG7F5XB8T43SD6F88R",
-      "name": "palmerston_north_2022_0.125m",
-      "title": "Palmerston north 2022 0.125m",
-      "minZoom": 32,
-      "category": "New Aerial Photos"
     }
   ]
 }

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -936,7 +936,7 @@
       "2193": "s3://linz-basemaps/2193/waimate_urban_2018_0-075m_RGB/01F6P20H4Y55WG0SW5RXNP6Y9J",
       "3857": "s3://linz-basemaps/3857/waimate_urban_2018_0-075m_RGB/01ESF5HA3BXN5E50Z0608KJGTG",
       "name": "waimate_urban_2018_0-075m_RGB",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Waimate 0.075m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos"
     },
@@ -1080,7 +1080,7 @@
       "2193": "s3://linz-basemaps/2193/waimate_urban_2020_0-075m_RGB/01FJB8FDBCP2R3VT7TJC1NWGFD",
       "3857": "s3://linz-basemaps/3857/waimate_urban_2020_0-075m_RGB/01FJB8KPXHR48ZVDHE7M9PK6RH",
       "name": "waimate_urban_2020_0-075m_RGB",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Waimate 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
     },
@@ -1218,6 +1218,14 @@
       "name": "tauranga_winter_2022_0.1m",
       "minZoom": 32,
       "title": "Tauranga Winter 0.1m Urban Aerial Photos (2022)",
+      "category": "Urban Aerial Photos"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/waimate_2021_0.075m/01GKSQ99D3KZ2NN9H7MWSABMNM",
+      "3857": "s3://linz-basemaps/3857/waimate_2021_0.075m/01GKSQ9HMFNF4Z55QXCJ2Y2X0X",
+      "name": "waimate_2021_0.075m",
+      "minZoom": 14,
+      "title": "Waimate 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {


### PR DESCRIPTION
# New Layers
### palmerston_north_2022_0.125m
 - [NZTM2000Quad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-HSjr4Ltgrd2cqgHcT1vAFJsXbMVKKimWT1ksEc5EJZsp.json.gz&i=palmerston-north-2022-0.125m&p=NZTM2000Quad&debug#@-40.352739,175.653911,z9) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-HSjr4Ltgrd2cqgHcT1vAFJsXbMVKKimWT1ksEc5EJZsp.json.gz&p=NZTM2000Quad&debug#@-40.352739,175.653911,z9)
 - [WebMercatorQuad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-HSjr4Ltgrd2cqgHcT1vAFJsXbMVKKimWT1ksEc5EJZsp.json.gz&i=palmerston-north-2022-0.125m&p=WebMercatorQuad&debug#@-40.354917,175.654907,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-HSjr4Ltgrd2cqgHcT1vAFJsXbMVKKimWT1ksEc5EJZsp.json.gz&p=WebMercatorQuad&debug#@-40.354917,175.654907,z12)
# Updates
### palmerston-north_urban_2018-2019_0-125m_RGB
 - Zoom level updated. min zoom 14 -> 32
