### PR TITLE
chore: update scanned composite ids BM-892

### DIFF
--- a/config/tileset/scanned.post19891231.json
+++ b/config/tileset/scanned.post19891231.json
@@ -1,6 +1,6 @@
 {
   "type": "raster",
-  "id": "ts_scanned_aerial_imagery_post_19891231",
+  "id": "ts_scanned-aerial-imagery-post-1989-12-31",
   "title": "Scanned Aerial Imagery post 31 December 1989",
   "background": "#00000000",
   "category": "Scanned Aerial Imagery",

--- a/config/tileset/scanned.pre19900101.json
+++ b/config/tileset/scanned.pre19900101.json
@@ -1,6 +1,6 @@
 {
   "type": "raster",
-  "id": "ts_scanned_aerial_imagery_pre_19900101",
+  "id": "ts_scanned-aerial-imagery-pre-1990-01-01",
   "title": "Scanned Aerial Imagery pre 1 January 1990",
   "background": "#00000000",
   "category": "Scanned Aerial Imagery",


### PR DESCRIPTION
#### Description

Changes the scanned composite tileset identifiers

#### Intention

Alignment with other tilesets that use `-` instead of `snake_case` in their tileset names and identifiers.

#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
