### PR TITLE
feat(config): Refactoring config to separate all individual imagery and standardise imagery names (#766)

### DIFF
--- a/config/tileset/individual/test-individual-southland-2023-0.25m.json
+++ b/config/tileset/individual/test-individual-southland-2023-0.25m.json
@@ -1,0 +1,18 @@
+{
+  "type": "raster",
+  "id": "ts_test-individual-southland-2023-0.25m",
+  "title": "Test Individual Southland 2023 0.25m",
+  "background": "#00000000",
+  "category": "Urban Aerial Photos",
+  "layers": [
+    {
+      "2193": "s3://linz-basemaps/2193/southland_2023_0.25m/01H9PR2FQ7JRZMQY1NBAAVHPM4",
+      "3857": "s3://linz-basemaps/3857/southland_2023_0.25m/01H9PR5P65ZD4XYM0RN9KHYCZ8",
+      "name": "test-individual-southland-2023-0.25m",
+      "title": "Test Individual Southland 2023 0.25m",
+      "category": "Urban Aerial Photos",
+      "minZoom": 0,
+      "maxZoom": 32
+    }
+  ]
+}


### PR DESCRIPTION
feat(config): Refactoring config to separate all individual imagery and standardise imagery names (#766)

#### Description
*By moving the disabled layer into independent configs, we can remove
and clean up the aerial config file. Also, after standardised imagery
name, we can now access individual imagery by copy the name from config
into api.*

#### Intention
*Our aerial.json config file gets hard to manage to have a mixture of
different configs, and also get this ready for historical configs.*

#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title