### PR TITLE
feat(config): Refactoring config to separate all individual imagery and standardise imagery names

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -8,7 +8,7 @@
     {
       "2193": "s3://linz-basemaps/2193/gebco_2020_Nztm2000Quad_305-75m/01F1BFJN8R8P7BXN3XTHC5MT5G",
       "3857": "s3://linz-basemaps/3857/gebco_2020_305-75m/01EDMTM3P563P06TWYQAZRA9F6",
-      "name": "gebco_2020_305-75m",
+      "name": "gebco-2020-305.75m",
       "maxZoom": 15,
       "title": "GEBCO Gridded Bathymetry (2020)",
       "category": "Bathymetry"
@@ -16,7 +16,7 @@
     {
       "2193": "s3://linz-basemaps/2193/chatham-islands_digital-globe_2014-2019_0-5m/01F66EE7AETCNNKDJYCRSJ4CED",
       "3857": "s3://linz-basemaps/3857/chatham-islands_digital-globe_2014-2019_0-5m/01ED849PJ44FA7S612QAXN9P11",
-      "name": "chatham-islands_digital-globe_2014-2019_0-5m",
+      "name": "chatham-islands-digital-globe-2014-2019-0.5m",
       "maxZoom": 12,
       "title": "Chatham Islands 0.5m Satellite Imagery (2014-2019)",
       "category": "Satellite Imagery"
@@ -24,30 +24,22 @@
     {
       "2193": "s3://linz-basemaps/2193/chatham-islands_digital-globe_2014-2019_0-5m/01F66EEHWXVMK4B7E13AVZ8NE7",
       "3857": "s3://linz-basemaps/3857/chatham-islands_digital-globe_2014-2019_0-5m/01ED84CATGQ1THNG7QEEEZBEBT",
-      "name": "chatham-islands_digital-globe_2014-2019_0-5m",
+      "name": "chatham-islands-digital-globe-2014-2019-0.5m",
       "minZoom": 13,
       "title": "Chatham Islands 0.5m Satellite Imagery (2014-2019)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J",
-      "name": "nz_satellite_2020-2021_10m_RGB",
-      "minZoom": 32,
-      "title": "New Zealand 10m Satellite Imagery (2020-2021)",
-      "category": "Satellite Imagery"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G73E4AMSQ91TXQ3KC90NNPA0",
       "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G73E5DZKE9NSW6E41QQRT28T",
-      "name": "nz_satellite_2021-2022_10m_RGB",
+      "name": "nz-satellite-2021-2022-10m",
       "title": "New Zealand 10m Satellite Imagery (2021-2022)",
       "category": "Satellite Imagery"
     },
     {
       "2193": "s3://linz-basemaps/2193/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8BB9EBP892F3JQSSSHQG",
       "3857": "s3://linz-basemaps/3857/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8NX9DE6ZA3Y5VK1QAHNK",
-      "name": "auckland-islands_satellite_2014-2021_0-5m_RGB",
+      "name": "auckland-islands-satellite-2014-2021-0.5m",
       "minZoom": 2,
       "title": "Auckland Islands 0.5m Satellite Imagery (2014-2021)",
       "category": "Satellite Imagery"
@@ -55,7 +47,7 @@
     {
       "2193": "s3://linz-basemaps/2193/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5MYGMYCH5WPDCP1DMYHZ8",
       "3857": "s3://linz-basemaps/3857/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5N4E6Q4P2TV3MP94BKTMB",
-      "name": "antipodes-islands_satellite_2019-2020_0-5m_RGB",
+      "name": "antipodes-islands-satellite-2019-2020-0.5m",
       "minZoom": 5,
       "title": "Antipodes Islands 0.5m Satellite Imagery (2019-2020)",
       "category": "Satellite Imagery"
@@ -63,7 +55,7 @@
     {
       "2193": "s3://linz-basemaps/2193/bounty-islands_satellite_2020_0-5m_RGB/01FZYK75PS5DM0BKGZ885RZ94D",
       "3857": "s3://linz-basemaps/3857/bounty-islands_satellite_2020_0-5m_RGB/01FZYK7C7Y9GHSPRKM4B4C5RSY",
-      "name": "bounty-islands_satellite_2020_0-5m_RGB",
+      "name": "bounty-islands-satellite-2020-0.5m",
       "minZoom": 5,
       "title": "Bounty Islands 0.5m Satellite Imagery (2020)",
       "category": "Satellite Imagery"
@@ -71,7 +63,7 @@
     {
       "2193": "s3://linz-basemaps/2193/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E8Y3HSN66NDDKP89H2VTT",
       "3857": "s3://linz-basemaps/3857/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E9728953QMD6NY7BVDGSN",
-      "name": "campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB",
+      "name": "campbell-island-motu-ihupuku-satellite-2015-2020-0.5m",
       "minZoom": 2,
       "title": "Campbell Island/Motu Ihupuku 0.5m Satellite Imagery (2015-2020)",
       "category": "Satellite Imagery"
@@ -79,7 +71,7 @@
     {
       "2193": "s3://linz-basemaps/2193/kermadec-islands_satellite_2020-2021_0-5m_RGB/01G00S1WQ72T0PCN9T7QNE81V0",
       "3857": "s3://linz-basemaps/3857/kermadec-islands_satellite_2020-2021_0-5m_RGB/01G00S25RMGY8FEHWFRYNPFDFJ",
-      "name": "kermadec-islands_satellite_2020-2021_0-5m_RGB",
+      "name": "kermadec-islands-satellite-2020-2021-0.5m",
       "minZoom": 5,
       "title": "Kermadec Islands 0.5m Satellite Imagery (2020-2021)",
       "category": "Satellite Imagery"
@@ -87,7 +79,7 @@
     {
       "2193": "s3://linz-basemaps/2193/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XY0TVJJ4QVJ7988TCKGWS",
       "3857": "s3://linz-basemaps/3857/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XYQ8YKAZC7P5QJ4BPCX22",
-      "name": "nz-nearshore-islands_satellite_2010-2021_0-5m_RGB",
+      "name": "nz-nearshore-islands-satellite-2010-2021-0.5m",
       "minZoom": 13,
       "title": "New Zealand Nearshore Islands 0.5m Satellite Imagery (2010-2021)",
       "category": "Satellite Imagery"
@@ -95,23 +87,15 @@
     {
       "2193": "s3://linz-basemaps/2193/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01G011MVHNRWAMSQSPBKXVAEC3",
       "3857": "s3://linz-basemaps/3857/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01G011N3MVQVYP0Q1025R45219",
-      "name": "snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB",
+      "name": "snares-islands-tini-heke-satellite-2019-2020-0.5m",
       "minZoom": 5,
       "title": "Snares Islands/Tini Heke 0.5m Satellite Imagery (2019-2020)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
-      "name": "tasman_rural_2001-2002_1m_RGB",
-      "minZoom": 32,
-      "title": "Tasman 1m Rural Aerial Photos (2001-2002)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2004-2005_1m_RGB/01F6P1TQVSC7QRF1R3JAT893ZS",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2004-2005_1m_RGB/01EE962ZB3Z6Y7GVZ28XCWJ9JB",
-      "name": "tasman_rural_2004-2005_1m_RGB",
+      "name": "tasman-rural-2004-2005-1m",
       "minZoom": 13,
       "title": "Tasman 1m Rural Aerial Photos (2004-2005)",
       "category": "Rural Aerial Photos"
@@ -119,95 +103,39 @@
     {
       "2193": "s3://linz-basemaps/2193/southland_rural_2005-2011_0-75m_RGBA/01F6P1S7DSP4N5DCBGCTZCMJ27",
       "3857": "s3://linz-basemaps/3857/southland_rural_2005-2011_0-75m_RGBA/01ED835ZSP0MQ3W55QEMVZKNR1",
-      "name": "southland_rural_2005-2011_0-75m_RGBA",
+      "name": "southland-rural-2005-2011-0.75m",
       "minZoom": 13,
       "title": "Southland 0.75m Rural Aerial Photos (2005-2011)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2009-2010_0-50m_RGBA/01F6P1TWRFSGJ65V9Z0YXX4DHY",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2009-2010_0-50m_RGBA/01ED83CJ5ZT8SAGQKFT9MM59XR",
-      "name": "tasman_rural_2009-2010_0-50m_RGBA",
-      "minZoom": 32,
-      "title": "Tasman 0.5m Rural Aerial Photos (2009-2010)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2010-2012_0-50m_RGBA/01F66DT3ZBYZZM6R0AF9Q2989R",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2010-2012_0-50m_RGBA/01ED81BNAX2ESPMV59YPC3AQ2C",
-      "name": "auckland_rural_2010-2012_0-50m_RGBA",
+      "name": "auckland-rural-2010-2012-0.5m",
       "minZoom": 13,
       "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2011-2012_0-25m_RGBA/01F66E1BB777Z4GN4PAW44FGFA",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2011-2012_0-25m_RGBA/01EDMTQXYCBANNYTKD4VK6C2GK",
-      "name": "bay-of-plenty_rural_2011-2012_0-25m_RGBA",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.25m Rural Aerial Photos (2011-2012)",
-      "category": "Rural Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/marlborough_rural_2011-2012_0-40m_RGBA/01F6P1CMT137757Y7M473TP4MG",
-      "3857": "s3://linz-basemaps/3857/marlborough_rural_2011-2012_0-40m_RGBA/01ED82KF10YWWCA59936P87R9B",
-      "name": "marlborough_rural_2011-2012_0-40m_RGBA",
-      "minZoom": 32,
-      "title": "Marlborough 0.4m Rural Aerial Photos (2011-2012)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2012-2013_0-40m_RGBA/01F66E9294YKPYAJP7SXTVY2EM",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2012-2013_0-40m_RGBA/01ED81XK539QM497AYHM1X70JQ",
-      "name": "canterbury_rural_2012-2013_0-40m_RGBA",
+      "name": "canterbury-rural-2012-2013-0.4m",
       "minZoom": 13,
       "title": "Canterbury 0.4m Rural Aerial Photos (2012-2013)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_rural_2012-2013_0-40m_RGBA/01F6P153BFK34RSZZWPX9PRKS8",
-      "3857": "s3://linz-basemaps/3857/gisborne_rural_2012-2013_0-40m_RGBA/01EDMTSQF19FQB09MS46ZFWWRM",
-      "name": "gisborne_rural_2012-2013_0-40m_RGBA",
-      "minZoom": 32,
-      "title": "Gisborne 0.4m Rural Aerial Photos (2012-2013)",
-      "category": "Rural Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/waikato_rural_2012-2013_0-50m_RGBA/01F6P1XPDV00F86GA8J626Y3BM",
-      "3857": "s3://linz-basemaps/3857/waikato_rural_2012-2013_0-50m_RGBA/01ED83K3YEJ0FSG0DHCFTVBEF7",
-      "name": "waikato_rural_2012-2013_0-50m_RGBA",
-      "minZoom": 32,
-      "title": "Waikato 0.5m Rural Aerial Photos (2012-2013)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2013-2014_0-40m_RGBA/01F66E9VVX07WFC1C5Y05S4JXM",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2013-2014_0-40m_RGBA/01ED81YFYF0D76RZRH9FHF7JDN",
-      "name": "canterbury_rural_2013-2014_0-40m_RGBA",
+      "name": "canterbury-rural-2013-2014-0.4m",
       "minZoom": 13,
       "title": "Canterbury 0.4m Rural Aerial Photos (2013-2014)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/dunedin_rural_2013_0-40m_RGBA/01F6P12CMF8AKCDGVCGRB06B0G",
-      "3857": "s3://linz-basemaps/3857/dunedin_rural_2013_0-40m_RGBA/01ED8265AEHZM2DHB43GBFE5BG",
-      "name": "dunedin_rural_2013_0-40m_RGBA",
-      "minZoom": 32,
-      "title": "Dunedin 0.4m Rural Aerial Photos (2013)",
-      "category": "Rural Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/otago_rural_2013-2014_0-40m_RGBA/01F6P1MWWWTB2CE6FSCWPX6AKR",
-      "3857": "s3://linz-basemaps/3857/otago_rural_2013-2014_0-40m_RGBA/01ED8312YJGXG5195GMTGY9MNK",
-      "name": "otago_rural_2013-2014_0-40m_RGBA",
-      "minZoom": 32,
-      "title": "Otago 0.4m Rural Aerial Photos (2013-2014)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/southland-central-otago_rural_2013-2014_0-40m_RGBA/01F6P1R136F2BHRHRJ961SC7CH",
       "3857": "s3://linz-basemaps/3857/southland-central-otago_rural_2013-2014_0-40m_RGBA/01ED83886J46GSSZP6GKCCYGH1",
-      "name": "southland-central-otago_rural_2013-2014_0-40m_RGBA",
+      "name": "southland-central-otago-rural-2013-2014-0.4m",
       "minZoom": 13,
       "title": "Southland & Central Otago 0.4m Rural Aerial Photos (2013-2014)",
       "category": "Rural Aerial Photos"
@@ -215,103 +143,47 @@
     {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2014-2015_0-30m_RGBA/01F66EATPYCJF8R9WZRRE481ZP",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2014-2015_0-30m_RGBA/01ED81ZMNH3PM5Q3E2MWRFD22B",
-      "name": "canterbury_rural_2014-2015_0-30m_RGBA",
+      "name": "canterbury-rural-2014-2015-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2014-2015)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2014-2015_0-30m_RGBA/01F6P182DFPVC4HCAKPP42PCWN",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2014-2015_0-30m_RGBA/01ED82B3R581HMXNDS7HP3ATQ2",
-      "name": "hawkes-bay_rural_2014-2015_0-30m_RGBA",
-      "minZoom": 32,
-      "title": "Hawke's Bay 0.3m Rural Aerial Photos (2014-2015)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/northland_rural_2014-16_0-4m/01F6P1JB8GFYFC08W3AK9KFGJW",
       "3857": "s3://linz-basemaps/3857/northland_rural_2014-16_0-4m/01ED82WK4A955T96RV5NWEN3R6",
-      "name": "northland_rural_2014-16_0-4m",
+      "name": "northland-rural-2014-2016-0.4m",
       "minZoom": 13,
       "title": "Northland 0.4m Rural Aerial Photos (2014-2016)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2014-15_0-125m/01F66E4JBVW1AW4VKGRN95SDGZ",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2014-15_0-125m/01ED81RPD7YEYNTPM2WZZK3X1A",
-      "name": "bay-of-plenty_urban_2014-15_0-125m",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.125m Urban Aerial Photos (2014-2015)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2015-17_0-25m/01F66E2MGVQY9F4WXRYDRWRGPE",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2015-17_0-25m/01ED81P0KGVWJP2XHDKJJRYNQM",
-      "name": "bay-of-plenty_rural_2015-17_0-25m",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.25m Rural Aerial Photos (2015-2017)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2015-2016_0-30m_RGBA/01F66EBN9BYJA29NMW96ZJM7ZJ",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2015-2016_0-30m_RGBA/01ED82104D376HEF1ZMW8PRX5N",
-      "name": "canterbury_rural_2015-2016_0-30m_RGBA",
+      "name": "canterbury-rural-2015-2016-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2015-16_0-3m/01F6P1B7SH0X2FETDDT3RWT9Q9",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2015-16_0-3m/01ED82HKA5T8V6S1KZ4WN9EFNN",
-      "name": "manawatu-whanganui_rural_2015-16_0-3m",
-      "minZoom": 32,
-      "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2015-2016)",
-      "category": "Rural Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/marlborough_rural_2015-2016_0-20m_RGBA/01F6P1D8DJGBN4QNAB2Y64DVV3",
-      "3857": "s3://linz-basemaps/3857/marlborough_rural_2015-2016_0-20m_RGBA/01ED82MG0Q6A8VFAJSY7Q543N5",
-      "name": "marlborough_rural_2015-2016_0-20m_RGBA",
-      "minZoom": 32,
-      "title": "Marlborough 0.2m Rural Aerial Photos (2015-2016)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/southland-central-otago_rural_2015-2017_0-40m_RGB/01F6P1RQRT6N94DDKGRCSYKM6R",
       "3857": "s3://linz-basemaps/3857/southland-central-otago_rural_2015-2017_0-40m_RGB/01ED83A271YNKAW0KRH17RPMMV",
-      "name": "southland-central-otago_rural_2015-2017_0-40m_RGB",
+      "name": "southland-central-otago-rural-2015-2017-0.4m",
       "minZoom": 13,
       "title": "Southland & Central Otago 0.4m Rural Aerial Photos (2015-2017)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2015-16_0-3m/01F6P1V269CD5Z3Z5EC0Q8P7V6",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2015-16_0-3m/01ED83CXGMGPXTF67SETE7YBWP",
-      "name": "tasman_rural_2015-16_0-3m",
-      "minZoom": 32,
-      "title": "Tasman 0.3m Rural Aerial Photos (2015-2016)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/west-coast_rural_2015-16_0-3m/01F6P21PNQC7D67W5SHQF806Z3",
       "3857": "s3://linz-basemaps/3857/west-coast_rural_2015-16_0-3m/01ED83TT0ZHKXTPFXEGFJHP2M5",
-      "name": "west-coast_rural_2015-16_0-3m",
+      "name": "west-coast-rural-2015-2016-0.3m",
       "minZoom": 13,
       "title": "West Coast 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2016-17_0-3m/01F66E3G0Z8DNKWXG5M55QNW9G",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW",
-      "name": "bay-of-plenty_rural_2016-17_0-3m",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.3m Rural Aerial Photos (2016-2017)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2016-18_0-3m/01F66ECJGT5PGYPVK9MW7TYHPZ",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2016-18_0-3m/01ED8225A94WY3GQ4CNZ9E1PZN",
-      "name": "canterbury_rural_2016-18_0-3m",
+      "name": "canterbury-rural-2016-2018-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2017-2018)",
       "category": "Rural Aerial Photos"
@@ -319,39 +191,15 @@
     {
       "2193": "s3://linz-basemaps/2193/kaikoura-post-earthquake_rural_2016-17_0-3m/01F6P1AGSRJG1VKND6PD8BXH2Q",
       "3857": "s3://linz-basemaps/3857/kaikoura-post-earthquake_rural_2016-17_0-3m/01ED82F0376F6FJFMTV4JAVJ53",
-      "name": "kaikoura-post-earthquake_rural_2016-17_0-3m",
+      "name": "kaikoura-post-earthquake-rural-2016-2017-0.3m",
       "minZoom": 13,
       "title": "Kaikōura Earthquake 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Event"
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2016-17_0-3m/01F6P1BSQ6V27WZK0KM56M4Z1C",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2016-17_0-3m/01ED82JQASJDFZ6XEM018RJQN0",
-      "name": "manawatu-whanganui_rural_2016-17_0-3m",
-      "minZoom": 32,
-      "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2016-2017)",
-      "category": "Rural Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/taranaki_rural_2016-17_0-3m/01F6P1SZXEN3X5SDKT7XRQHEGY",
-      "3857": "s3://linz-basemaps/3857/taranaki_rural_2016-17_0-3m/01ED83B7TAK5SBKVYFJZMTE9AV",
-      "name": "taranaki_rural_2016-17_0-3m",
-      "minZoom": 32,
-      "title": "Taranaki 0.3m Rural Aerial Photos (2016-2018)",
-      "category": "Rural Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2016-17_0-3m/01F6P1V84P2HJ1YB0D5X1CSWJH",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2016-17_0-3m/01ED83DC7MCMBCRNN45E07HCHH",
-      "name": "tasman_rural_2016-17_0-3m",
-      "minZoom": 32,
-      "title": "Tasman 0.3m Rural Aerial Photos (2016-2017)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/wellington_rural_2021_0-3m_RGB/01FB82NZY0ASDQBKT28DSXS8XC",
       "3857": "s3://linz-basemaps/3857/wellington_rural_2021_0-3m_RGB/01FB82QKPWEHV0FWN7KBXM6NDM",
-      "name": "wellington_rural_2021_0-3m_RGB",
+      "name": "wellington-rural-2021-0.3m",
       "minZoom": 13,
       "title": "Wellington 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
@@ -359,7 +207,7 @@
     {
       "2193": "s3://linz-basemaps/2193/west-coast_rural_2016-17_0-3m/01F6P220GYWC836YQ4RRZGSV73",
       "3857": "s3://linz-basemaps/3857/west-coast_rural_2016-17_0-3m/01ED83VT2T06B1FVXF9P6CCV8C",
-      "name": "west-coast_rural_2016-17_0-3m",
+      "name": "west-coast-rural-2016-2017-0.3m",
       "minZoom": 13,
       "title": "West Coast 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos"
@@ -367,7 +215,7 @@
     {
       "2193": "s3://linz-basemaps/2193/gisborne_rural_2017-2019_0-3m_RGB/01F6P15VGNRA3N06S2NEY9PFAX",
       "3857": "s3://linz-basemaps/3857/gisborne_rural_2017-2019_0-3m_RGB/01EZWZGMW2Q53VNC65X2X4VFRZ",
-      "name": "gisborne_rural_2017-2019_0-3m_RGB",
+      "name": "gisborne-rural-2017-2019-0.3m",
       "minZoom": 13,
       "title": "Gisborne 0.3m Rural Aerial Photos (2017-2019)",
       "category": "Rural Aerial Photos"
@@ -375,7 +223,7 @@
     {
       "2193": "s3://linz-basemaps/2193/marlborough_rural_2017-18_0-3m/01F6P1E05SRRSMA94E11F1EAFJ",
       "3857": "s3://linz-basemaps/3857/marlborough_rural_2017-18_0-3m/01EDAMZ587FYSZ9NY8TP40VASS",
-      "name": "marlborough_rural_2017-18_0-3m",
+      "name": "marlborough-rural-2017-2018-0.3m",
       "minZoom": 13,
       "title": "Marlborough 0.3m Rural Aerial Photos (2017-2018)",
       "category": "Rural Aerial Photos"
@@ -383,7 +231,7 @@
     {
       "2193": "s3://linz-basemaps/2193/otago_rural_2017-2019_0-30m_RGB/01F6P1N3TA18Y2GYJ5B4YGGZYC",
       "3857": "s3://linz-basemaps/3857/otago_rural_2017-2019_0-30m_RGB/01ED831MKK85M1QNCNZV0AYPYC",
-      "name": "otago_rural_2017-2019_0-30m_RGB",
+      "name": "otago-rural-2017-2019-0.3m",
       "minZoom": 13,
       "title": "Otago 0.3m Rural Aerial Photos (2017-2019)",
       "category": "Rural Aerial Photos"
@@ -391,23 +239,15 @@
     {
       "2193": "s3://linz-basemaps/2193/waikato_rural_2017-19_0-3m/01F6P1YQNFECBE6S3TESNSPA2X",
       "3857": "s3://linz-basemaps/3857/waikato_rural_2017-19_0-3m/01EDAN2JJVFCS9WZWMB9105XFH",
-      "name": "waikato_rural_2017-19_0-3m",
+      "name": "waikato-rural-2017-2019-0.3m",
       "minZoom": 13,
       "title": "Waikato 0.3m Rural Aerial Photos (2016-2019)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2019-2020_0-3m_RGB/01FC200TCKR7ZTJEN6Q8ZJAET1",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2019-2020_0-3m_RGB/01FC1ZY5V4XCEXDSWT3FE3A8VM",
-      "name": "hawkes-bay_rural_2019-2020_0-3m_RGB",
-      "minZoom": 32,
-      "title": "Hawke's Bay 0.3m Rural Aerial Photos (2019-2020)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/nelson_rural_2018-19_0-3m/01F6P1FJNXVVTS7HC3VS3FHEYX",
       "3857": "s3://linz-basemaps/3857/nelson_rural_2018-19_0-3m/01ED82T5HM0H275QJPMDQN0JFJ",
-      "name": "nelson_rural_2018-19_0-3m",
+      "name": "nelson-rural-2018-2019-0.3m",
       "minZoom": 13,
       "title": "Nelson 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
@@ -415,23 +255,15 @@
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2018-19_0-3m/01F6P1VDEYFR0XB5XJMN9X6V1C",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2018-19_0-3m/01ED83DSMR8N1FQFVXM8JASBV2",
-      "name": "tasman_rural_2018-19_0-3m",
+      "name": "tasman-rural-2018-2019-0.3m",
       "minZoom": 13,
       "title": "Tasman 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2019_0-3m/01F66E4BR5XTJENFTSACWB55DM",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2019_0-3m/01ED81R5BX4EB3W7TB3Z8ZE89S",
-      "name": "bay-of-plenty_rural_2019_0-3m",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.3m Rural Aerial Photos (2019)",
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2021_0-2m/01H3E4XFK8N1JYJCM8BHDQAJPQ",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2021_0-2m/01H3E4ZG0MJ0SABSSBW2MJXVNS",
-      "name": "bay-of-plenty_rural_2021_0-2m",
+      "name": "bay-of-plenty-rural-2021-0.2m",
       "minZoom": 13,
       "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
@@ -439,7 +271,7 @@
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2020_0-3m_RGB/01FBGB1QN859XRGNNWT6ZBHEN8",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2020_0-3m_RGB/01FBGB0T73562VAZBEBHZ7E84T",
-      "name": "tasman_rural_2020_0-3m_RGB",
+      "name": "tasman-rural-2020-0.3m",
       "minZoom": 13,
       "title": "Tasman 0.3m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos"
@@ -447,7 +279,7 @@
     {
       "2193": "s3://linz-basemaps/2193/tasman_2022-2023_0.25m/01H4Q84VRY1WFXERB721NJZPED",
       "3857": "s3://linz-basemaps/3857/tasman_2022-2023_0.25m/01H4Q85QE0ZF7E13DSGGZRR04V",
-      "name": "tasman_2022-2023_0.25m",
+      "name": "tasman-2022-2023-0.25m",
       "minZoom": 13,
       "title": "Tasman 0.25m Rural Aerial Photos (2022-2023)",
       "category": "Rural Aerial Photos"
@@ -455,7 +287,7 @@
     {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2019_0-3m_RGB/01FJJFP25MYHH34JEV0XM9Z8Q8",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2019_0-3m_RGB/01FJJFN1H62SA0836CKX2BYE5F",
-      "name": "canterbury_rural_2019_0-3m_RGB",
+      "name": "canterbury-rural-2019-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
@@ -463,7 +295,7 @@
     {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2020_0-3m_RGB/01FHRTDFP4DDQD4X1G63SDF0AX",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2020_0-3m_RGB/01FHRTF5GHTZD5SEXP3MS7E911",
-      "name": "canterbury_rural_2020_0-3m_RGB",
+      "name": "canterbury-rural-2020-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos"
@@ -471,7 +303,7 @@
     {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2020-2021_0-2m_RGB/01FHV1ZNDNT9256J13H89BRKWT",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2020-2021_0-2m_RGB/01FHV1VPTBM52WH81ZT7XAX93W",
-      "name": "canterbury_rural_2020-2021_0-2m_RGB",
+      "name": "canterbury-rural-2020-2021-0.2m",
       "minZoom": 13,
       "title": "Canterbury 0.2m Rural Aerial Photos (2020-2021)",
       "category": "Rural Aerial Photos"
@@ -479,7 +311,7 @@
     {
       "2193": "s3://linz-basemaps/2193/otago_rural_2019-2021_0-3m_RGB/01FKP9RXGA4EXSFWBGKHKVTPMT",
       "3857": "s3://linz-basemaps/3857/otago_rural_2019-2021_0-3m_RGB/01FKP9PAF9VNHC4FYGQRGHF593",
-      "name": "otago_rural_2019-2021_0-3m_RGB",
+      "name": "otago-rural-2019-2021-0.3m",
       "minZoom": 13,
       "title": "Otago 0.3m Rural Aerial Photos (2019-2021)",
       "category": "Rural Aerial Photos"
@@ -487,7 +319,7 @@
     {
       "2193": "s3://linz-basemaps/2193/canterbury-waitaki_rural_2021_0-3m_RGB/01FQ07ZVQYC3M57D8N84WFM4F5",
       "3857": "s3://linz-basemaps/3857/canterbury-waitaki_rural_2021_0-3m_RGB/01FQ07XS8GHPFS913PGY5P9010",
-      "name": "canterbury-waitaki_rural_2021_0-3m_RGB",
+      "name": "canterbury-waitaki-rural-2021-0.3m",
       "minZoom": 13,
       "title": "Canterbury - Waitaki 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
@@ -495,7 +327,7 @@
     {
       "2193": "s3://linz-basemaps/2193/canterbury-mackenzie_rural_2021_0-3m_RGB/01FQ081YGQNSSB120WPZ3N70W0",
       "3857": "s3://linz-basemaps/3857/canterbury-mackenzie_rural_2021_0-3m_RGB/01FQ080VWM2VAMT9G2BYPWZTKB",
-      "name": "canterbury-mackenzie_rural_2021_0-3m_RGB",
+      "name": "canterbury-mackenzie-rural-2021-0.3m",
       "minZoom": 13,
       "title": "Canterbury - Mackenzie 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
@@ -503,7 +335,7 @@
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2022_0-3m_RGB/01G75YD43EBA980HFWVF6ZFV6B",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2022_0-3m_RGB/01G75YDG4KFEZ5BAGTPHMEAPP7",
-      "name": "tasman_rural_2022_0-3m_RGB",
+      "name": "tasman-rural-2022-0.3m",
       "minZoom": 13,
       "title": "Tasman 0.3m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
@@ -511,7 +343,7 @@
     {
       "2193": "s3://linz-basemaps/2193/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ84DPHCND4PG6BD0W999A",
       "3857": "s3://linz-basemaps/3857/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ9988GKX5JF0F0EW2R9Q3",
-      "name": "marlborough_rural_2021-2022_0-25m_RGB",
+      "name": "marlborough-rural-2021-2022-0.25m",
       "minZoom": 13,
       "title": "Marlborough 0.25m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
@@ -519,7 +351,7 @@
     {
       "2193": "s3://linz-basemaps/2193/marlborough_2023_0.25m/01H6WRJWDK9VNKK6HE2PZ63AKG",
       "3857": "s3://linz-basemaps/3857/marlborough_2023_0.25m/01H6WRKSPQD92366HB8WT35BQK",
-      "name": "marlborough_2023_0.25m",
+      "name": "marlborough-2023-0.25m",
       "minZoom": 13,
       "title": "Marlborough 0.25m Rural Aerial Photos (2023) - Draft",
       "category": "Rural Aerial Photos"
@@ -527,7 +359,7 @@
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH2Y0Q4PENH4T22PGJB521",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH42RKHGCSHRB3EMZVZD91",
-      "name": "hawkes-bay_rural_2021-2022_0-3m_RGB",
+      "name": "hawkes-bay-rural-2021-2022-0.3m",
       "minZoom": 13,
       "title": "Hawke's Bay 0.3m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
@@ -535,7 +367,7 @@
     {
       "2193": "s3://linz-basemaps/2193/taranaki_rural_2021-2022_0.25m_RGB/01GDKFTY5BPAHMSKKVC336J9Y2",
       "3857": "s3://linz-basemaps/3857/taranaki_rural_2021-2022_0.25m_RGB/01GDKFVY7VZ7CVYGYG02FXSEMJ",
-      "name": "taranaki_rural_2021-2022_0.25m_RGB",
+      "name": "taranaki-rural-2021-2022-0.25m",
       "minZoom": 13,
       "title": "Taranaki 0.25m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
@@ -543,7 +375,7 @@
     {
       "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2021-2022_0.3m/01GVCD2Y9RTQ57TWG4MPTHJ84R",
       "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2021-2022_0.3m/01GVCDBNDH2Z9JEHDHJSD1EJ79",
-      "name": "manawatu-whanganui_rural_2021-2022_0.3m",
+      "name": "manawatu-whanganui-rural-2021-2022-0.3m",
       "minZoom": 13,
       "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
@@ -551,7 +383,7 @@
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_2021-2022_0.2m/01GHW1Y474AHB191P8SRKENK7Y",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_2021-2022_0.2m/01GHW1ZWNS4N0GP9TAM09WHPBC",
-      "name": "bay-of-plenty_2021-2022_0.2m",
+      "name": "bay-of-plenty-2021-2022-0.2m",
       "minZoom": 13,
       "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
@@ -559,31 +391,15 @@
     {
       "2193": "s3://linz-basemaps/2193/canterbury_2022_0.3m/01GPEXMRQCA525WF8B0XBV5575",
       "3857": "s3://linz-basemaps/3857/canterbury_2022_0.3m/01GPEXPBHG2XJZK0JPGKNAVD6A",
-      "name": "canterbury_2022_0.3m",
+      "name": "canterbury-2022-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_2016-2017_0.3m/01GYDZV2M9EBXKZAFW97K4HHMW",
-      "3857": "s3://linz-basemaps/3857/wellington_2016-2017_0.3m/01GYDZW8JYHN2NX0JMTKDEZBY5",
-      "name": "wellington_2016-2017_0.3m",
-      "minZoom": 32,
-      "title": "Wellington 0.3m Rural Aerial Photos (2016-2017)",
-      "category": "Rural Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/waikato_2021-2023_0.3m/01GR01J88ME71DQHG17PX0KHBJ",
-      "3857": "s3://linz-basemaps/3857/waikato_2021-2023_0.3m/01GR01MDBQ033559AM244BZQTY",
-      "name": "waikato_2021-2023_0.3m",
-      "title": "Waikato 0.3m Rural Aerial Photos (2021-2023) - Draft",
-      "minZoom": 32,
-      "category": "Rural Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/gisborne_rural_2021-2023_0.2m/01H2S2ADDFREPQC2797VEN5RAE",
       "3857": "s3://linz-basemaps/3857/gisborne_rural_2021-2023_0.2m/01H2S2CJTQKXXY2NHZ88D4TP2X",
-      "name": "gisborne_rural_2021-2023_0.2m",
+      "name": "gisborne-rural-2021-2023-0.2m",
       "minZoom": 13,
       "title": "Gisborne 0.2m Rural Aerial Photos (2021-2023)",
       "category": "Rural Aerial Photos"
@@ -591,23 +407,15 @@
     {
       "2193": "s3://linz-basemaps/2193/gisborne-cyclone-gabrielle_2023_0.2m/01H3K4335ESRYK95NJCRBRHPBA",
       "3857": "s3://linz-basemaps/3857/gisborne-cyclone-gabrielle_2023_0.2m/01H3K452YF9S5KB9RZPP8JBBAZ",
-      "name": "gisborne-cyclone-gabrielle_2023_0.2m",
+      "name": "gisborne-cyclone-gabrielle-2023-0.2m",
       "title": "Cyclone Gabrielle Gisborne 0.2m Aerial Photos (20 February 2023 - 25 April 2023)",
       "minZoom": 13,
       "category": "Event"
     },
     {
-      "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",
-      "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ",
-      "name": "selwyn_urban_2012-2013_0-125m_RGBA",
-      "minZoom": 32,
-      "title": "Selwyn 0.125m Urban Aerial Photos (2012-2013)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/timaru_urban_2012-2013_0-075m_RGBA/01F6P1XAGNDZVM0DH9JCFSE7QB",
       "3857": "s3://linz-basemaps/3857/timaru_urban_2012-2013_0-075m_RGBA/01ED83HWB82K047N1KYK9A5SKD",
-      "name": "timaru_urban_2012-2013_0-075m_RGBA",
+      "name": "timaru-urban-2012-2013-0.075m",
       "minZoom": 14,
       "title": "Timaru 0.075m Urban Aerial Photos (2012-2013)",
       "category": "Urban Aerial Photos"
@@ -615,279 +423,63 @@
     {
       "2193": "s3://linz-basemaps/2193/hurunui_urban_2013_0-125m_RGBA/01F6P1965MX7W515NM9VR90V67",
       "3857": "s3://linz-basemaps/3857/hurunui_urban_2013_0-125m_RGBA/01ED82CK977V2ZJ095QZDGSME6",
-      "name": "hurunui_urban_2013_0-125m_RGBA",
+      "name": "hurunui-urban-2013-0.125m",
       "minZoom": 14,
       "title": "Hurunui 0.125m Urban Aerial Photos (2013)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2013-2014_0-075m_RGBA/01F6P20317FNJJSB1KJFH7Y35Y",
-      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2013-2014_0-075m_RGBA/01ED83PPQFH8Z8HNY1WV7W4SS5",
-      "name": "waimakariri_urban_2013-2014_0-075m_RGBA",
-      "minZoom": 32,
-      "title": "Waimakariri 0.075m Urban Aerial Photos (2013-2014)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/hastings-district_urban_2014-2015_0-10m_RGB/01F6P172EQ3JF930CN3XNVVVJ9",
-      "3857": "s3://linz-basemaps/3857/hastings-district_urban_2014-2015_0-10m_RGB/01EDN0YH2TM1B5NWHR4RHGBMPF",
-      "name": "hastings-district_urban_2014-2015_0-10m_RGB",
-      "minZoom": 32,
-      "title": "Hastings District 0.1m Urban Aerial Photos (2014-2015)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/northland_urban_2014-2015_0-10m_RGBA/01F6P1K57WYSAZVCTP35DVKG4B",
       "3857": "s3://linz-basemaps/3857/northland_urban_2014-2015_0-10m_RGBA/01ED82YEHRRNR3YQC55TJY37E6",
-      "name": "northland_urban_2014-2015_0-10m_RGBA",
+      "name": "northland-urban-2014-2015-0.1m",
       "minZoom": 14,
       "title": "Northland 0.1m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/palmerston-north-city_urban_2014-15_0-125m/01F6P1P22165F058BN82D3ZY8Q",
-      "3857": "s3://linz-basemaps/3857/palmerston-north-city_urban_2014-15_0-125m/01ED8346J2H15Z24G6P9SZ7S0P",
-      "name": "palmerston-north-city_urban_2014-15_0-125m",
-      "minZoom": 32,
-      "title": "Palmerston North 0.125m Urban Aerial Photos (2015)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/waikato_urban_2014_0-10m_RGBA/01F6P1ZQZ4X5GHHX544CJJ3NNH",
-      "3857": "s3://linz-basemaps/3857/waikato_urban_2014_0-10m_RGBA/01ED83NZS98MYTMWM4D1EVZ07T",
-      "name": "waikato_urban_2014_0-10m_RGBA",
-      "minZoom": 32,
-      "title": "Waikato District 0.1m Urban Aerial Photos (2014)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/waikato_2021-2022_0.05m/01H29E3DXNNYKJZFHBEX1NZRVF",
-      "3857": "s3://linz-basemaps/3857/waikato_2021-2022_0.05m/01H29E3QQR0YKW4CB96JZ9BHZA",
-      "name": "waikato_2021-2022_0.05m",
-      "minZoom": 32,
-      "title": "Waikato District 0.05m Urban Aerial Photos (2021-2022)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/wairoa_urban_2014-2015_0-10m_RGBA/01F6P20PT6TN7XVJGPSA7NPQ93",
-      "3857": "s3://linz-basemaps/3857/wairoa_urban_2014-2015_0-10m_RGBA/01ED83R64ZX665P14R805CJVE2",
-      "name": "wairoa_urban_2014-2015_0-10m_RGBA",
-      "minZoom": 32,
-      "title": "Wairoa 0.1m Urban Aerial Photos (2014-2015)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2015-16_0-125m/01F66E63QY3BR3W3ARXRBPK1NP",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2015-16_0-125m/01ED81TJP9G5Q6VJKG921RT0QS",
-      "name": "bay-of-plenty_urban_2015-16_0-125m",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.125m Urban Aerial Photos (2015-2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2015-16_0-1m/01F66E757Y78C33NKN50W9PW5C",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2015-16_0-1m/01ED81VN7AJ586W5HK2BSPHAPH",
-      "name": "bay-of-plenty_urban_2015-16_0-1m",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.1m Urban Aerial Photos (2015-2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2015-2016_0-075m_RGBA/01F6P0KPJJK4MJ3JZVS0DJK0Q7",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2015-2016_0-075m_RGBA/01EWEQ26HDCMDQKTZ1RHSXPBEW",
-      "name": "christchurch_urban_2015-2016_0-075m_RGBA",
-      "minZoom": 32,
-      "title": "Christchurch 0.075m Urban Aerial Photos (2015-2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/thames-coromandel_urban_2015_0-05m/01F6P1WD2YV0SQ3WE62RZ0RJY5",
       "3857": "s3://linz-basemaps/3857/thames-coromandel_urban_2015_0-05m/01ED83GB3JEMR4D72PFD8JVCV6",
-      "name": "thames-coromandel_urban_2015_0-05m",
+      "name": "thames-coromandel-urban-2015-0.05m",
       "minZoom": 14,
       "title": "Thames Coromandel 0.05m Urban Aerial Photos (2015)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2015-2016_0-075m_RGBA/01F6P20ANWJDXNWCTHBTK3MJNF",
-      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2015-2016_0-075m_RGBA/01ED83QD75BDF3D46932B3ZKZD",
-      "name": "waimakariri_urban_2015-2016_0-075m_RGBA",
-      "minZoom": 32,
-      "title": "Waimakariri 0.075m Urban Aerial Photos (2015-2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/whanganui_urban_2015-16_0-1m/01F63WK62MCAAH3Q1RQ21EGHJ1",
-      "3857": "s3://linz-basemaps/3857/whanganui_urban_2015-16_0-1m/01ED83WV5VV20JWAP0MT3D7W4W",
-      "name": "whanganui_urban_2015-16_0-1m",
-      "minZoom": 32,
-      "title": "Whanganui 0.1m Urban Aerial Photos (2015-2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/hamilton_urban_2016-17_0-1m/01F6P16P7FMHSDAWX2VM3PKAHS",
-      "3857": "s3://linz-basemaps/3857/hamilton_urban_2016-17_0-1m/01EDAN1CYCXAEMG21PB6VCD0KX",
-      "name": "hamilton_urban_2016-17_0-1m",
-      "minZoom": 32,
-      "title": "Hamilton 0.1m Urban Aerial Photos (2016-2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-1m/01F6P1A7YH7JXE247G85F25WG6",
-      "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-1m/01ED82E60KN099T9A8V11KCSK0",
-      "name": "invercargill_urban_2016_0-1m",
-      "minZoom": 32,
-      "title": "Invercargill 0.1m Urban Aerial Photos (2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-05m/01F6P1A2VKHHFQW764DRW93G4Y",
-      "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-05m/01ED82DPKVVWA818DY9QQ9GS0J",
-      "name": "invercargill_urban_2016_0-05m",
-      "minZoom": 32,
-      "title": "Invercargill 0.05m Urban Aerial Photos (2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2016-17_1-125m/01F6P1P8H7KNRQQR0ADDKQRJ6S",
-      "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2016-17_1-125m/01ED833N7FD05YRW6ZR5799SAZ",
-      "name": "palmerston-north_urban_2016-17_1-125m",
-      "minZoom": 32,
-      "title": "Palmerston North 0.125m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/porirua_urban_2016_0-075m/01F6P1PP0S3T9HTDTDJW7ADAEH",
-      "3857": "s3://linz-basemaps/3857/porirua_urban_2016_0-075m/01ED834RYVP97AYQVDDQ6MJECY",
-      "name": "porirua_urban_2016_0-075m",
-      "minZoom": 32,
-      "title": "Porirua 0.075m Urban Aerial Photos (2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/auckland_urban_2017_0-075m/01F66DXCRR1CFTFQTE5R3525EJ",
       "3857": "s3://linz-basemaps/3857/auckland_urban_2017_0-075m/01ED81HZRR86YBB8A0ZQRABP96",
-      "name": "auckland_urban_2017_0-075m",
+      "name": "auckland-urban-2017-0.075m",
       "minZoom": 14,
       "title": "Auckland 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_2015-2016_0.075m/01GYDZV2MH0QVT8XXDMNMYK0DP",
-      "3857": "s3://linz-basemaps/3857/auckland_2015-2016_0.075m/01GYDZYBK72ED9ACTRSZNKS7GP",
-      "name": "auckland_2015-2016_0.075m",
-      "minZoom": 32,
-      "title": "Auckland 0.075m Urban Aerial Photos (2015-2016)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/central-hawkes-bay_urban_2017-18_0-1m/01F66EDQC993D73W17EG40HJ2N",
-      "3857": "s3://linz-basemaps/3857/central-hawkes-bay_urban_2017-18_0-1m/01ED823PTAVX9DQ7GE9WBACX8C",
-      "name": "central-hawkes-bay_urban_2017-18_0-1m",
-      "minZoom": 32,
-      "title": "Central Hawke's Bay 0.1m Urban Aerial Photos (2017-2018)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/gisborne_urban_2017-18_0-1m/01F6P168K626GCA0RY790XHRVY",
-      "3857": "s3://linz-basemaps/3857/gisborne_urban_2017-18_0-1m/01ECTS33A3VYA5A8ZBHCDFYFR8",
-      "name": "gisborne_urban_2017-18_0-1m",
-      "minZoom": 32,
-      "title": "Gisborne 0.1m Urban Aerial Photos (2017-2018)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/gisborne_2022-2023_0.1m/01GWGH1WFBNG4WFSFVR2XK316S",
       "3857": "s3://linz-basemaps/3857/gisborne_2022-2023_0.1m/01GWGH2ED4XWY7TB96Q397FBJB",
-      "name": "gisborne_2022-2023_0.1m",
+      "name": "gisborne-2022-2023-0.1m",
       "minZoom": 14,
       "title": "Gisborne 0.1m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hastings-district_urban_2017-18_0-1m/01F6P17PSJ1SWNYV2V28922WKY",
-      "3857": "s3://linz-basemaps/3857/hastings-district_urban_2017-18_0-1m/01ED82A7KFS8RMNPRYDQ60MCQ1",
-      "name": "hastings-district_urban_2017-18_0-1m",
-      "minZoom": 32,
-      "title": "Hastings 0.1m Urban Aerial Photos (2017-2018)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/hutt-city_urban_2017_0-10m/01F6P19XT96PPWHAABTAGXGV3N",
-      "3857": "s3://linz-basemaps/3857/hutt-city_urban_2017_0-10m/01ED82D0F9NBGVM9WRRT46AV1V",
-      "name": "hutt-city_urban_2017_0-10m",
-      "minZoom": 32,
-      "title": "Hutt City 0.10m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/kapiti-coast_urban_2021_0-075m_RGB/01FC1XYXHBADGNDYM36SH8D1XY",
       "3857": "s3://linz-basemaps/3857/kapiti-coast_urban_2021_0-075m_RGB/01FC1Y20KQZQDJESGSR97G9SSW",
-      "name": "kapiti-coast_urban_2021_0-075m_RGB",
+      "name": "kapiti-coast-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Kapiti Coast 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_urban_2017-18_0-1m/01F6P1EM0AK6GZN9TG913VB6CH",
-      "3857": "s3://linz-basemaps/3857/marlborough_urban_2017-18_0-1m/01ED82QS0GBHX38Z6B1YHQNZM0",
-      "name": "marlborough_urban_2017-18_0-1m",
-      "minZoom": 32,
-      "title": "Marlborough 0.1m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/marlborough_urban_2020-2021_0-1m_RGB/01FCKSW2KY42Z0HA11BJ4RMZ0S",
       "3857": "s3://linz-basemaps/3857/marlborough_urban_2020-2021_0-1m_RGB/01FCKSYT6Y3ZJJ4SAKKB4GEK52",
-      "name": "marlborough_urban_2020-2021_0-1m_RGB",
+      "name": "marlborough-urban-2020-2021-0.1m",
       "minZoom": 14,
       "title": "Marlborough 0.1m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-05m/01F6P1F7BT85M2T5S01FXWAPPD",
-      "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-05m/01ED82S7R88B0CGQWZKH4V7R2H",
-      "name": "napier-city_urban_2017-18_0-05m",
-      "minZoom": 32,
-      "title": "Napier 0.05m Urban Aerial Photos (2017-2018)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-1m/01F6P1FCJZWD8JY7DJEDEB45K7",
-      "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-1m/01ED82SKPVV12M4RYHRK08DWG4",
-      "name": "napier-city_urban_2017-18_0-1m",
-      "minZoom": 32,
-      "title": "Napier 0.1m Urban Aerial Photos (2017-2018)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/new-plymouth_urban_2017_0-10m/01F6P1FPAFD6D8SRHZX3GFJFWY",
-      "3857": "s3://linz-basemaps/3857/new-plymouth_urban_2017_0-10m/01ED82VQR8M1STH3EPMF3E8KFQ",
-      "name": "new-plymouth_urban_2017_0-10m",
-      "minZoom": 32,
-      "title": "New Plymouth 0.10m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/tasman_urban_2017_0-075m/01F6P1VT8BV5T0DPVSG1VEJX0Y",
-      "3857": "s3://linz-basemaps/3857/tasman_urban_2017_0-075m/01ED83ENCYFX7KFVKH0S7SK92W",
-      "name": "tasman_urban_2017_0-075m",
-      "minZoom": 32,
-      "title": "Tasman 0.075m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/tasman_urban_2017_0-1m/01F6P1VW99KC0PEBYPDAZ3RNKK",
-      "3857": "s3://linz-basemaps/3857/tasman_urban_2017_0-1m/01ED83F2SBS02QP80KSQ3GRR92",
-      "name": "tasman_urban_2017_0-1m",
-      "minZoom": 32,
-      "title": "Tasman 0.1m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/tasman_urban_2020_0-1m_RGB/01FDQV9ZW9ETAQB2VJG26WGHP3",
       "3857": "s3://linz-basemaps/3857/tasman_urban_2020_0-1m_RGB/01FDQVCGEJA1YQJBT14AVZ3TJC",
-      "name": "tasman_urban_2020_0-1m_RGB",
+      "name": "tasman-urban-2020-0.1m",
       "minZoom": 14,
       "title": "Tasman 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
@@ -895,63 +487,15 @@
     {
       "2193": "s3://linz-basemaps/2193/tasman_urban_2020-2021_0-075m_RGB/01FDTG4HYDSJ0E4SNV54E3CCJM",
       "3857": "s3://linz-basemaps/3857/tasman_urban_2020-2021_0-075m_RGB/01FDTG1HG7S4HBR2BQPTE7ZRWJ",
-      "name": "tasman_urban_2020-2021_0-075m_RGB",
+      "name": "tasman-urban-2020-2021-0.075m",
       "minZoom": 14,
       "title": "Tasman 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tauranga_urban_2017_0-1m/01F6P1W5KQ18HM9ZM9N35CXJ91",
-      "3857": "s3://linz-basemaps/3857/tauranga_urban_2017_0-1m/01ED83FS8PC1YC7Y7WKJ90P5TN",
-      "name": "tauranga_urban_2017_0-1m",
-      "minZoom": 32,
-      "title": "Tauranga 0.1m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/upper-hutt_urban_2017_0-10m/01F6P1XK2AVYDJ66NY2MKSEXW1",
-      "3857": "s3://linz-basemaps/3857/upper-hutt_urban_2017_0-10m/01ED83JPKMXF5TVKFD4RP91ZRB",
-      "name": "upper-hutt_urban_2017_0-10m",
-      "minZoom": 32,
-      "title": "Upper Hutt 0.1m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/wellington_urban_2017_0-10m/01F6P21F387PCQQB757VZ4E6GS",
-      "3857": "s3://linz-basemaps/3857/wellington_urban_2017_0-10m/01ED83SQ85A7B1MJ42BK13EGCQ",
-      "name": "wellington_urban_2017_0-10m",
-      "minZoom": 32,
-      "title": "Wellington 0.1m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/whanganui_urban_2017-18_0-075m/01F6P22D2ENZ889MYXP3WN950N",
-      "3857": "s3://linz-basemaps/3857/whanganui_urban_2017-18_0-075m/01ED83XAAFYRNDQFZJRBSH21TF",
-      "name": "whanganui_urban_2017-18_0-075m",
-      "minZoom": 32,
-      "title": "Whanganui 0.075m Urban Aerial Photos (2017)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2018_0-075m/01F6P0NTCAD62YAXJ1DKKK2AY3",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2018_0-075m/01ED825VGXM6K9YX52DP7SMXQE",
-      "name": "christchurch_urban_2018_0-075m",
-      "minZoom": 32,
-      "title": "Christchurch 0.075m Urban Aerial Photos (2018)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2018-2019_0-075m_RGB/01F6P0MJKAVT7XTXXPS19FQP81",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2018-2019_0-075m_RGB/01EMFHZ28DMWDCJ7VEE15HTYPZ",
-      "name": "christchurch_urban_2018-2019_0-075m_RGB",
-      "minZoom": 32,
-      "title": "Christchurch 0.075m Urban Aerial Photos (2018-2019)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/dunedin_urban_2018-19_0-1m/01F6P12VGV6BJR4AWJR29V6JQM",
       "3857": "s3://linz-basemaps/3857/dunedin_urban_2018-19_0-1m/01ED826QV4Q60TNS6VM8HE36BV",
-      "name": "dunedin_urban_2018-19_0-1m",
+      "name": "dunedin-urban-2018-2019-0.1m",
       "minZoom": 14,
       "title": "Dunedin 0.1m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos"
@@ -959,7 +503,7 @@
     {
       "2193": "s3://linz-basemaps/2193/hurunui_urban_2018-2019_0-075m_RGB/01F6P19APSPMW8GM4XZYQTCGES",
       "3857": "s3://linz-basemaps/3857/hurunui_urban_2018-2019_0-075m_RGB/01ESPMPK1H0CH2G5K839WN1BT9",
-      "name": "hurunui_urban_2018-2019_0-075m_RGB",
+      "name": "hurunui-urban-2018-2019-0.075m",
       "minZoom": 14,
       "title": "Hurunui 0.075m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos"
@@ -967,31 +511,15 @@
     {
       "2193": "s3://linz-basemaps/2193/otago_urban_2018_0-1m/01F6P1NRHYW2SVKHBMRZ0NXYQA",
       "3857": "s3://linz-basemaps/3857/otago_urban_2018_0-1m/01ED832ZRP7TDQEX5WMVHCP3VM",
-      "name": "otago_urban_2018_0-1m",
+      "name": "otago-urban-2018-0.1m",
       "minZoom": 14,
       "title": "Otago 0.1m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2018-2019_0-125m_RGB/01F6P1PF375AH4BPQ9PTQA7GYD",
-      "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2018-2019_0-125m_RGB/01ESF5MHFP5RCKQW94Z2947CES",
-      "name": "palmerston-north_urban_2018-2019_0-125m_RGB",
-      "minZoom": 32,
-      "title": "Palmerston North 0.125m Urban Aerial Photos (2018)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2018-19_0-1m/01F66E7K4ESMSWZ1CNMCQ8B700",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2018-19_0-1m/01ED81W4KDQQRW9PEQ9KS7T8DV",
-      "name": "bay-of-plenty_urban_2018-19_0-1m",
-      "minZoom": 32,
-      "title": "Bay of Plenty 0.1m Urban Aerial Photos (2018-2019)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2018-2019_0-075m_RGB/01F6P1Q9FCCZ9EH7HE7X2SK2Q1",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2018-2019_0-075m_RGB/01ESPVY6HBS1SH79ZH24RW7ZSQ",
-      "name": "selwyn_urban_2018-2019_0-075m_RGB",
+      "name": "selwyn-urban-2018-2019-0.075m",
       "minZoom": 14,
       "title": "Selwyn 0.075m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos"
@@ -999,7 +527,7 @@
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2019_0-075m_RGB/01FMJQBZ1H9F9KBFK8VH5THM2K",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2019_0-075m_RGB/01FMJQANZJNCWB6SZAYG7P11ZT",
-      "name": "selwyn_urban_2019_0-075m_RGB",
+      "name": "selwyn-urban-2019-0.075m",
       "minZoom": 14,
       "title": "Selwyn 0.075m Urban Aerial Photos (2019)",
       "category": "Urban Aerial Photos"
@@ -1007,71 +535,31 @@
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2020-2021_0-075m_RGB/01FSWMZ640BA2YD74DDGA1A62X",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2020-2021_0-075m_RGB/01FSWN35JY2PC7GMHEBXYART77",
-      "name": "selwyn_urban_2020-2021_0-075m_RGB",
+      "name": "selwyn-urban-2020-2021-0.075m",
       "minZoom": 14,
       "title": "Selwyn 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waimate_urban_2018_0-075m_RGB/01F6P20H4Y55WG0SW5RXNP6Y9J",
-      "3857": "s3://linz-basemaps/3857/waimate_urban_2018_0-075m_RGB/01ESF5HA3BXN5E50Z0608KJGTG",
-      "name": "waimate_urban_2018_0-075m_RGB",
-      "minZoom": 32,
-      "title": "Waimate 0.075m Urban Aerial Photos (2018)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/hamilton_urban_2019_0-1m/01F6P16V72XPFJK2X5V68YYM0X",
-      "3857": "s3://linz-basemaps/3857/hamilton_urban_2019_0-1m/01ED8284FFT9RYZ0F7XTKD64D4",
-      "name": "hamilton_urban_2019_0-1m",
-      "minZoom": 32,
-      "title": "Hamilton 0.1m Urban Aerial Photos (2019)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/manawatu_urban_2019_0-125m/01F6P1C55PMBG08K4W549J8EQ8",
-      "3857": "s3://linz-basemaps/3857/manawatu_urban_2019_0-125m/01ED82GV8E3DRWQ86D80SN1FPW",
-      "name": "manawatu_urban_2019_0-125m",
-      "minZoom": 32,
-      "title": "Manawatu 0.125m Urban Aerial Photos (2019)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/manawatu_2022-2023_0.1m/01H4Q66MQ16RH0A8VMSTEDG6W4",
       "3857": "s3://linz-basemaps/3857/manawatu_2022-2023_0.1m/01H4Q67HMMFNPJ9GEA6XYS1XDG",
-      "name": "manawatu_2022-2023_0.1m",
+      "name": "manawatu-2022-2023-0.1m",
       "minZoom": 14,
       "title": "Manawatu 0.1m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2R7RYJHP0DVXJMZ3M0QDY",
-      "3857": "s3://linz-basemaps/3857/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2SN9GVFBEW48N4V5E41ZQ",
-      "name": "banks-peninsula_urban_2019-2020_0-075m_RGB",
-      "minZoom": 32,
-      "title": "Banks Peninsula 0.075m Urban Aerial Photos (2019-2020)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/porirua_urban_2020_0-10m_RGB/01F6P1PTH5SBS82G5VVKYHFR63",
       "3857": "s3://linz-basemaps/3857/porirua_urban_2020_0-10m_RGB/01ESM35CSPVJD54ZMT4T5FVV29",
-      "name": "porirua_urban_2020_0-10m_RGB",
+      "name": "porirua-urban-2020-0.1m",
       "minZoom": 14,
       "title": "Porirua 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/ashburton_urban_2020_0-075m_RGB/01FPV7HMJN6RQNSANMZ2SRY0BK",
-      "3857": "s3://linz-basemaps/3857/ashburton_urban_2020_0-075m_RGB/01FPV7ABAWS4ZCWN91VR7SDK0A",
-      "name": "ashburton_urban_2020_0-075m_RGB",
-      "minZoom": 32,
-      "title": "Ashburton 0.075m Urban Aerial Photos (2020)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/wellington-city_urban_2021_0-075m_RGB/01GBRRFSNR0V1N50WP0H1E7SDP",
       "3857": "s3://linz-basemaps/3857/wellington-city_urban_2021_0-075m_RGB/01GBRRG6Z6Q8SJNECE7K49M88R",
-      "name": "wellington-city_urban_2021_0-075m_RGB",
+      "name": "wellington-city-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Wellington City 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1079,7 +567,7 @@
     {
       "2193": "s3://linz-basemaps/2193/carterton_urban_2021_0-075m_RGB/01FC534VYVGP4WMS19M8SV1E6S",
       "3857": "s3://linz-basemaps/3857/carterton_urban_2021_0-075m_RGB/01FC53660FJRP02Z4GZAQPZJV6",
-      "name": "carterton_urban_2021_0-075m_RGB",
+      "name": "carterton-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Carterton 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1087,7 +575,7 @@
     {
       "2193": "s3://linz-basemaps/2193/south-wairarapa_urban_2021_0-075m/01FCVP124PSVRSW7JCEC4KS2K1",
       "3857": "s3://linz-basemaps/3857/south-wairarapa_urban_2021_0-075m/01FCVP30VG02HSFH1VVRM97RXP",
-      "name": "south-wairarapa_urban_2021_0-075m",
+      "name": "south-wairarapa-urban-2021-0.075m",
       "minZoom": 14,
       "title": "South Wairarapa 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1095,7 +583,7 @@
     {
       "2193": "s3://linz-basemaps/2193/masterton_urban_2021_0-075m_RGB/01FCYQ2P6RB18BWV5B8WTDGX4R",
       "3857": "s3://linz-basemaps/3857/masterton_urban_2021_0-075m_RGB/01FCYQ5JV710MS355E84P574DV",
-      "name": "masterton_urban_2021_0-075m_RGB",
+      "name": "masterton-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Masterton 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1103,7 +591,7 @@
     {
       "2193": "s3://linz-basemaps/2193/hutt-city_urban_2021_0-075m_RGB/01FFGK6PT74ZGK3VFX3PY50S0S",
       "3857": "s3://linz-basemaps/3857/hutt-city_urban_2021_0-075m_RGB/01FFGK7ZHHJ4SCYWMET8J4K3J1",
-      "name": "hutt-city_urban_2021_0-075m_RGB",
+      "name": "hutt-city-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Hutt City 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1111,7 +599,7 @@
     {
       "2193": "s3://linz-basemaps/2193/upper-hutt_urban_2021_0-075m_RGB/01FFH545V69N2SC5K4PSH7VZCV",
       "3857": "s3://linz-basemaps/3857/upper-hutt_urban_2021_0-075m_RGB/01FFH51T317TVK35J75ZRZV0PN",
-      "name": "upper-hutt_urban_2021_0-075m_RGB",
+      "name": "upper-hutt-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Upper Hutt 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1119,7 +607,7 @@
     {
       "2193": "s3://linz-basemaps/2193/rangitikei_urban_2021_0-125m_RGB/01FGT7KFSVPEX2RPW5PKN3XCAE",
       "3857": "s3://linz-basemaps/3857/rangitikei_urban_2021_0-125m_RGB/01FGT7MAMPX1EPKW678BP3YWGQ",
-      "name": "rangitikei_urban_2021_0-125m_RGB",
+      "name": "rangitikei-urban-2021-0.125m",
       "minZoom": 14,
       "title": "Rangitīkei 0.125m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1127,7 +615,7 @@
     {
       "2193": "s3://linz-basemaps/2193/northland_urban_2016_0-1m_RGB/01FH4G3JZ5NSF7MTXB5291SRN9",
       "3857": "s3://linz-basemaps/3857/northland_urban_2016_0-1m_RGB/01FH4G1K9A0YHZVCDE5B0J501A",
-      "name": "northland_urban_2016_0-1m_RGB",
+      "name": "northland-urban-2016-0.1m",
       "minZoom": 14,
       "title": "Northland 0.1m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos"
@@ -1135,7 +623,7 @@
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FVDF75ZM3KHXDYJES57AG",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FX6SQBKE27MWG6K3E86CM",
-      "name": "bay-of-plenty_urban_2020_0-1m_RGB",
+      "name": "bay-of-plenty-urban-2020-0.1m",
       "minZoom": 13,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
@@ -1143,7 +631,7 @@
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_2023_0.1m/01H7BSV0VASQPKX47EQD4JWYDM",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_2023_0.1m/01H7BSWXXHTC8581TSPJS1QTM1",
-      "name": "bay-of-plenty_2023_0.1m",
+      "name": "bay-of-plenty-2023-0.1m",
       "minZoom": 13,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
@@ -1151,7 +639,7 @@
     {
       "2193": "s3://linz-basemaps/2193/mackenzie_urban_2020_0-075m_RGB/01FPV7GGNZ008JBH25F35KXC71",
       "3857": "s3://linz-basemaps/3857/mackenzie_urban_2020_0-075m_RGB/01FPV7C0KD6R4FD8TTE3S43ETF",
-      "name": "mackenzie_urban_2020_0-075m_RGB",
+      "name": "mackenzie-urban-2020-0.075m",
       "minZoom": 14,
       "title": "MacKenzie 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
@@ -1159,31 +647,15 @@
     {
       "2193": "s3://linz-basemaps/2193/timaru_urban_2020_0-075m_RGB/01FPV7FD7SX1JKW7TK25ESMYN1",
       "3857": "s3://linz-basemaps/3857/timaru_urban_2020_0-075m_RGB/01FPV7DVA9TW7XQCR64SSB12DA",
-      "name": "timaru_urban_2020_0-075m_RGB",
+      "name": "timaru-urban-2020-0.075m",
       "minZoom": 14,
       "title": "Timaru 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waimate_urban_2020_0-075m_RGB/01FJB8FDBCP2R3VT7TJC1NWGFD",
-      "3857": "s3://linz-basemaps/3857/waimate_urban_2020_0-075m_RGB/01FJB8KPXHR48ZVDHE7M9PK6RH",
-      "name": "waimate_urban_2020_0-075m_RGB",
-      "minZoom": 32,
-      "title": "Waimate 0.075m Urban Aerial Photos (2020)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2021_0-05m_RGB/01FKHMHNJ130J9DF3J9CSYZ41V",
-      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2021_0-05m_RGB/01FKHMK3VK9GRFB762B8JW33HW",
-      "name": "waimakariri_urban_2021_0-05m_RGB",
-      "minZoom": 32,
-      "title": "Waimakariri 0.05m Urban Aerial Photos (2021)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/waimakariri_2023_0.1m/01H4Q66MSD5ATAS9QX25FZ385V",
       "3857": "s3://linz-basemaps/3857/waimakariri_2023_0.1m/01H4Q681F7MWQY303BM8TKAT6K",
-      "name": "waimakariri_2023_0.1m",
+      "name": "waimakariri-2023-0.1m",
       "minZoom": 14,
       "title": "Waimakariri 0.1m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
@@ -1191,7 +663,7 @@
     {
       "2193": "s3://linz-basemaps/2193/christchurch_urban_2020-2021_0-075m_RGB/01FPXB0T4ZCASWGX1X1GVEHDQZ",
       "3857": "s3://linz-basemaps/3857/christchurch_urban_2020-2021_0-075m_RGB/01FPXB36CCAK3FC6FWCMK1D156",
-      "name": "christchurch_urban_2020-2021_0-075m_RGB",
+      "name": "christchurch-urban-2020-2021-0.075m",
       "minZoom": 13,
       "title": "Christchurch 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos"
@@ -1199,7 +671,7 @@
     {
       "2193": "s3://linz-basemaps/2193/christchurch_urban_2021_0-05m_RGB/01FPXAY15VB9MES5WQ0N2SPEG6",
       "3857": "s3://linz-basemaps/3857/christchurch_urban_2021_0-05m_RGB/01FPXB6TVAQZV4W9KXWQ7H5ZQA",
-      "name": "christchurch_urban_2021_0-05m_RGB",
+      "name": "christchurch-urban-2021-0.05m",
       "minZoom": 14,
       "title": "Christchurch 0.05m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1207,7 +679,7 @@
     {
       "2193": "s3://linz-basemaps/2193/waitaki_urban_2020-2021_0-075m_RGB/01FSWMVSKCNWK9H4J3JP6RAQ0S",
       "3857": "s3://linz-basemaps/3857/waitaki_urban_2020-2021_0-075m_RGB/01FSWMXCT9AF67HW8BQKV9WM0K",
-      "name": "waitaki_urban_2020-2021_0-075m_RGB",
+      "name": "waitaki-urban-2020-2021-0.075m",
       "minZoom": 14,
       "title": "Waitaki 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos"
@@ -1215,7 +687,7 @@
     {
       "2193": "s3://linz-basemaps/2193/ōtorohanga_urban_2021_0-1m_RGB/01FYWKAJ86W9P7RWM1VB62KD0H",
       "3857": "s3://linz-basemaps/3857/ōtorohanga_urban_2021_0-1m_RGB/01FYWKATAEK2ZTJQ2PX44Y0XNT",
-      "name": "ōtorohanga_urban_2021_0-1m_RGB",
+      "name": "ōtorohanga-urban-2021-0.1m",
       "minZoom": 14,
       "title": "Ōtorohanga 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1223,7 +695,7 @@
     {
       "2193": "s3://linz-basemaps/2193/waipa_urban_2021_0-1m_RGB/01G28WB9GKP01A8DPYWG9CBMN1",
       "3857": "s3://linz-basemaps/3857/waipa_urban_2021_0-1m_RGB/01G28WC5349Y0J3CGWGTZ796DD",
-      "name": "waipa_urban_2021_0-1m_RGB",
+      "name": "waipa-urban-2021-0.1m",
       "minZoom": 14,
       "title": "Waipa 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1231,7 +703,7 @@
     {
       "2193": "s3://linz-basemaps/2193/waikato_urban_2021_0-1m_RGB/01G75YF8RQTNWDSTJ9618EGGSH",
       "3857": "s3://linz-basemaps/3857/waikato_urban_2021_0-1m_RGB/01G75YFYNRYPFF9H8P4CR4HDAJ",
-      "name": "waikato_urban_2021_0-1m_RGB",
+      "name": "waikato-urban-2021-0.1m",
       "minZoom": 14,
       "title": "Waikato District 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1239,23 +711,15 @@
     {
       "2193": "s3://linz-basemaps/2193/nelson_urban_2022_0-075m_RGB/01G87CWVWSG7KWE3DHC6R18BCX",
       "3857": "s3://linz-basemaps/3857/nelson_urban_2022_0-075m_RGB/01G87CXGF81D5CVT22B038BCM1",
-      "name": "nelson_urban_2022_0-075m_RGB",
+      "name": "nelson-urban-2022-0.075m",
       "minZoom": 14,
       "title": "Nelson 0.075m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hamilton_urban_2020-2021_0-05m_RGB/01GASE5J7NJSZRVD92X9J655TQ",
-      "3857": "s3://linz-basemaps/3857/hamilton_urban_2020-2021_0-05m_RGB/01GASE6HES5VTVKV66G5S82KV3",
-      "name": "hamilton_urban_2020-2021_0-05m_RGB",
-      "minZoom": 32,
-      "title": "Hamilton 0.05m Urban Aerial Photos (2020-2021)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/hamilton_2023_0.05m/01H6YT6HDGMQ0DA04Q4YKTN6KS",
       "3857": "s3://linz-basemaps/3857/hamilton_2023_0.05m/01H6YT8M3R6BN6V2869HA33NQ1",
-      "name": "hamilton_2023_0.05m",
+      "name": "hamilton-2023-0.05m",
       "minZoom": 14,
       "title": "Hamilton 0.05m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
@@ -1263,7 +727,7 @@
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546",
-      "name": "hawkes-bay_urban_2022_0.1m_RGB",
+      "name": "hawkes-bay-urban-2022-0.1m",
       "minZoom": 14,
       "title": "Hawke's Bay 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
@@ -1271,23 +735,15 @@
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94",
-      "name": "hawkes-bay_urban_2022_0.05m_RGB",
+      "name": "hawkes-bay-urban-2022-0.05m",
       "minZoom": 14,
       "title": "Hawke's Bay 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tauranga-city_urban_2022_0.1m_RGB/01GD1V79CP27V3FD5XFWGCTPEM",
-      "3857": "s3://linz-basemaps/3857/tauranga-city_urban_2022_0.1m_RGB/01GD1V81RYJDH8NWK7C33PVNWR",
-      "name": "tauranga-city_urban_2022_0.1m_RGB",
-      "minZoom": 32,
-      "title": "Tauranga 0.1m Urban Aerial Photos (2022)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.1m_RGB/01GDM79KSKKCZ4FQCX5S2Q4BDQ",
       "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.1m_RGB/01GDM7ACWGP9QZP7V3MF4MPKH8",
-      "name": "taranaki_urban_2022_0.1m_RGB",
+      "name": "taranaki-urban-2022-0.1m",
       "minZoom": 14,
       "title": "Taranaki 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
@@ -1295,7 +751,7 @@
     {
       "2193": "s3://linz-basemaps/2193/taranaki_2022-2023_0.1m/01H4Q85VREX8HE76AY26NY2K8G",
       "3857": "s3://linz-basemaps/3857/taranaki_2022-2023_0.1m/01H4Q867YPZYQ66124QQD5W9KA",
-      "name": "taranaki_2022-2023_0.1m",
+      "name": "taranaki-2022-2023-0.1m",
       "minZoom": 14,
       "title": "Taranaki 0.1m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos"
@@ -1303,7 +759,7 @@
     {
       "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.05m_RGB/01GDM781KPM27STN22MDPWC57Y",
       "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.05m_RGB/01GDM7896HY2KQG4K3ESSZMPH6",
-      "name": "taranaki_urban_2022_0.05m_RGB",
+      "name": "taranaki-urban-2022-0.05m",
       "minZoom": 14,
       "title": "Taranaki 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
@@ -1311,7 +767,7 @@
     {
       "2193": "s3://linz-basemaps/2193/taranaki_2022-2023_0.05m/01H4Q85E2DHHDYDSEQGB80WA6F",
       "3857": "s3://linz-basemaps/3857/taranaki_2022-2023_0.05m/01H4Q85VW9QY89WFKEQFZDRW56",
-      "name": "taranaki_2022-2023_0.05m",
+      "name": "taranaki-2022-2023-0.05m",
       "minZoom": 14,
       "title": "Taranaki 0.05m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos"
@@ -1319,7 +775,7 @@
     {
       "2193": "s3://linz-basemaps/2193/invercargill_2022_0.1m/01GG8G03K4N284BJ7Q0DFTRW6P",
       "3857": "s3://linz-basemaps/3857/invercargill_2022_0.1m/01GG8G0NQDH4F6XPCMQS312DRK",
-      "name": "invercargill_urban_2022_0.1m",
+      "name": "invercargill-urban-2022-0.1m",
       "minZoom": 14,
       "title": "Invercargill 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
@@ -1327,7 +783,7 @@
     {
       "2193": "s3://linz-basemaps/2193/ashburton_urban_2021-2022_0.075m/01GM796A98A5WRYAKBJXRN57Z4",
       "3857": "s3://linz-basemaps/3857/ashburton_urban_2021-2022_0.075m/01GM79743023G6STTDG08J4GV8",
-      "name": "ashburton_urban_2021-2022_0.075m",
+      "name": "ashburton-urban-2021-2022-0.075m",
       "minZoom": 14,
       "title": "Ashburton 0.075m Urban Aerial Photos (2021-2022)",
       "category": "Urban Aerial Photos"
@@ -1335,7 +791,7 @@
     {
       "2193": "s3://linz-basemaps/2193/invercargill_2022_0.05m/01GJ3WD5DCSRF0QN7JKN82GPCF",
       "3857": "s3://linz-basemaps/3857/invercargill_2022_0.05m/01GJ3WDN7PTMGZ14AH56GPX39G",
-      "name": "invercargill_2022_0.05m",
+      "name": "invercargill-2022-0.05m",
       "minZoom": 14,
       "title": "Invercargill 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
@@ -1343,23 +799,15 @@
     {
       "2193": "s3://linz-basemaps/2193/southland_2023_0.1m/01H795QH5JXYH5AYFKE7DG9H82",
       "3857": "s3://linz-basemaps/3857/southland_2023_0.1m/01H795RNWP5JPF23FGWJFTNPC9",
-      "name": "southland_2023_0.1m",
+      "name": "southland-2023-0.1m",
       "minZoom": 14,
       "title": "Southland 0.1m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tauranga_winter_2022_0.1m/01GK5GPDK50QX6XXQ44KJEDHAW",
-      "3857": "s3://linz-basemaps/3857/tauranga_winter_2022_0.1m/01GK5GQ48BAXY62JFW6CPAH5XX",
-      "name": "tauranga_winter_2022_0.1m",
-      "minZoom": 32,
-      "title": "Tauranga Winter 0.1m Urban Aerial Photos (2022)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/waimate_2021_0.075m/01GKSQ99D3KZ2NN9H7MWSABMNM",
       "3857": "s3://linz-basemaps/3857/waimate_2021_0.075m/01GKSQ9HMFNF4Z55QXCJ2Y2X0X",
-      "name": "waimate_2021_0.075m",
+      "name": "waimate-2021-0.075m",
       "minZoom": 14,
       "title": "Waimate 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
@@ -1367,7 +815,7 @@
     {
       "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMPDNDV54KMKAS2RQH4A3WNE",
       "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMPDP0B72W5VKH15PRD5DGYC",
-      "name": "palmerston_north_2022_0.125m",
+      "name": "palmerston-north-2022-0.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2022)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
@@ -1375,7 +823,7 @@
     {
       "2193": "s3://linz-basemaps/2193/queenstown-lakes_2022-2023_0.1m/01GTFDQVAACPYQXCPBVH51RBYK",
       "3857": "s3://linz-basemaps/3857/queenstown-lakes_2022-2023_0.1m/01GTFDR0FZYRAMMGZN24RR5XY4",
-      "name": "queenstown-lakes_2022-2023_0.1m",
+      "name": "queenstown-lakes-2022-2023-0.1m",
       "title": "Queenstown Lakes 0.1m Urban Aerial Photos (2022-2023)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
@@ -1383,7 +831,7 @@
     {
       "2193": "s3://linz-basemaps/2193/taupo_2019_0.1m/01H4EY7Y0YNZWDBQPPH5DN90E1",
       "3857": "s3://linz-basemaps/3857/taupo_2019_0.1m/01H4EY825250VGCTG7ZJ0BPAY4",
-      "name": "taupo_2019_0.1m",
+      "name": "taupo-2019-0.1m",
       "title": "Taupō 0.1m Urban Aerial Photos (2019)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
@@ -1391,7 +839,7 @@
     {
       "2193": "s3://linz-basemaps/2193/taupo_2021_0.15m/01GX7WPF56PRH3N4NHV06BBF73",
       "3857": "s3://linz-basemaps/3857/taupo_2021_0.15m/01GX7WPPSD1RZK0JCSYTYW3DJ2",
-      "name": "taupo_2021_0.15m",
+      "name": "taupo-2021-0.15m",
       "title": "Taupō 0.15m Urban Aerial Photos (2021)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
@@ -1399,7 +847,7 @@
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
-      "name": "auckland_rural_2020_0-075m_RGB",
+      "name": "auckland-rural-2020-0.075m",
       "minZoom": 13,
       "title": "Auckland 0.075m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos"
@@ -1407,23 +855,15 @@
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2022_0-075m_RGB/01G6HJ9S4PGK6MTVEZWWHV56QN",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2022_0-075m_RGB/01G6HJBFJRBKJ7FQPHVRACKMNQ",
-      "name": "auckland_rural_2022_0-075m_RGB",
+      "name": "auckland-rural-2022-0.075m",
       "minZoom": 13,
       "title": "Auckland 0.075m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/kapiti-coast_2017_0.10m/01GYDZV2MK43PJNEVXPZSHDZ4F",
-      "3857": "s3://linz-basemaps/3857/kapiti-coast_2017_0.10m/01GYDZVZ557KRJP17670MJZ1T7",
-      "name": "kapiti-coast_2017_0.10m",
-      "title": "Kapiti Coast 0.10m Urban Aerial Photos (2017)",
-      "minZoom": 32,
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/whanganui_2022_0.075m/01GZMXEKG8QRB3W2TS4EXEGVR7",
       "3857": "s3://linz-basemaps/3857/whanganui_2022_0.075m/01GZMXF18WABTRJ2B3TZ20JPJZ",
-      "name": "whanganui_2022_0.075m",
+      "name": "whanganui-2022-0.075m",
       "minZoom": 14,
       "title": "Whanganui 0.075m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
@@ -1431,64 +871,24 @@
     {
       "2193": "s3://linz-basemaps/2193/taupo_2023_0.075m/01H0RX2PWKENR1D1S7E6GYNH1E",
       "3857": "s3://linz-basemaps/3857/taupo_2023_0.075m/01H0RX3235SBMQJ5T3DF8FQTJN",
-      "name": "taupo_2023_0.075m",
+      "name": "taupo-2023-0.075m",
       "minZoom": 14,
       "title": "Taupō 0.075m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
     {
       "3857": "s3://linz-basemaps/3857/geographx_nz_dem_2012_8-0m/01FM8DEN1XG1QGNT229A4T3KZ6",
-      "name": "geographx_nz_dem_2012_8-0m",
+      "name": "geographx-nz-dem-2012-8m",
       "maxZoom": 14,
       "title": "New Zealand 8m DEM Hillshade (2012)",
       "category": "Elevation"
     },
     {
       "3857": "s3://linz-basemaps/3857/geographx_nz_texture_shade_2012_8-0m/01FMK5CJHR30YG9A0JDNVXYCKN",
-      "name": "geographx_nz_texture_shade_2012_8-0m",
+      "name": "geographx-nz-texture-shade-2012-8m",
       "maxZoom": 14,
       "title": "New Zealand 8m DEM Texture Shade (2012)",
       "category": "Elevation"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/top-of-the-south_flood_2022_0.15m/01GGDTRTDV2BA47P4TQ6CGWMFR",
-      "3857": "s3://linz-basemaps/3857/top-of-the-south_flood_2022_0.15m/01GGDTSGRK0Z4C70WXBYMEXK4X",
-      "name": "top-of-the-south_flood_2022_0.15m",
-      "minZoom": 32,
-      "title": "Top of the South Flood 0.15m Aerial Photos (2022)",
-      "category": "Event"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/north-island_2023_10m/01GV1YW3PFVAD8089Q96W69WYT",
-      "3857": "s3://linz-basemaps/3857/north-island_2023_10m/01GV1YWSQ3V9F2ZQ7KYCT6VR72",
-      "name": "north-island_2023_10m",
-      "title": "Cyclone Gabrielle North Island 10m Satellite Imagery (18-21 February 2023)",
-      "minZoom": 32,
-      "category": "Event"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/north-island-pre-cyclone-gabrielle_2022_10m/01GTFV298JMC5EDMA3YVJEPBEX",
-      "3857": "s3://linz-basemaps/3857/north-island-pre-cyclone-gabrielle_2022_10m/01GTFV2P4GH36AS9P3AZ88ABYY",
-      "name": "north-island-pre-cyclone-gabrielle_2022_10m",
-      "title": "Cyclone Gabrielle [Before] North Island 10m Satellite Imagery (22 November 2022)",
-      "minZoom": 32,
-      "category": "Event"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/north-island_2023_0.5m/01GW39PB2ZMJ5KADZSSP860WRS",
-      "3857": "s3://linz-basemaps/3857/north-island_2023_0.5m/01GW39S72PRNYN6MRRWF83T82E",
-      "name": "north-island_2023_0.5m",
-      "title": "Cyclone Gabrielle North Island 0.5m Satellite Imagery (21 February 2023 - 8 March 2023)",
-      "minZoom": 32,
-      "category": "Event"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2M1MDGF1WQK198M68HS2N",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2Q6YCZ67HAAAYRTVHGANY",
-      "name": "hawkes-bay-cyclone-gabrielle_2023_0.1m",
-      "title": "Cyclone Gabrielle Hawke's Bay 0.1m Aerial Photos (19-21 February 2023)",
-      "minZoom": 32,
-      "category": "Event"
     }
   ]
 }


### PR DESCRIPTION
#### Description
*By moving the disabled layer into independent configs, we can remove and clean up the aerial config file. Also, after standardised imagery name, we can now access individual imagery by copy the name from config into api.*

#### Intention
*Our aerial.json config file gets hard to manage to have a mixture of different configs, and also get this ready for historical configs.*

#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title