### PR TITLE
feat(aerial): don't show Bay of Plenty urbans

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -240,7 +240,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2014-15_0-125m/01F66E4JBVW1AW4VKGRN95SDGZ",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2014-15_0-125m/01ED81RPD7YEYNTPM2WZZK3X1A",
       "name": "bay-of-plenty_urban_2014-15_0-125m",
-      "minZoom": 13,
+      "minZoom": 32,
       "title": "Bay of Plenty 0.125m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos"
     },
@@ -248,7 +248,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2015-17_0-25m/01F66E2MGVQY9F4WXRYDRWRGPE",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2015-17_0-25m/01ED81P0KGVWJP2XHDKJJRYNQM",
       "name": "bay-of-plenty_rural_2015-17_0-25m",
-      "minZoom": 13,
+      "minZoom": 32,
       "title": "Bay of Plenty 0.25m Rural Aerial Photos (2015-2017)",
       "category": "Rural Aerial Photos"
     },
@@ -304,7 +304,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2016-17_0-3m/01F66E3G0Z8DNKWXG5M55QNW9G",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW",
       "name": "bay-of-plenty_rural_2016-17_0-3m",
-      "minZoom": 13,
+      "minZoom": 32,
       "title": "Bay of Plenty 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos"
     },
@@ -920,7 +920,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2018-19_0-1m/01F66E7K4ESMSWZ1CNMCQ8B700",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2018-19_0-1m/01ED81W4KDQQRW9PEQ9KS7T8DV",
       "name": "bay-of-plenty_urban_2018-19_0-1m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos"
     },
@@ -976,7 +976,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2018-19_0-1m/01F66E7K4ESMSWZ1CNMCQ8B700",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2018-19_0-1m/01ED81W4KDQQRW9PEQ9KS7T8DV",
       "name": "bay-of-plenty_urban_2018-19_0-1m",
-      "minZoom": 14,
+      "minZoom": 32,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos"
     },
@@ -1072,7 +1072,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FVDF75ZM3KHXDYJES57AG",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FX6SQBKE27MWG6K3E86CM",
       "name": "bay-of-plenty_urban_2020_0-1m_RGB",
-      "minZoom": 14,
+      "minZoom": 13,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
     },

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -973,14 +973,6 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2018-19_0-1m/01F66E7K4ESMSWZ1CNMCQ8B700",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2018-19_0-1m/01ED81W4KDQQRW9PEQ9KS7T8DV",
-      "name": "bay-of-plenty_urban_2018-19_0-1m",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.1m Urban Aerial Photos (2018-2019)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2R7RYJHP0DVXJMZ3M0QDY",
       "3857": "s3://linz-basemaps/3857/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2SN9GVFBEW48N4V5E41ZQ",
       "name": "banks-peninsula_urban_2019-2020_0-075m_RGB",


### PR DESCRIPTION
Deprioritising a number of Bay of Plenty datasets as recent 20cm Rural + 10cm Tauranga imagery provide full coverage. Bay of Plenty councils confused by older 10cm urbans in Whakatāne, I think it makes sense to remove them too.