### PR TITLE
config(style): Update the aerial hybrid style to remove topo250 refference

### DIFF
--- a/config/style/aerialhybrid.json
+++ b/config/style/aerialhybrid.json
@@ -678,13 +678,13 @@
       }
     },
     {
-      "id": "Transport-Roads-Topo250-Casing",
+      "id": "Transport-Roads-8-Casing",
       "type": "line",
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 6,
       "maxzoom": 8,
-      "filter": ["all", ["==", "class", "motorway"], ["in", "hway_num", "1", "1B", "2", "3", "3A", "4", "5", "6", "6A", "7", "8", "8A", "18", "20", "51", "76"]],
+      "filter": ["all", ["==", "class", "motorway"]],
       "layout": { "visibility": "visible" },
       "paint": {
         "line-width": {
@@ -697,13 +697,13 @@
       }
     },
     {
-      "id": "Transport-Roads-Topo250",
+      "id": "Transport-Roads-8",
       "type": "line",
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
       "minzoom": 6,
       "maxzoom": 8,
-      "filter": ["all", ["in", "hway_num", "1", "1B", "2", "3", "3A", "4", "5", "6", "6A", "7", "8", "8A", "18", "20", "51", "76"]],
+      "filter": ["all", ["==", "class", "motorway"]],
       "layout": { "visibility": "visible" },
       "paint": {
         "line-width": {
@@ -777,10 +777,10 @@
       "minzoom": 8,
       "filter": ["all", ["in", "hway_num", "25A", "20A", "20B", "29A", "30A", "74A", "67A"]],
       "layout": {
-        "symbol-placement": "line",
+        "icon-rotation-alignment": "viewport",
+        "icon-pitch-alignment": "viewport",
+        "visibility": "visible",
         "text-field": "{hway_num}",
-        "text-font": ["Open Sans Bold"],
-        "icon-text-fit": "none",
         "text-size": {
           "stops": [
             [8, 9],
@@ -788,25 +788,7 @@
             [15, 14]
           ]
         },
-        "symbol-spacing": {
-          "stops": [
-            [6, 500],
-            [13, 400]
-          ]
-        },
-        "visibility": "visible",
-        "text-justify": "center",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "icon-rotation-alignment": "viewport",
-        "icon-offset": [0, 1],
-        "icon-pitch-alignment": "viewport",
-        "icon-anchor": "center",
-        "icon-keep-upright": false,
-        "text-keep-upright": true,
-        "icon-rotate": 0,
-        "icon-padding": 2,
-        "icon-text-fit-padding": [1, 4, 3, 3],
+        "icon-text-fit": "none",
         "icon-size": {
           "stops": [
             [8, 1.2],
@@ -814,12 +796,30 @@
             [15, 1.7]
           ]
         },
-        "icon-image": "highway_pnt_wide"
+        "symbol-placement": "line",
+        "icon-image": "highway_pnt_wide",
+        "text-font": ["Open Sans Bold"],
+        "icon-padding": 2,
+        "symbol-spacing": {
+          "stops": [
+            [6, 500],
+            [13, 400]
+          ]
+        },
+        "text-pitch-alignment": "viewport",
+        "text-justify": "center",
+        "icon-text-fit-padding": [1, 4, 3, 3],
+        "icon-anchor": "center",
+        "text-rotation-alignment": "viewport",
+        "icon-offset": [0, 1],
+        "text-keep-upright": true,
+        "icon-keep-upright": false,
+        "icon-rotate": 0
       },
       "paint": {
         "text-translate-anchor": "map",
-        "text-color": "rgba(255, 255, 255, 1)",
-        "icon-translate-anchor": "map"
+        "icon-translate-anchor": "map",
+        "text-color": "rgba(255, 255, 255, 1)"
       }
     },
     {
@@ -830,10 +830,10 @@
       "minzoom": 8,
       "filter": ["all", ["has", "hway_num"], ["!in", "hway_num", "6,94", "2,50", "1,3", "12,15", "14,15", "6,96", "25A", "20A", "20B", "29A", "30A", "74A", "67A"], ["!=", "lane_count", 1]],
       "layout": {
-        "symbol-placement": "line",
+        "icon-rotation-alignment": "viewport",
+        "icon-pitch-alignment": "viewport",
+        "visibility": "visible",
         "text-field": "{hway_num}",
-        "text-font": ["Open Sans Bold"],
-        "icon-text-fit": "none",
         "text-size": {
           "stops": [
             [8, 9],
@@ -841,25 +841,7 @@
             [15, 14]
           ]
         },
-        "symbol-spacing": {
-          "stops": [
-            [6, 500],
-            [13, 400]
-          ]
-        },
-        "visibility": "visible",
-        "text-justify": "center",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "icon-rotation-alignment": "viewport",
-        "icon-offset": [0, 1],
-        "icon-pitch-alignment": "viewport",
-        "icon-anchor": "center",
-        "icon-keep-upright": false,
-        "text-keep-upright": true,
-        "icon-rotate": 0,
-        "icon-padding": 2,
-        "icon-text-fit-padding": [1, 4, 3, 3],
+        "icon-text-fit": "none",
         "icon-size": {
           "stops": [
             [8, 1.2],
@@ -867,12 +849,30 @@
             [15, 1.7]
           ]
         },
-        "icon-image": "highway_pnt_standard"
+        "symbol-placement": "line",
+        "icon-image": "highway_pnt_standard",
+        "text-font": ["Open Sans Bold"],
+        "icon-padding": 2,
+        "symbol-spacing": {
+          "stops": [
+            [6, 500],
+            [13, 400]
+          ]
+        },
+        "text-pitch-alignment": "viewport",
+        "text-justify": "center",
+        "icon-text-fit-padding": [1, 4, 3, 3],
+        "icon-anchor": "center",
+        "text-rotation-alignment": "viewport",
+        "icon-offset": [0, 1],
+        "text-keep-upright": true,
+        "icon-keep-upright": false,
+        "icon-rotate": 0
       },
       "paint": {
         "text-translate-anchor": "map",
-        "text-color": "rgba(255, 255, 255, 1)",
-        "icon-translate-anchor": "map"
+        "icon-translate-anchor": "map",
+        "text-color": "rgba(255, 255, 255, 1)"
       }
     },
     {
@@ -934,31 +934,6 @@
           ]
         },
         "text-font": ["Open Sans Regular"]
-      }
-    },
-    {
-      "id": "Transport-Railway-Symbol",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 12.5,
-      "filter": ["all", ["==", "class", "railway_pt"]],
-      "layout": {
-        "icon-allow-overlap": true,
-        "text-justify": "right",
-        "text-field": "{name}",
-        "icon-anchor": "right",
-        "text-offset": [0.75, 0],
-        "text-anchor": "left",
-        "text-size": 11,
-        "icon-image": "railway_11",
-        "text-font": ["Open Sans Bold Italic"]
-      },
-      "paint": {
-        "text-halo-blur": 0.5,
-        "text-color": "rgba(94, 94, 94, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 1
       }
     },
     {
@@ -1312,43 +1287,6 @@
     },
     {
       "id": "Poi-Railway-Symbol",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 12,
-      "maxzoom": 14,
-      "filter": ["all", ["==", "class", "railway"]],
-      "layout": {
-        "icon-allow-overlap": false,
-        "visibility": "visible",
-        "text-field": "",
-        "text-anchor": "left",
-        "text-size": 16,
-        "icon-size": {
-          "stops": [
-            [12, 1],
-            [13, 1],
-            [20, 2]
-          ]
-        },
-        "icon-image": "rail_station_train_diesel_pnt_red",
-        "text-font": ["Open Sans Bold Italic"],
-        "icon-optional": true,
-        "text-justify": "left",
-        "text-max-width": 5,
-        "icon-anchor": "center",
-        "text-offset": [1.25, 1.5]
-      },
-      "paint": {
-        "text-halo-blur": 0.5,
-        "text-color": "rgba(94, 94, 94, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 1.5,
-        "text-translate": [0, -15]
-      }
-    },
-    {
-      "id": "Poi-Railway-Symbol-copy",
       "type": "symbol",
       "source": "LINZ Basemaps",
       "source-layer": "poi",


### PR DESCRIPTION
# Vector Style Update
* [aerialhybrid](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-127GvctxD4sYB2y3KvsheyfK6mVVg4UaqNgmwAKtEFdy.json.gz&i=topographic&s=aerialhybrid&debug)
