### PR TITLE
fix(vector): replace missing fonts

### DIFF
--- a/config/style/topographic.json
+++ b/config/style/topographic.json
@@ -4246,7 +4246,7 @@
         "text-justify": "left",
         "text-anchor": "left",
         "text-field": "{name}",
-        "text-font": ["Roboto Condensed Italic"],
+        "text-font": ["Roboto Light Italic"],
         "icon-anchor": "right",
         "text-size": 12,
         "text-offset": [0.5, 0],
@@ -4425,7 +4425,7 @@
       "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"], ["has", "name"]],
       "layout": {
         "visibility": "visible",
-        "text-font": ["Open Sans Cond Light Italic"],
+        "text-font": ["Open Sans Light Italic"],
         "text-field": "{name}",
         "text-size": 12,
         "text-justify": "center",
@@ -4447,7 +4447,7 @@
       "layout": {
         "visibility": "visible",
         "icon-image": "swamp_pnt",
-        "text-font": ["Open Sans Cond Light Italic"],
+        "text-font": ["Open Sans Light Italic"],
         "text-field": "{name}",
         "text-size": 12,
         "text-justify": "right",


### PR DESCRIPTION
#### Motivation

When Maplibre cannot find fonts it fails to render the tile, the topographic styles referenced fonts that are not in ../fonts and when rendering these features it fails to render the map.



#### Modification
Swap instances of missing fonts with fonts that exist.

#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
