### PR TITLE
fix(aerial): Revert the satellite layer after overview been fixed and generated.

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -31,7 +31,7 @@
     },
     {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01GQ1HYZYCVRERQQS6FR1P5X7M",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J",
       "name": "nz_satellite_2020-2021_10m_RGB",
       "minZoom": 32,
       "title": "New Zealand 10m Satellite Imagery (2020-2021)",
@@ -39,7 +39,7 @@
     },
     {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G73E4AMSQ91TXQ3KC90NNPA0",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01GQ1J1V05X64SDTM673WTMJ7J",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G73E5DZKE9NSW6E41QQRT28T",
       "name": "nz_satellite_2021-2022_10m_RGB",
       "title": "New Zealand 10m Satellite Imagery (2021-2022)",
       "category": "Satellite Imagery"


### PR DESCRIPTION
# Updates
### nz_satellite_2020-2021_10m_RGB
 - Zoom level updated. min zoom undefined -> 32
- Layer update [WebMercatorQuad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-7AAbmAyS5vsPcgZG9E2ja8RtyTALp7QeoewtGE6d6yyS.json.gz&i=nz-satellite-2020-2021-10m&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-7AAbmAyS5vsPcgZG9E2ja8RtyTALp7QeoewtGE6d6yyS.json.gz&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12)
### nz_satellite_2021-2022_10m_RGB
- Layer update [WebMercatorQuad](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-7AAbmAyS5vsPcgZG9E2ja8RtyTALp7QeoewtGE6d6yyS.json.gz&i=nz-satellite-2021-2022-10m&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12) -- [Aerial](https://basemaps.linz.govt.nz/?config=s3://linz-basemaps-staging/config/config-7AAbmAyS5vsPcgZG9E2ja8RtyTALp7QeoewtGE6d6yyS.json.gz&p=WebMercatorQuad&debug#@-41.376809,172.968750,z12)
### tasman_rural_2001-2002_1m_RGB
 - Zoom level updated. min zoom undefined -> 32
### tasman_rural_2009-2010_0-50m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### bay-of-plenty_rural_2011-2012_0-25m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### marlborough_rural_2011-2012_0-40m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### gisborne_rural_2012-2013_0-40m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### waikato_rural_2012-2013_0-50m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### dunedin_rural_2013_0-40m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### otago_rural_2013-2014_0-40m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### hawkes-bay_rural_2014-2015_0-30m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### manawatu-whanganui_rural_2015-16_0-3m
 - Zoom level updated. min zoom undefined -> 32
### marlborough_rural_2015-2016_0-20m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### tasman_rural_2015-16_0-3m
 - Zoom level updated. min zoom undefined -> 32
### manawatu-whanganui_rural_2016-17_0-3m
 - Zoom level updated. min zoom undefined -> 32
### taranaki_rural_2016-17_0-3m
 - Zoom level updated. min zoom undefined -> 32
### tasman_rural_2016-17_0-3m
 - Zoom level updated. min zoom undefined -> 32
### hawkes-bay_rural_2019-2020_0-3m_RGB
 - Zoom level updated. min zoom undefined -> 32
### bay-of-plenty_rural_2019_0-3m
 - Zoom level updated. min zoom undefined -> 32
### waikato_2021-2023_0.3m
 - Zoom level updated. min zoom undefined -> 32
### waimakariri_urban_2013-2014_0-075m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### hastings-district_urban_2014-2015_0-10m_RGB
 - Zoom level updated. min zoom undefined -> 32
### palmerston-north-city_urban_2014-15_0-125m
 - Zoom level updated. min zoom undefined -> 32
### waikato_urban_2014_0-10m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### bay-of-plenty_urban_2015-16_0-125m
 - Zoom level updated. min zoom undefined -> 32
### bay-of-plenty_urban_2015-16_0-1m
 - Zoom level updated. min zoom undefined -> 32
### christchurch_urban_2015-2016_0-075m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### waimakariri_urban_2015-2016_0-075m_RGBA
 - Zoom level updated. min zoom undefined -> 32
### hamilton_urban_2016-17_0-1m
 - Zoom level updated. min zoom undefined -> 32
### invercargill_urban_2016_0-1m
 - Zoom level updated. min zoom undefined -> 32
### invercargill_urban_2016_0-05m
 - Zoom level updated. min zoom undefined -> 32
### palmerston-north_urban_2016-17_1-125m
 - Zoom level updated. min zoom undefined -> 32
### porirua_urban_2016_0-075m
 - Zoom level updated. min zoom undefined -> 32
### central-hawkes-bay_urban_2017-18_0-1m
 - Zoom level updated. min zoom undefined -> 32
### hastings-district_urban_2017-18_0-1m
 - Zoom level updated. min zoom undefined -> 32
### hutt-city_urban_2017_0-10m
 - Zoom level updated. min zoom undefined -> 32
### napier-city_urban_2017-18_0-05m
 - Zoom level updated. min zoom undefined -> 32
### napier-city_urban_2017-18_0-1m
 - Zoom level updated. min zoom undefined -> 32
### new-plymouth_urban_2017_0-10m
 - Zoom level updated. min zoom undefined -> 32
### tasman_urban_2017_0-075m
 - Zoom level updated. min zoom undefined -> 32
### tasman_urban_2017_0-1m
 - Zoom level updated. min zoom undefined -> 32
### tauranga_urban_2017_0-1m
 - Zoom level updated. min zoom undefined -> 32
### upper-hutt_urban_2017_0-10m
 - Zoom level updated. min zoom undefined -> 32
### wellington_urban_2017_0-10m
 - Zoom level updated. min zoom undefined -> 32
### christchurch_urban_2018_0-075m
 - Zoom level updated. min zoom undefined -> 32
### christchurch_urban_2018-2019_0-075m_RGB
 - Zoom level updated. min zoom undefined -> 32
### palmerston-north_urban_2018-2019_0-125m_RGB
 - Zoom level updated. min zoom undefined -> 32
### waimate_urban_2018_0-075m_RGB
 - Zoom level updated. min zoom undefined -> 32
### hamilton_urban_2019_0-1m
 - Zoom level updated. min zoom undefined -> 32
### banks-peninsula_urban_2019-2020_0-075m_RGB
 - Zoom level updated. min zoom undefined -> 32
### ashburton_urban_2020_0-075m_RGB
 - Zoom level updated. min zoom undefined -> 32
### waimate_urban_2020_0-075m_RGB
 - Zoom level updated. min zoom undefined -> 32
### tauranga_winter_2022_0.1m
 - Zoom level updated. min zoom undefined -> 32
### top-of-the-south_flood_2022_0.15m
 - Zoom level updated. min zoom undefined -> 32
