### PR TITLE
feat(aerial): restore bay-of-plenty-rural-2016-2017-0.3m

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -269,6 +269,14 @@
       "category": "Rural Aerial Photos"
     },
     {
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2016-17_0-3m/01F66E3G0Z8DNKWXG5M55QNW9G",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW",
+      "name": "bay-of-plenty-rural-2016-2017-0.3m",
+      "title": "Bay of Plenty 0.3m Rural Aerial Photos (2016-2017)",
+      "minZoom": 13,
+      "category": "Rural Aerial Photos"
+    },
+    {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2021_0-2m/01H3E4XFK8N1JYJCM8BHDQAJPQ",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2021_0-2m/01H3E4ZG0MJ0SABSSBW2MJXVNS",
       "name": "bay-of-plenty-rural-2021-0.2m",


### PR DESCRIPTION
Restoring bay-of-plenty-rural-2016-2017-0.3m to aerial config to ensure basemaps coverage over Motiti Island.
