### PR TITLE
feat(aerial): add date to cyclone imagery title

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -101,14 +101,6 @@
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/north-island-cyclone-gabrielle_2023_10m/01GT86B8BWT1WQEAQK7CE4KEXA",
-      "3857": "s3://linz-basemaps/3857/north-island-cyclone-gabrielle_2023_10m/01GT86BYJ4VBD14QKA0HN76FE2",
-      "name": "north-island-cyclone-gabrielle_2023_10m",
-      "title": "North Island 10m Cyclone Gabrielle Satellite Imagery (20 February 2023)",
-      "minZoom": 32,
-      "category": "Event"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
       "name": "tasman_rural_2001-2002_1m_RGB",
@@ -1296,6 +1288,14 @@
       "name": "top-of-the-south_flood_2022_0.15m",
       "minZoom": 32,
       "title": "Top of the South 0.15m Flood Aerial Photos (2022)",
+      "category": "Event"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/north-island-cyclone-gabrielle_2023_10m/01GT86B8BWT1WQEAQK7CE4KEXA",
+      "3857": "s3://linz-basemaps/3857/north-island-cyclone-gabrielle_2023_10m/01GT86BYJ4VBD14QKA0HN76FE2",
+      "name": "north-island-cyclone-gabrielle_2023_10m",
+      "title": "North Island 10m Cyclone Gabrielle Satellite Imagery (20 February 2023)",
+      "minZoom": 32,
       "category": "Event"
     }
   ]

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -104,7 +104,7 @@
       "2193": "s3://linz-basemaps/2193/north-island-cyclone-gabrielle_2023_10m/01GT86B8BWT1WQEAQK7CE4KEXA",
       "3857": "s3://linz-basemaps/3857/north-island-cyclone-gabrielle_2023_10m/01GT86BYJ4VBD14QKA0HN76FE2",
       "name": "north-island-cyclone-gabrielle_2023_10m",
-      "title": "North Island 10m Cyclone Gabrielle Satellite Imagery (2023)",
+      "title": "North Island 10m Cyclone Gabrielle Satellite Imagery (20 February 2023)",
       "minZoom": 32,
       "category": "Event"
     },


### PR DESCRIPTION
This is a temporary measure for the Cyclone Gabrielle response until we expose the full date in some other way in the Basemaps UI.

Also grouped this imagery with other Event imagery.