### PR TITLE
fix(aerial): Switch the satellite to new data to fix the broken overview.

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -31,7 +31,7 @@
     },
     {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01GQ1BY7VRX3T9ZYMERXYRZZHH",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01GQ1HYZYCVRERQQS6FR1P5X7M",
       "name": "nz_satellite_2020-2021_10m_RGB",
       "minZoom": 32,
       "title": "New Zealand 10m Satellite Imagery (2020-2021)",
@@ -39,7 +39,7 @@
     },
     {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G73E4AMSQ91TXQ3KC90NNPA0",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01GQ1BSND57ZVT82AGEEKA2VJR",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01GQ1J1V05X64SDTM673WTMJ7J",
       "name": "nz_satellite_2021-2022_10m_RGB",
       "title": "New Zealand 10m Satellite Imagery (2021-2022)",
       "category": "Satellite Imagery"

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -31,7 +31,7 @@
     },
     {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01GQ1BY7VRX3T9ZYMERXYRZZHH",
       "name": "nz_satellite_2020-2021_10m_RGB",
       "minZoom": 32,
       "title": "New Zealand 10m Satellite Imagery (2020-2021)",
@@ -39,7 +39,7 @@
     },
     {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G73E4AMSQ91TXQ3KC90NNPA0",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G73E5DZKE9NSW6E41QQRT28T",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01GQ1BSND57ZVT82AGEEKA2VJR",
       "name": "nz_satellite_2021-2022_10m_RGB",
       "title": "New Zealand 10m Satellite Imagery (2021-2022)",
       "category": "Satellite Imagery"


### PR DESCRIPTION
# Updates
### nz_satellite_2020-2021_10m_RGB
- Layer update [WebMercatorQuad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-2b6cBzCW1ffduBdyuhRW62CUDXspnf8ikQZY5omXydCG.json.gz&i=nz-satellite-2020-2021-10m&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-2b6cBzCW1ffduBdyuhRW62CUDXspnf8ikQZY5omXydCG.json.gz&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12)
### nz_satellite_2021-2022_10m_RGB
- Layer update [WebMercatorQuad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-2b6cBzCW1ffduBdyuhRW62CUDXspnf8ikQZY5omXydCG.json.gz&i=nz-satellite-2021-2022-10m&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-2b6cBzCW1ffduBdyuhRW62CUDXspnf8ikQZY5omXydCG.json.gz&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12)
