### PR TITLE
ci: Sort style config files by prettier json sort plugin.

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,4 +1,13 @@
 module.exports = {
   ...require('@linzjs/style/.prettierrc.js'),
-  printWidth: 200
+  printWidth: 200,
+  overrides: [
+    {
+      files: ["config/style/*.json"],
+      options: {
+        plugins: ["prettier-plugin-sort-json"],
+        jsonRecursiveSort: true
+      }
+    },
+  ]
 };

--- a/config/style/aerialhybrid.json
+++ b/config/style/aerialhybrid.json
@@ -1,69 +1,26 @@
 {
-  "version": 8,
-  "name": "aerialhybrid",
-  "metadata": {
-    "openmaptiles:version": "3.x",
-    "maputnik:renderer": "mbgljs",
-    "maputnik:license": "https://github.com/maputnik/osm-liberty/blob/gh-pages/LICENSE.md"
-  },
-  "sources": {
-    "LINZ-Imagery": {
-      "tiles": ["/v1/tiles/aerial/EPSG:3857/{z}/{x}/{y}.webp"],
-      "type": "raster",
-      "minzoom": 0,
-      "maxzoom": 28,
-      "tileSize": 256
-    },
-    "LINZ Basemaps": { "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json", "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0" }
-  },
-  "sprite": "/v1/sprites/topographic",
   "glyphs": "/v1/fonts/{fontstack}/{range}.pbf",
+  "id": "st_aerialhybrid",
   "layers": [
     {
       "id": "Aerial-Imagery",
-      "type": "raster",
+      "layout": { "visibility": "visible" },
       "source": "LINZ-Imagery",
-      "layout": { "visibility": "visible" }
+      "type": "raster"
     },
     {
-      "id": "Parcels-Ln-Shadow",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "parcel_boundaries",
-      "minzoom": 15,
       "filter": ["none", ["==", "parcel_intent", "Road"], ["==", "parcel_intent", "Hydro"]],
+      "id": "Parcels-Ln-Shadow",
       "layout": { "visibility": "visible" },
+      "minzoom": 15,
       "paint": {
-        "line-opacity": {
-          "stops": [
-            [15, 0.4],
-            [18, 1]
-          ]
-        },
-        "line-width": {
-          "stops": [
-            [16, 0.75],
-            [24, 1.5]
-          ]
-        },
-        "line-offset": 1,
         "line-color": {
           "stops": [
             [16, "rgba(58, 58, 58, 0.4)"],
             [20, "rgba(70, 70, 70, 0.7)"]
           ]
-        }
-      }
-    },
-    {
-      "id": "Parcels-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "parcel_boundaries",
-      "minzoom": 15,
-      "filter": ["none", ["==", "parcel_intent", "Road"], ["==", "parcel_intent", "Hydro"]],
-      "layout": { "visibility": "visible" },
-      "paint": {
+        },
+        "line-offset": 1,
         "line-opacity": {
           "stops": [
             [15, 0.4],
@@ -75,29 +32,58 @@
             [16, 0.75],
             [24, 1.5]
           ]
-        },
-        "line-offset": 0,
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "parcel_boundaries",
+      "type": "line"
+    },
+    {
+      "filter": ["none", ["==", "parcel_intent", "Road"], ["==", "parcel_intent", "Hydro"]],
+      "id": "Parcels-Ln",
+      "layout": { "visibility": "visible" },
+      "minzoom": 15,
+      "paint": {
         "line-color": {
           "stops": [
             [16, "rgba(141, 141, 141, 0.4)"],
             [20, "rgba(196, 196, 196, 0.7)"]
           ]
+        },
+        "line-offset": 0,
+        "line-opacity": {
+          "stops": [
+            [15, 0.4],
+            [18, 1]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [16, 0.75],
+            [24, 1.5]
+          ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "parcel_boundaries",
+      "type": "line"
     },
     {
-      "id": "Transport-FootTracks-Shadow",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 14,
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
+      "id": "Transport-FootTracks-Shadow",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 14,
       "paint": {
+        "line-color": {
+          "stops": [
+            [13, "rgba(231, 231, 231, 0.7)"],
+            [18, "rgba(231, 231, 231, 0.4)"]
+          ]
+        },
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -110,35 +96,22 @@
             [15, 1.5],
             [19, 5]
           ]
-        },
-        "line-color": {
-          "stops": [
-            [13, "rgba(231, 231, 231, 0.7)"],
-            [18, "rgba(231, 231, 231, 0.4)"]
-          ]
         }
-      }
-    },
-    {
-      "id": "Transport-FootTracks",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 14,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
+      "id": "Transport-FootTracks",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 14,
       "paint": {
-        "line-width": {
-          "stops": [
-            [14, 1],
-            [15, 1.5],
-            [19, 3]
-          ]
-        },
         "line-color": "rgba(78, 78, 78, 0.8)",
         "line-dasharray": {
           "base": 1,
@@ -147,22 +120,37 @@
             [15, [2.5, 3]],
             [16, [2.5, 3]]
           ]
+        },
+        "line-width": {
+          "stops": [
+            [14, 1],
+            [15, 1.5],
+            [19, 3]
+          ]
         }
-      }
-    },
-    {
-      "id": "Transport-VehicleTracks-Shadow",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "vehicle"]],
+      "id": "Transport-VehicleTracks-Shadow",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-blur": 0.75,
+        "line-color": {
+          "stops": [
+            [13, "rgba(231, 231, 231, 0.7)"],
+            [18, "rgba(231, 231, 231, 0.4)"]
+          ]
+        },
+        "line-dasharray": [8],
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -171,45 +159,29 @@
           ]
         },
         "line-width": {
+          "base": 1,
           "stops": [
             [13, 1.5],
             [15, 5],
             [19, 18]
-          ],
-          "base": 1
-        },
-        "line-blur": 0.75,
-        "line-dasharray": [8],
-        "line-color": {
-          "stops": [
-            [13, "rgba(231, 231, 231, 0.7)"],
-            [18, "rgba(231, 231, 231, 0.4)"]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-VehicleTracks",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "vehicle"]],
+      "id": "Transport-VehicleTracks",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "line-opacity": 1,
-        "line-width": {
-          "stops": [
-            [13, 1],
-            [15, 2],
-            [19, 8]
-          ],
-          "base": 1
-        },
+        "line-color": "rgba(78, 78, 78, 0.8)",
         "line-dasharray": {
           "base": 1,
           "stops": [
@@ -219,22 +191,31 @@
             [17, [6, 8]]
           ]
         },
-        "line-color": "rgba(78, 78, 78, 0.8)"
-      }
-    },
-    {
-      "id": "Transport-1Casing",
-      "type": "line",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [13, 1],
+            [15, 2],
+            [19, 8]
+          ]
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"]],
+      "id": "Transport-1Casing",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-color": "rgba(78, 78, 78, 1)",
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -248,23 +229,23 @@
             [15, 5],
             [19, 18]
           ]
-        },
-        "line-color": "rgba(78, 78, 78, 1)"
-      }
-    },
-    {
-      "id": "Transport-2Casing",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["in", "lane_count", 2, 3, 4, 5, 6, 7, 8], ["!=", "class", "motorway"]],
+      "id": "Transport-2Casing",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-color": "rgba(78, 78, 78, 1)",
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -278,24 +259,24 @@
             [15, 6],
             [19, 16]
           ]
-        },
-        "line-color": "rgba(78, 78, 78, 1)"
-      }
-    },
-    {
-      "id": "Transport-1Metalled-White",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "metalled"], ["==", "lane_count", 1]],
+      "id": "Transport-1Metalled-White",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "line-translate-anchor": "map",
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -303,31 +284,31 @@
             [18, 0.4]
           ]
         },
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [13, 0.5],
             [15, 3],
             [19, 16]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(184, 184, 184, 1)"
-      }
-    },
-    {
-      "id": "Transport-2Metalled-White",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "metalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
+      "id": "Transport-2Metalled-White",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "line-translate-anchor": "map",
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -335,31 +316,31 @@
             [18, 0.4]
           ]
         },
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [13, 1],
             [15, 5],
             [19, 18]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(184, 184, 184, 1)"
-      }
-    },
-    {
-      "id": "Transport-UnMetalled",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "unmetalled"]],
+      "id": "Transport-UnMetalled",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "line-translate-anchor": "map",
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -367,31 +348,31 @@
             [18, 0.4]
           ]
         },
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [13, 0.5],
             [15, 3],
             [19, 16]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(184, 184, 184, 1)"
-      }
-    },
-    {
-      "id": "Transport-2UnMetalled",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "unmetalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
+      "id": "Transport-2UnMetalled",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "line-translate-anchor": "map",
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -399,31 +380,31 @@
             [18, 0.4]
           ]
         },
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [13, 1],
             [15, 5],
             [19, 18]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(184, 184, 184, 1)"
-      }
-    },
-    {
-      "id": "Transport-1Sealed",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "sealed"], ["==", "lane_count", 1], ["!=", "class", "motorway"]],
+      "id": "Transport-1Sealed",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "line-translate-anchor": "map",
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -431,31 +412,31 @@
             [18, 0.4]
           ]
         },
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [13, 0.5],
             [15, 3],
             [19, 16]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(184, 184, 184, 1)"
-      }
-    },
-    {
-      "id": "Transport-2+Sealed",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "sealed"], ["in", "lane_count", 2, 3, 4, 5, 6, 7], ["!=", "class", "motorway"]],
+      "id": "Transport-2+Sealed",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "line-translate-anchor": "map",
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
         "line-opacity": {
           "stops": [
             [13, 1],
@@ -463,30 +444,30 @@
             [18, 0.4]
           ]
         },
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [13, 1],
             [15, 5],
             [19, 18]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(184, 184, 184, 1)"
-      }
-    },
-    {
-      "id": "Transport-1HWY-Casing",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 1]],
+      "id": "Transport-1HWY-Casing",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
+        "line-color": "rgba(69, 69, 69, 1)",
         "line-opacity": {
           "stops": [
             [8, 1],
@@ -501,23 +482,23 @@
             [15, 4],
             [20, 30]
           ]
-        },
-        "line-color": "rgba(69, 69, 69, 1)"
-      }
-    },
-    {
-      "id": "Transport-2HWY-Casing",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
+      "id": "Transport-2HWY-Casing",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
+        "line-color": "rgba(69, 69, 69, 1)",
         "line-opacity": {
           "stops": [
             [8, 1],
@@ -532,23 +513,23 @@
             [15, 6],
             [18, 30]
           ]
-        },
-        "line-color": "rgba(69, 69, 69, 1)"
-      }
-    },
-    {
-      "id": "Transport-HWY-Casing",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
+      "id": "Transport-HWY-Casing",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
+        "line-color": "rgba(69, 69, 69, 1)",
         "line-opacity": {
           "stops": [
             [8, 1],
@@ -563,23 +544,28 @@
             [15, 6],
             [18, 30]
           ]
-        },
-        "line-color": "rgba(69, 69, 69, 1)"
-      }
-    },
-    {
-      "id": "Transport-1HWY",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["==", "lane_count", 1]],
+      "id": "Transport-1HWY",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
+        "line-color": {
+          "stops": [
+            [8, "rgba(232, 218, 123, 1)"],
+            [10, "rgba(210, 162, 84, 1)"]
+          ]
+        },
         "line-opacity": {
           "stops": [
             [8, 1],
@@ -595,65 +581,29 @@
             [17, 14],
             [20, 30]
           ]
-        },
-        "line-color": {
-          "stops": [
-            [8, "rgba(232, 218, 123, 1)"],
-            [10, "rgba(210, 162, 84, 1)"]
-          ]
         }
-      }
-    },
-    {
-      "id": "Transport-2HWY",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
+      "id": "Transport-2HWY",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
-        "line-opacity": {
-          "stops": [
-            [8, 1],
-            [13, 0.75],
-            [16, 0.25]
-          ]
-        },
-        "line-width": {
-          "stops": [
-            [8, 1],
-            [10, 1],
-            [14, 3],
-            [18, 30]
-          ]
-        },
         "line-blur": 0,
         "line-color": {
           "stops": [
             [8, "rgba(232, 218, 123, 1)"],
             [10, "rgba(210, 162, 84, 1)"]
           ]
-        }
-      }
-    },
-    {
-      "id": "Transport-HWY",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 8,
-      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round",
-        "line-cap": "round"
-      },
-      "paint": {
+        },
         "line-opacity": {
           "stops": [
             [8, 1],
@@ -668,180 +618,152 @@
             [14, 3],
             [18, 30]
           ]
-        },
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
+      "id": "Transport-HWY",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
         "line-color": {
           "stops": [
             [8, "rgba(232, 218, 123, 1)"],
             [10, "rgba(210, 162, 84, 1)"]
           ]
+        },
+        "line-opacity": {
+          "stops": [
+            [8, 1],
+            [13, 0.75],
+            [16, 0.25]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [8, 1],
+            [10, 1],
+            [14, 3],
+            [18, 30]
+          ]
         }
-      }
-    },
-    {
-      "id": "Transport-Roads-8-Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 6,
-      "maxzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"]],
+      "id": "Transport-Roads-8-Casing",
       "layout": { "visibility": "visible" },
+      "maxzoom": 8,
+      "minzoom": 6,
       "paint": {
+        "line-color": "rgba(69, 69, 69, 1)",
         "line-width": {
           "stops": [
             [5, 1.5],
             [8, 4]
           ]
-        },
-        "line-color": "rgba(69, 69, 69, 1)"
-      }
-    },
-    {
-      "id": "Transport-Roads-8",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 6,
-      "maxzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"]],
+      "id": "Transport-Roads-8",
       "layout": { "visibility": "visible" },
+      "maxzoom": 8,
+      "minzoom": 6,
       "paint": {
-        "line-width": {
-          "stops": [
-            [5, 0.75],
-            [8, 1.5]
-          ]
-        },
         "line-color": {
           "stops": [
             [6, "rgba(232, 218, 123, 1)"],
             [10, "rgba(210, 162, 84, 1)"]
           ]
+        },
+        "line-width": {
+          "stops": [
+            [5, 0.75],
+            [8, 1.5]
+          ]
         }
-      }
-    },
-    {
-      "id": "Transport-FerryCrossing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11.5,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "ferry"]],
+      "id": "Transport-FerryCrossing",
+      "minzoom": 11.5,
       "paint": {
-        "line-width": 1,
         "line-color": "rgba(74, 110, 153, 1)",
-        "line-dasharray": [8, 10]
-      }
+        "line-dasharray": [8, 10],
+        "line-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
       "id": "Airport-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "aerodrome_label",
-      "minzoom": 12,
       "layout": {
-        "icon-rotation-alignment": "viewport",
-        "icon-pitch-alignment": "viewport",
-        "visibility": "visible",
-        "text-field": "{name}",
-        "text-size": 11,
-        "text-anchor": "top",
-        "text-allow-overlap": false,
-        "icon-text-fit": "none",
-        "icon-size": 1.2,
+        "icon-anchor": "bottom",
         "icon-ignore-placement": false,
         "icon-image": "airport_airport_pnt_fill",
-        "text-font": ["Open Sans Bold Italic"],
+        "icon-offset": [0, 0],
+        "icon-pitch-alignment": "viewport",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1.2,
+        "icon-text-fit": "none",
         "symbol-spacing": 250,
-        "text-pitch-alignment": "auto",
+        "text-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Bold Italic"],
         "text-justify": "center",
         "text-max-width": 5,
-        "icon-anchor": "bottom",
+        "text-padding": 2,
+        "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
-        "icon-offset": [0, 0],
-        "text-padding": 2
+        "text-size": 11,
+        "visibility": "visible"
       },
+      "minzoom": 12,
       "paint": {
-        "text-halo-blur": 0.5,
+        "icon-opacity": 0.8,
         "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-blur": 0.5,
         "text-halo-color": "rgba(0, 0, 0, 1)",
-        "text-halo-width": 1,
-        "icon-opacity": 0.8
-      }
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "aerodrome_label",
+      "type": "symbol"
     },
     {
-      "id": "All-Highway-Labels-three",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 8,
       "filter": ["all", ["in", "hway_num", "25A", "20A", "20B", "29A", "30A", "74A", "67A"]],
+      "id": "All-Highway-Labels-three",
       "layout": {
-        "icon-rotation-alignment": "viewport",
-        "icon-pitch-alignment": "viewport",
-        "visibility": "visible",
-        "text-field": "{hway_num}",
-        "text-size": {
-          "stops": [
-            [8, 9],
-            [11, 10],
-            [15, 14]
-          ]
-        },
-        "icon-text-fit": "none",
-        "icon-size": {
-          "stops": [
-            [8, 1.2],
-            [12, 1.5],
-            [15, 1.7]
-          ]
-        },
-        "symbol-placement": "line",
+        "icon-anchor": "center",
         "icon-image": "highway_pnt_wide",
-        "text-font": ["Open Sans Bold"],
-        "icon-padding": 2,
-        "symbol-spacing": {
-          "stops": [
-            [6, 500],
-            [13, 400]
-          ]
-        },
-        "text-pitch-alignment": "viewport",
-        "text-justify": "center",
-        "icon-text-fit-padding": [1, 4, 3, 3],
-        "icon-anchor": "center",
-        "text-rotation-alignment": "viewport",
-        "icon-offset": [0, 1],
-        "text-keep-upright": true,
         "icon-keep-upright": false,
-        "icon-rotate": 0
-      },
-      "paint": {
-        "text-translate-anchor": "map",
-        "icon-translate-anchor": "map",
-        "text-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "All-Highway-Labels-standard",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 8,
-      "filter": ["all", ["has", "hway_num"], ["!in", "hway_num", "6,94", "2,50", "1,3", "12,15", "14,15", "6,96", "25A", "20A", "20B", "29A", "30A", "74A", "67A"], ["!=", "lane_count", 1]],
-      "layout": {
-        "icon-rotation-alignment": "viewport",
+        "icon-offset": [0, 1],
+        "icon-padding": 2,
         "icon-pitch-alignment": "viewport",
-        "visibility": "visible",
-        "text-field": "{hway_num}",
-        "text-size": {
-          "stops": [
-            [8, 9],
-            [11, 10],
-            [15, 14]
-          ]
-        },
-        "icon-text-fit": "none",
+        "icon-rotate": 0,
+        "icon-rotation-alignment": "viewport",
         "icon-size": {
           "stops": [
             [8, 1.2],
@@ -849,46 +771,106 @@
             [15, 1.7]
           ]
         },
+        "icon-text-fit": "none",
+        "icon-text-fit-padding": [1, 4, 3, 3],
         "symbol-placement": "line",
-        "icon-image": "highway_pnt_standard",
-        "text-font": ["Open Sans Bold"],
-        "icon-padding": 2,
         "symbol-spacing": {
           "stops": [
             [6, 500],
             [13, 400]
           ]
         },
-        "text-pitch-alignment": "viewport",
+        "text-field": "{hway_num}",
+        "text-font": ["Open Sans Bold"],
         "text-justify": "center",
-        "icon-text-fit-padding": [1, 4, 3, 3],
-        "icon-anchor": "center",
-        "text-rotation-alignment": "viewport",
-        "icon-offset": [0, 1],
         "text-keep-upright": true,
-        "icon-keep-upright": false,
-        "icon-rotate": 0
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [8, 9],
+            [11, 10],
+            [15, 14]
+          ]
+        },
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
-        "text-translate-anchor": "map",
         "icon-translate-anchor": "map",
-        "text-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "All-Road-Labels",
-      "type": "symbol",
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-translate-anchor": "map"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
-      "filter": ["all", ["has", "name"]],
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "hway_num"], ["!in", "hway_num", "6,94", "2,50", "1,3", "12,15", "14,15", "6,96", "25A", "20A", "20B", "29A", "30A", "74A", "67A"], ["!=", "lane_count", 1]],
+      "id": "All-Highway-Labels-standard",
       "layout": {
-        "symbol-spacing": 250,
-        "text-transform": "none",
-        "icon-pitch-alignment": "auto",
-        "visibility": "visible",
+        "icon-anchor": "center",
+        "icon-image": "highway_pnt_standard",
+        "icon-keep-upright": false,
+        "icon-offset": [0, 1],
+        "icon-padding": 2,
+        "icon-pitch-alignment": "viewport",
+        "icon-rotate": 0,
+        "icon-rotation-alignment": "viewport",
+        "icon-size": {
+          "stops": [
+            [8, 1.2],
+            [12, 1.5],
+            [15, 1.7]
+          ]
+        },
+        "icon-text-fit": "none",
+        "icon-text-fit-padding": [1, 4, 3, 3],
+        "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [6, 500],
+            [13, 400]
+          ]
+        },
+        "text-field": "{hway_num}",
+        "text-font": ["Open Sans Bold"],
         "text-justify": "center",
+        "text-keep-upright": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [8, 9],
+            [11, 10],
+            [15, 14]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "icon-translate-anchor": "map",
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-translate-anchor": "map"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "name"]],
+      "id": "All-Road-Labels",
+      "layout": {
+        "icon-ignore-placement": false,
+        "icon-pitch-alignment": "auto",
+        "icon-text-fit": "both",
+        "symbol-placement": "line",
+        "symbol-spacing": 250,
+        "text-anchor": "center",
         "text-field": "{name}",
+        "text-font": ["Open Sans Bold"],
+        "text-justify": "center",
         "text-size": {
           "stops": [
             [13, 8],
@@ -898,12 +880,10 @@
             [22, 28]
           ]
         },
-        "text-anchor": "center",
-        "icon-text-fit": "both",
-        "symbol-placement": "line",
-        "icon-ignore-placement": false,
-        "text-font": ["Open Sans Bold"]
+        "text-transform": "none",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
         "text-color": "rgba(255, 255, 255, 1)",
         "text-halo-color": "rgba(0, 0, 0, 1)",
@@ -916,16 +896,14 @@
           ]
         },
         "text-opacity": 1
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
     },
     {
-      "id": "Aeroway-Helipads",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "aeroway",
-      "minzoom": 12,
-      "maxzoom": 21,
       "filter": ["all", ["==", "class", "helipad"]],
+      "id": "Aeroway-Helipads",
       "layout": {
         "icon-image": {
           "stops": [
@@ -934,16 +912,18 @@
           ]
         },
         "text-font": ["Open Sans Regular"]
-      }
+      },
+      "maxzoom": 21,
+      "minzoom": 12,
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "symbol"
     },
     {
       "id": "Housenumber",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "housenumber",
-      "minzoom": 17,
       "layout": {
         "text-allow-overlap": false,
+        "text-anchor": "bottom",
         "text-field": "{housenumber}",
         "text-font": ["Roboto Bold Italic"],
         "text-size": {
@@ -951,88 +931,73 @@
             [17, 10],
             [19, 12]
           ]
-        },
-        "text-anchor": "bottom"
+        }
       },
+      "minzoom": 17,
       "paint": {
         "icon-color": "rgba(0, 0, 0, 1)",
-        "text-halo-color": "rgba(14, 14, 14, 1)",
         "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-color": "rgba(14, 14, 14, 1)",
         "text-halo-width": 1
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "housenumber",
+      "type": "symbol"
     },
     {
-      "id": "Place-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "place_names",
-      "minzoom": 3,
       "filter": ["all"],
+      "id": "Place-Names",
       "layout": {
         "icon-allow-overlap": false,
-        "text-optional": true,
-        "icon-pitch-alignment": "auto",
-        "visibility": "visible",
-        "text-field": "{label}",
-        "text-allow-overlap": true,
-        "icon-text-fit": "both",
-        "symbol-placement": "point",
-        "icon-ignore-placement": false,
-        "text-font": ["Open Sans Bold"],
-        "icon-optional": false,
-        "symbol-avoid-edges": false,
-        "symbol-spacing": 1,
-        "text-pitch-alignment": "viewport",
-        "text-max-width": 100,
         "icon-anchor": "center",
-        "text-rotation-alignment": "viewport",
+        "icon-ignore-placement": false,
+        "icon-optional": false,
+        "icon-pitch-alignment": "auto",
+        "icon-text-fit": "both",
+        "symbol-avoid-edges": false,
+        "symbol-placement": "point",
+        "symbol-spacing": 1,
+        "symbol-z-order": "auto",
+        "text-allow-overlap": true,
+        "text-field": "{label}",
+        "text-font": ["Open Sans Bold"],
         "text-ignore-placement": false,
+        "text-max-width": 100,
+        "text-optional": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
         "text-writing-mode": [],
-        "symbol-z-order": "auto"
+        "visibility": "visible"
       },
+      "minzoom": 3,
       "paint": {
-        "icon-halo-width": 1,
-        "text-halo-color": "rgba(255, 252, 252, 0.75)",
-        "icon-halo-color": "rgba(255, 255, 255, 1)",
-        "text-translate-anchor": "viewport",
         "icon-color": "rgba(53, 53, 53, 1)",
+        "icon-halo-blur": 1,
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
+        "icon-halo-width": 1,
+        "icon-opacity": 1,
         "text-color": {
           "stops": [
             [6, "rgba(35, 34, 34, 1)"],
             [19, "rgba(111, 111, 111, 1)"]
           ]
         },
-        "icon-opacity": 1,
-        "icon-halo-blur": 1,
-        "text-halo-width": 2.5
-      }
+        "text-halo-color": "rgba(255, 252, 252, 0.75)",
+        "text-halo-width": 2.5,
+        "text-translate-anchor": "viewport"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place_names",
+      "type": "symbol"
     },
     {
       "id": "Place-Names-3-12",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
-      "minzoom": 3,
-      "maxzoom": 13,
       "layout": {
-        "icon-rotation-alignment": "auto",
-        "text-variable-anchor": ["top", "bottom-left"],
-        "text-optional": true,
-        "text-field": "{name}",
-        "text-size": {
-          "stops": [
-            [2, 10],
-            [5, 16],
-            [8, 16],
-            [10, 17],
-            [12, 17],
-            [14, 17]
-          ]
-        },
-        "text-anchor": "center",
         "icon-ignore-placement": false,
+        "icon-rotation-alignment": "auto",
+        "text-anchor": "center",
+        "text-field": "{name}",
         "text-font": ["Roboto Regular"],
-        "text-pitch-alignment": "viewport",
         "text-letter-spacing": {
           "stops": [
             [10, 0.08],
@@ -1047,49 +1012,83 @@
             [6, [0, 1.25]]
           ]
         },
-        "text-rotation-alignment": "viewport"
+        "text-optional": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [2, 10],
+            [5, 16],
+            [8, 16],
+            [10, 17],
+            [12, 17],
+            [14, 17]
+          ]
+        },
+        "text-variable-anchor": ["top", "bottom-left"]
       },
+      "maxzoom": 13,
+      "minzoom": 3,
       "paint": {
-        "text-halo-color": "rgba(32, 32, 32, 1)",
-        "icon-halo-color": "rgba(255, 255, 255, 1)",
         "icon-color": {
           "stops": [
             [6, "rgba(53, 53, 53, 1)"],
             [10, "rgba(53, 53, 53, 1)"]
           ]
         },
-        "text-halo-blur": 1,
-        "icon-translate-anchor": "viewport",
-        "text-color": "rgba(255, 252, 252, 1)",
-        "text-halo-width": {
-          "stops": [
-            [4, 1.5],
-            [9, 1.5]
-          ]
-        },
-        "icon-opacity": 1,
         "icon-halo-blur": {
           "stops": [
             [13, 1],
             [14, 0.5]
           ]
         },
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
+        "icon-opacity": 1,
+        "icon-translate-anchor": "viewport",
+        "text-color": "rgba(255, 252, 252, 1)",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(32, 32, 32, 1)",
+        "text-halo-width": {
+          "stops": [
+            [4, 1.5],
+            [9, 1.5]
+          ]
+        },
         "text-opacity": 1
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
     },
     {
-      "id": "All-FootTrack-Labels",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 13,
       "filter": ["all", ["has", "name"], ["==", "class", "track"], ["==", "track_use", "foot"]],
+      "id": "All-FootTrack-Labels",
       "layout": {
-        "icon-rotation-alignment": "viewport",
-        "icon-pitch-alignment": "auto",
         "icon-allow-overlap": false,
-        "visibility": "visible",
+        "icon-anchor": "bottom",
+        "icon-ignore-placement": false,
+        "icon-image": "track_walking_pnt_fill",
+        "icon-offset": [0, -3],
+        "icon-pitch-alignment": "auto",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": {
+          "stops": [
+            [13, 1.2],
+            [20, 2]
+          ]
+        },
+        "icon-text-fit": "none",
+        "symbol-placement": "point",
+        "symbol-spacing": 100,
+        "text-allow-overlap": false,
+        "text-anchor": "top",
         "text-field": "{name}",
+        "text-font": ["Open Sans Semi Bold"],
+        "text-ignore-placement": false,
+        "text-justify": "center",
+        "text-max-width": 4,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
         "text-size": {
           "stops": [
             [13, 10],
@@ -1099,209 +1098,203 @@
             [22, 140]
           ]
         },
-        "text-anchor": "top",
-        "text-allow-overlap": false,
-        "icon-text-fit": "none",
-        "icon-size": {
-          "stops": [
-            [13, 1.2],
-            [20, 2]
-          ]
-        },
-        "symbol-placement": "point",
-        "icon-ignore-placement": false,
-        "icon-image": "track_walking_pnt_fill",
-        "text-font": ["Open Sans Semi Bold"],
-        "symbol-spacing": 100,
         "text-transform": "none",
-        "text-pitch-alignment": "viewport",
-        "text-justify": "center",
-        "text-max-width": 4,
-        "icon-anchor": "bottom",
-        "text-rotation-alignment": "viewport",
-        "icon-offset": [0, -3],
-        "text-ignore-placement": false
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
         "text-color": "rgba(255, 255, 255, 1)",
         "text-halo-color": "rgba(0, 0, 0, 1)",
         "text-halo-width": 0.8,
         "text-opacity": 1
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
     },
     {
-      "id": "Landcover-GolfCourse-Symbol",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 12,
-      "maxzoom": 20,
       "filter": ["all", ["==", "class", "grass"], ["==", "grass_type", "golf_course"]],
+      "id": "Landcover-GolfCourse-Symbol",
       "layout": {
-        "icon-rotation-alignment": "viewport",
-        "icon-pitch-alignment": "viewport",
-        "visibility": "visible",
-        "text-field": "{name}",
-        "text-anchor": "left",
-        "text-size": 11,
-        "icon-size": 1.2,
+        "icon-anchor": "right",
         "icon-image": "golf_course_pnt_dual",
+        "icon-pitch-alignment": "viewport",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1.2,
+        "text-anchor": "left",
+        "text-field": "{name}",
         "text-font": ["Open Sans Semi Bold Italic"],
         "text-justify": "left",
         "text-max-width": 6,
         "text-offset": [0.5, 0],
-        "icon-anchor": "right"
+        "text-size": 11,
+        "visibility": "visible"
       },
+      "maxzoom": 20,
+      "minzoom": 12,
       "paint": {
-        "text-halo-width": 0.8,
         "text-color": "rgba(146, 201, 156, 1)",
-        "text-halo-color": "rgba(0, 0, 0, 1)"
-      }
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 0.8
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
     },
     {
-      "id": "Landuse-Landfill-Symbol",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 13.5,
       "filter": ["all", ["==", "class", "landfill"]],
+      "id": "Landuse-Landfill-Symbol",
       "layout": {
-        "text-justify": "left",
-        "text-max-width": 4,
-        "visibility": "visible",
-        "text-field": "{name}",
         "icon-anchor": "right",
-        "text-offset": [0.5, 0],
-        "text-anchor": "left",
-        "text-size": 12,
+        "icon-image": "landfill_pnt",
         "icon-size": {
           "stops": [
             [12, 1.2],
             [16, 1.5]
           ]
         },
-        "icon-image": "landfill_pnt",
-        "text-font": ["Roboto Condensed Italic"]
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-justify": "left",
+        "text-max-width": 4,
+        "text-offset": [0.5, 0],
+        "text-size": 12,
+        "visibility": "visible"
       },
+      "minzoom": 13.5,
       "paint": {
+        "text-color": "rgba(255, 255, 255, 1)",
         "text-halo-blur": 0.5,
         "text-halo-color": "rgba(28, 25, 17, 1)",
-        "text-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1.5
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
     },
     {
-      "id": "Poi-Beacon-Lighthouse",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 12,
-      "maxzoom": 20,
       "filter": ["all", ["==", "class", "beacon"], ["==", "type", "lighthouse"]],
+      "id": "Poi-Beacon-Lighthouse",
       "layout": {
         "icon-allow-overlap": true,
-        "text-justify": "right",
-        "text-field": "{name}",
         "icon-anchor": "center",
-        "text-size": 11,
-        "text-anchor": "left",
-        "text-allow-overlap": true,
-        "icon-size": 1.3,
         "icon-image": "beacon_lighthouse_land_pnt",
-        "text-font": ["Open Sans Semi Bold Italic"]
+        "icon-size": 1.3,
+        "text-allow-overlap": true,
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Semi Bold Italic"],
+        "text-justify": "right",
+        "text-size": 11
       },
+      "maxzoom": 20,
+      "minzoom": 12,
       "paint": {
         "text-color": "rgba(255, 214, 150, 1)",
         "text-halo-color": "rgba(0, 0, 0, 1)",
         "text-halo-width": 0.8,
         "text-translate": [15, 0]
-      }
-    },
-    {
-      "id": "Poi-Hut-Label",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["any", ["==", "class", "hut"]],
+      "id": "Poi-Hut-Label",
       "layout": {
         "icon-allow-overlap": true,
-        "text-justify": "left",
-        "text-max-width": 5,
-        "visibility": "visible",
+        "icon-image": "building_pnt_hut",
+        "icon-size": 1.5,
+        "text-anchor": "left",
         "text-field": {
           "stops": [
             [6, ""],
             [15, "{name}"]
           ]
         },
+        "text-font": ["Open Sans Semi Bold"],
+        "text-justify": "left",
+        "text-max-width": 5,
         "text-offset": [1, 0],
         "text-size": 12,
-        "text-anchor": "left",
-        "icon-size": 1.5,
-        "icon-image": "building_pnt_hut",
-        "text-font": ["Open Sans Semi Bold"]
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "text-halo-color": "rgba(59, 55, 55, 1)",
+        "icon-opacity": 0.9,
         "text-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 1.5,
-        "icon-opacity": 0.9
-      }
-    },
-    {
-      "id": "Poi-Monument",
-      "type": "symbol",
+        "text-halo-color": "rgba(59, 55, 55, 1)",
+        "text-halo-width": 1.5
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
-      "maxzoom": 20,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "monument"]],
+      "id": "Poi-Monument",
       "layout": {
         "icon-allow-overlap": true,
-        "text-radial-offset": 0,
-        "visibility": "visible",
-        "text-field": "{name}",
-        "text-size": 11,
-        "text-anchor": "left",
-        "text-allow-overlap": false,
+        "icon-anchor": "center",
+        "icon-image": "monument_pnt",
         "icon-size": {
           "stops": [
             [12, 1.2],
             [16, 1.6]
           ]
         },
-        "icon-image": "monument_pnt",
+        "text-allow-overlap": false,
+        "text-anchor": "left",
+        "text-field": "{name}",
         "text-font": ["Open Sans Semi Bold Italic"],
         "text-justify": "left",
         "text-max-width": 5,
-        "icon-anchor": "center",
-        "text-offset": [1.5, 0]
+        "text-offset": [1.5, 0],
+        "text-radial-offset": 0,
+        "text-size": 11,
+        "visibility": "visible"
       },
+      "maxzoom": 20,
+      "minzoom": 12,
       "paint": {
+        "icon-opacity": 0.85,
         "text-color": "rgba(255, 214, 150, 1)",
         "text-halo-color": "rgba(0, 0, 0, 1)",
-        "text-halo-width": 0.8,
-        "icon-opacity": 0.85
-      }
-    },
-    {
-      "id": "Poi-Railway-Symbol",
-      "type": "symbol",
+        "text-halo-width": 0.8
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "railway"]],
+      "id": "Poi-Railway-Symbol",
       "layout": {
         "icon-allow-overlap": true,
-        "visibility": "visible",
+        "icon-anchor": "center",
+        "icon-image": "rail_station_train_diesel_pnt_red",
+        "icon-optional": true,
+        "icon-size": {
+          "stops": [
+            [12, 0.4],
+            [13, 1],
+            [20, 2]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-anchor": "left",
         "text-field": {
           "stops": [
             [12, "{name}"],
             [13, "{name}"]
           ]
         },
-        "text-anchor": "left",
+        "text-font": ["Open Sans Bold Italic"],
+        "text-justify": "left",
+        "text-max-width": 5,
+        "text-offset": [1.25, 1.5],
         "text-size": {
           "stops": [
             [13, 10],
@@ -1310,38 +1303,25 @@
             [18, 19]
           ]
         },
-        "text-allow-overlap": false,
-        "icon-size": {
-          "stops": [
-            [12, 0.4],
-            [13, 1],
-            [20, 2]
-          ]
-        },
-        "icon-image": "rail_station_train_diesel_pnt_red",
-        "text-font": ["Open Sans Bold Italic"],
-        "icon-optional": true,
-        "text-justify": "left",
-        "text-max-width": 5,
-        "icon-anchor": "center",
-        "text-offset": [1.25, 1.5]
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "text-color": "rgba(255, 255, 255, 1)",
         "text-halo-blur": 0.5,
         "text-halo-color": "rgba(16, 16, 16, 1)",
-        "text-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
         "text-translate": [0, -15]
-      }
-    },
-    {
-      "id": "Poi-RifleRange-Label",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "rifle_range"]],
+      "id": "Poi-RifleRange-Label",
       "layout": {
+        "icon-image": "rifle_range_pnt",
         "icon-size": {
           "stops": [
             [12, 1.2],
@@ -1349,10 +1329,10 @@
           ]
         },
         "text-field": "",
-        "icon-image": "rifle_range_pnt",
         "text-font": ["Open Sans Regular"],
         "text-size": 9
       },
+      "minzoom": 13,
       "paint": {
         "icon-opacity": {
           "stops": [
@@ -1360,16 +1340,16 @@
             [13, 0.9]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Showground-Symbol",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13.5,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "showground"]],
+      "id": "Poi-Showground-Symbol",
       "layout": {
+        "icon-image": "showground_pnt",
         "icon-size": {
           "stops": [
             [12, 1.2],
@@ -1377,33 +1357,53 @@
           ]
         },
         "text-field": "",
-        "icon-image": "showground_pnt",
         "text-font": ["Open Sans Bold Italic"],
         "text-size": 9
       },
+      "minzoom": 13.5,
       "paint": {
         "text-color": "rgba(121, 195, 128, 0.2)",
         "text-halo-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "Poi-SportsField-Label",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "sports_field"]],
+      "id": "Poi-SportsField-Label",
       "layout": {
         "text-field": "{name}",
         "text-font": ["Open Sans Semi Bold Italic"],
         "text-size": 11
       },
+      "minzoom": 13,
       "paint": {
-        "text-halo-width": 1,
         "text-color": "rgba(146, 201, 156, 1)",
-        "text-halo-color": "rgba(0, 0, 0, 1)"
-      }
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
     }
   ],
-  "id": "st_aerialhybrid"
+  "metadata": {
+    "maputnik:license": "https://github.com/maputnik/osm-liberty/blob/gh-pages/LICENSE.md",
+    "maputnik:renderer": "mbgljs",
+    "openmaptiles:version": "3.x"
+  },
+  "name": "aerialhybrid",
+  "sources": {
+    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json" },
+    "LINZ-Imagery": {
+      "maxzoom": 28,
+      "minzoom": 0,
+      "tileSize": 256,
+      "tiles": ["/v1/tiles/aerial/EPSG:3857/{z}/{x}/{y}.webp"],
+      "type": "raster"
+    }
+  },
+  "sprite": "/v1/sprites/topographic",
+  "version": 8
 }

--- a/config/style/basic.json
+++ b/config/style/basic.json
@@ -1,44 +1,38 @@
 {
-  "version": 8,
-  "name": "basic",
-  "sources": {
-    "openmaptiles": {
-      "type": "vector",
-      "url": "/v1/tiles/topographic/EPSG:3857/tile.json",
-      "attribution": "© 2022 Toitū Te Whenua © OpenMapTiles - CC BY 4.0"
-    }
-  },
+  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+  "id": "st_basic",
   "layers": [
     {
       "id": "background",
-      "type": "background",
       "paint": {
         "background-color": "hsl(205, 56%, 73%)"
-      }
+      },
+      "type": "background"
     },
     {
-      "id": "coastline",
-      "type": "fill",
-      "source": "openmaptiles",
-      "source-layer": "coastline",
-      "minzoom": 0,
       "filter": ["all"],
+      "id": "coastline",
       "layout": {
         "visibility": "visible"
       },
+      "minzoom": 0,
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "stops": [
             [1, "rgba(228, 234, 228, 1)"],
             [10, "rgba(232, 232, 232, 1)"],
             [20, "rgba(232, 232, 232, 1)"]
           ]
-        },
-        "fill-antialias": true
-      }
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "coastline",
+      "type": "fill"
     },
     {
       "filter": ["all", ["==", "$type", "Polygon"], ["in", "class", "residential", "suburb", "neighbourhood"]],
+      "id": "landuse-residential",
       "layout": {
         "visibility": "visible"
       },
@@ -46,54 +40,54 @@
         "fill-color": "hsl(47, 13%, 86%)",
         "fill-opacity": 0.7
       },
-      "id": "landuse-residential",
       "source": "openmaptiles",
       "source-layer": "landuse",
       "type": "fill"
     },
     {
       "filter": ["==", "class", "grass"],
+      "id": "landcover_grass",
       "paint": {
         "fill-color": "hsl(82, 46%, 72%)",
         "fill-opacity": 0.45
       },
-      "id": "landcover_grass",
       "source": "openmaptiles",
       "source-layer": "landcover",
       "type": "fill"
     },
     {
       "filter": ["==", "class", "wood"],
+      "id": "landcover_wood",
       "paint": {
         "fill-color": "hsl(82, 46%, 72%)",
         "fill-opacity": {
+          "base": 1,
           "stops": [
             [8, 0.6],
             [22, 1]
-          ],
-          "base": 1
+          ]
         }
       },
-      "id": "landcover_wood",
       "source": "openmaptiles",
       "source-layer": "landcover",
       "type": "fill"
     },
     {
       "filter": ["all", ["==", "$type", "Polygon"], ["!=", "intermittent", 1], ["!=", "brunnel", "tunnel"]],
+      "id": "water",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
         "fill-color": "hsl(205, 56%, 73%)"
       },
-      "id": "water",
       "source": "openmaptiles",
       "source-layer": "water",
       "type": "fill"
     },
     {
       "filter": ["all", ["==", "$type", "Polygon"], ["==", "intermittent", 1]],
+      "id": "water_intermittent",
       "layout": {
         "visibility": "visible"
       },
@@ -101,13 +95,13 @@
         "fill-color": "hsl(205, 56%, 73%)",
         "fill-opacity": 0.7
       },
-      "id": "water_intermittent",
       "source": "openmaptiles",
       "source-layer": "water",
       "type": "fill"
     },
     {
       "filter": ["==", "subclass", "ice_shelf"],
+      "id": "landcover-ice-shelf",
       "layout": {
         "visibility": "visible"
       },
@@ -115,179 +109,179 @@
         "fill-color": "hsl(47, 26%, 88%)",
         "fill-opacity": 0.8
       },
-      "id": "landcover-ice-shelf",
       "source": "openmaptiles",
       "source-layer": "landcover",
       "type": "fill"
     },
     {
       "filter": ["==", "subclass", "glacier"],
+      "id": "landcover-glacier",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
         "fill-color": "hsl(47, 22%, 94%)",
         "fill-opacity": {
+          "base": 1,
           "stops": [
             [0, 1],
             [8, 0.5]
-          ],
-          "base": 1
+          ]
         }
       },
-      "id": "landcover-glacier",
       "source": "openmaptiles",
       "source-layer": "landcover",
       "type": "fill"
     },
     {
       "filter": ["all", ["in", "class", "sand"]],
+      "id": "landcover_sand",
       "metadata": {},
       "paint": {
+        "fill-antialias": false,
         "fill-color": "rgba(232, 214, 38, 1)",
-        "fill-opacity": 0.3,
-        "fill-antialias": false
+        "fill-opacity": 0.3
       },
-      "id": "landcover_sand",
       "source": "openmaptiles",
       "source-layer": "landcover",
       "type": "fill"
     },
     {
       "filter": ["==", "class", "agriculture"],
+      "id": "landuse",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
         "fill-color": "#eae0d0"
       },
-      "id": "landuse",
       "source": "openmaptiles",
       "source-layer": "landuse",
       "type": "fill"
     },
     {
       "filter": ["==", "class", "national_park"],
+      "id": "landuse_overlay_national_park",
       "paint": {
         "fill-color": "#E1EBB0",
         "fill-opacity": {
+          "base": 1,
           "stops": [
             [5, 0],
             [9, 0.75]
-          ],
-          "base": 1
+          ]
         }
       },
-      "id": "landuse_overlay_national_park",
       "source": "openmaptiles",
       "source-layer": "landcover",
       "type": "fill"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "tunnel"]],
+      "id": "waterway-tunnel",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
-        "line-opacity": 1,
-        "line-width": {
-          "stops": [
-            [8, 1],
-            [20, 2]
-          ],
-          "base": 1.4
-        },
+        "line-color": "hsl(205, 56%, 73%)",
+        "line-dasharray": [3, 3],
         "line-gap-width": {
           "stops": [
             [12, 0],
             [20, 6]
           ]
         },
-        "line-dasharray": [3, 3],
-        "line-color": "hsl(205, 56%, 73%)"
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [8, 1],
+            [20, 2]
+          ]
+        }
       },
-      "id": "waterway-tunnel",
       "source": "openmaptiles",
       "source-layer": "waterway",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["!in", "brunnel", "tunnel", "bridge"], ["!=", "intermittent", 1]],
+      "id": "waterway",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
+        "line-color": "hsl(205, 56%, 73%)",
         "line-opacity": 1,
         "line-width": {
+          "base": 1.4,
           "stops": [
             [8, 1],
             [20, 8]
-          ],
-          "base": 1.4
-        },
-        "line-color": "hsl(205, 56%, 73%)"
+          ]
+        }
       },
-      "id": "waterway",
       "source": "openmaptiles",
       "source-layer": "waterway",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["!in", "brunnel", "tunnel", "bridge"], ["==", "intermittent", 1]],
+      "id": "waterway_intermittent",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
+        "line-color": "hsl(205, 56%, 73%)",
+        "line-dasharray": [2, 1],
         "line-opacity": 1,
         "line-width": {
+          "base": 1.4,
           "stops": [
             [8, 1],
             [20, 8]
-          ],
-          "base": 1.4
-        },
-        "line-dasharray": [2, 1],
-        "line-color": "hsl(205, 56%, 73%)"
+          ]
+        }
       },
-      "id": "waterway_intermittent",
       "source": "openmaptiles",
       "source-layer": "waterway",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "tunnel"], ["==", "class", "transit"]],
+      "id": "tunnel_railway_transit",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter"
       },
+      "minzoom": 0,
       "paint": {
+        "line-color": "hsl(34, 12%, 66%)",
+        "line-dasharray": [3, 3],
         "line-opacity": {
+          "base": 1,
           "stops": [
             [11, 0],
             [16, 1]
-          ],
-          "base": 1
-        },
-        "line-dasharray": [3, 3],
-        "line-color": "hsl(34, 12%, 66%)"
+          ]
+        }
       },
-      "id": "tunnel_railway_transit",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "type": "line",
-      "minzoom": 0
+      "type": "line"
     },
     {
+      "id": "building",
       "paint": {
+        "fill-antialias": true,
         "fill-color": "rgba(222, 211, 190, 1)",
         "fill-opacity": {
+          "base": 1,
           "stops": [
             [13, 0],
             [15, 1]
-          ],
-          "base": 1
+          ]
         },
-        "fill-antialias": true,
         "fill-outline-color": {
           "stops": [
             [15, "rgba(212, 177, 146, 0)"],
@@ -295,663 +289,663 @@
           ]
         }
       },
-      "id": "building",
       "source": "openmaptiles",
       "source-layer": "building",
       "type": "fill"
     },
     {
       "filter": ["==", "$type", "Point"],
+      "id": "housenumber",
       "layout": {
         "text-field": "{housenumber}",
         "text-font": ["Noto Sans Regular"],
         "text-size": 10
       },
+      "minzoom": 17,
       "paint": {
         "text-color": "rgba(212, 177, 146, 1)"
       },
-      "id": "housenumber",
       "source": "openmaptiles",
       "source-layer": "housenumber",
-      "type": "symbol",
-      "minzoom": 17
+      "type": "symbol"
     },
     {
       "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "pier"]],
+      "id": "road_area_pier",
       "layout": {
         "visibility": "visible"
       },
       "metadata": {},
       "paint": {
-        "fill-color": "hsl(47, 26%, 88%)",
-        "fill-antialias": true
+        "fill-antialias": true,
+        "fill-color": "hsl(47, 26%, 88%)"
       },
-      "id": "road_area_pier",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "fill"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "pier"]],
+      "id": "road_pier",
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
       "metadata": {},
       "paint": {
+        "line-color": "hsl(47, 26%, 88%)",
         "line-width": {
+          "base": 1.2,
           "stops": [
             [15, 1],
             [17, 4]
-          ],
-          "base": 1.2
-        },
-        "line-color": "hsl(47, 26%, 88%)"
+          ]
+        }
       },
-      "id": "road_pier",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "Polygon"], ["in", "brunnel", "bridge"]],
+      "id": "road_bridge_area",
       "layout": {},
       "paint": {
         "fill-color": "hsl(47, 26%, 88%)",
         "fill-opacity": 0.5
       },
-      "id": "road_bridge_area",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "fill"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "path", "track"]],
+      "id": "road_path",
       "layout": {
         "line-cap": "square",
         "line-join": "bevel"
       },
       "paint": {
+        "line-color": "hsl(0, 0%, 97%)",
+        "line-dasharray": [1, 1],
         "line-width": {
+          "base": 1.55,
           "stops": [
             [4, 0.25],
             [20, 10]
-          ],
-          "base": 1.55
-        },
-        "line-dasharray": [1, 1],
-        "line-color": "hsl(0, 0%, 97%)"
+          ]
+        }
       },
-      "id": "road_path",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "minor", "service"]],
+      "id": "road_minor",
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
+      "minzoom": 13,
       "paint": {
+        "line-color": "hsl(0, 0%, 97%)",
         "line-width": {
+          "base": 1.55,
           "stops": [
             [4, 0.25],
             [20, 30]
-          ],
-          "base": 1.55
-        },
-        "line-color": "hsl(0, 0%, 97%)"
+          ]
+        }
       },
-      "id": "road_minor",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "type": "line",
-      "minzoom": 13
+      "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "tunnel"], ["==", "class", "minor_road"]],
+      "id": "tunnel_minor",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter"
       },
       "paint": {
+        "line-color": "#efefef",
+        "line-dasharray": [0.36, 0.18],
         "line-width": {
+          "base": 1.55,
           "stops": [
             [4, 0.25],
             [20, 30]
-          ],
-          "base": 1.55
-        },
-        "line-dasharray": [0.36, 0.18],
-        "line-color": "#efefef"
+          ]
+        }
       },
-      "id": "tunnel_minor",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "tunnel"], ["in", "class", "primary", "secondary", "tertiary", "trunk"]],
+      "id": "tunnel_major",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter"
       },
       "paint": {
+        "line-color": "#fff",
+        "line-dasharray": [0.28, 0.14],
         "line-width": {
+          "base": 1.4,
           "stops": [
             [6, 0.5],
             [20, 30]
-          ],
-          "base": 1.4
-        },
-        "line-dasharray": [0.28, 0.14],
-        "line-color": "#fff"
+          ]
+        }
       },
-      "id": "tunnel_major",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "Polygon"], ["in", "class", "runway", "taxiway"]],
+      "id": "aeroway-area",
       "layout": {
         "visibility": "visible"
       },
       "metadata": {
         "mapbox:group": "1444849345966.4436"
       },
+      "minzoom": 4,
       "paint": {
         "fill-color": "rgba(255, 255, 255, 1)",
         "fill-opacity": {
+          "base": 1,
           "stops": [
             [13, 0],
             [14, 1]
-          ],
-          "base": 1
+          ]
         }
       },
-      "id": "aeroway-area",
       "source": "openmaptiles",
       "source-layer": "aeroway",
-      "type": "fill",
-      "minzoom": 4
+      "type": "fill"
     },
     {
       "filter": ["all", ["in", "class", "taxiway"], ["==", "$type", "LineString"]],
+      "id": "aeroway-taxiway",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
       "metadata": {
         "mapbox:group": "1444849345966.4436"
       },
+      "minzoom": 12,
       "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
         "line-opacity": 1,
         "line-width": {
+          "base": 1.5,
           "stops": [
             [12, 1],
             [17, 10]
-          ],
-          "base": 1.5
-        },
-        "line-color": "rgba(255, 255, 255, 1)"
+          ]
+        }
       },
-      "id": "aeroway-taxiway",
       "source": "openmaptiles",
       "source-layer": "aeroway",
-      "type": "line",
-      "minzoom": 12
+      "type": "line"
     },
     {
       "filter": ["all", ["in", "class", "runway"], ["==", "$type", "LineString"]],
+      "id": "aeroway-runway",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
       "metadata": {
         "mapbox:group": "1444849345966.4436"
       },
+      "minzoom": 4,
       "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
         "line-opacity": 1,
         "line-width": {
+          "base": 1.5,
           "stops": [
             [11, 4],
             [17, 50]
-          ],
-          "base": 1.5
-        },
-        "line-color": "rgba(255, 255, 255, 1)"
+          ]
+        }
       },
-      "id": "aeroway-runway",
       "source": "openmaptiles",
       "source-layer": "aeroway",
-      "type": "line",
-      "minzoom": 4
+      "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "trunk", "primary"]],
+      "id": "road_trunk_primary",
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
       "paint": {
+        "line-color": "#fff",
         "line-width": {
+          "base": 1.4,
           "stops": [
             [6, 0.5],
             [20, 30]
-          ],
-          "base": 1.4
-        },
-        "line-color": "#fff"
+          ]
+        }
       },
-      "id": "road_trunk_primary",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "secondary", "tertiary"]],
+      "id": "road_secondary_tertiary",
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
       "paint": {
+        "line-color": "#fff",
         "line-width": {
+          "base": 1.4,
           "stops": [
             [6, 0.5],
             [20, 20]
-          ],
-          "base": 1.4
-        },
-        "line-color": "#fff"
+          ]
+        }
       },
-      "id": "road_secondary_tertiary",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "class", "motorway"]],
+      "id": "road_major_motorway",
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
       "paint": {
+        "line-color": "hsl(0, 0%, 100%)",
+        "line-offset": 0,
         "line-width": {
+          "base": 1.4,
           "stops": [
             [8, 1],
             [16, 10]
-          ],
-          "base": 1.4
-        },
-        "line-offset": 0,
-        "line-color": "hsl(0, 0%, 100%)"
+          ]
+        }
       },
-      "id": "road_major_motorway",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "class", "transit"], ["!=", "brunnel", "tunnel"]],
+      "id": "railway-transit",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
+        "line-color": "hsl(34, 12%, 66%)",
         "line-opacity": {
+          "base": 1,
           "stops": [
             [11, 0],
             [16, 1]
-          ],
-          "base": 1
-        },
-        "line-color": "hsl(34, 12%, 66%)"
+          ]
+        }
       },
-      "id": "railway-transit",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["==", "class", "rail"],
+      "id": "railway",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
+        "line-color": "hsl(34, 12%, 66%)",
         "line-opacity": {
+          "base": 1,
           "stops": [
             [11, 0],
             [16, 1]
-          ],
-          "base": 1
-        },
-        "line-color": "hsl(34, 12%, 66%)"
+          ]
+        }
       },
-      "id": "railway",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter"
-      },
-      "paint": {
-        "line-width": {
-          "stops": [
-            [12, 0.5],
-            [20, 10]
-          ],
-          "base": 1.6
-        },
-        "line-gap-width": {
-          "stops": [
-            [4, 0.25],
-            [20, 30]
-          ],
-          "base": 1.55
-        },
-        "line-color": "#bbbbbb"
-      },
       "id": "waterway-bridge-case",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "#bbbbbb",
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 30]
+          ]
+        },
+        "line-width": {
+          "base": 1.6,
+          "stops": [
+            [12, 0.5],
+            [20, 10]
+          ]
+        }
+      },
       "source": "openmaptiles",
       "source-layer": "waterway",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "bridge"]],
+      "id": "waterway-bridge",
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
       "paint": {
+        "line-color": "hsl(205, 56%, 73%)",
         "line-width": {
+          "base": 1.55,
           "stops": [
             [4, 0.25],
             [20, 30]
-          ],
-          "base": 1.55
-        },
-        "line-color": "hsl(205, 56%, 73%)"
+          ]
+        }
       },
-      "id": "waterway-bridge",
       "source": "openmaptiles",
       "source-layer": "waterway",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "bridge"], ["==", "class", "minor_road"]],
+      "id": "bridge_minor case",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter"
       },
       "paint": {
-        "line-width": {
-          "stops": [
-            [12, 0.5],
-            [20, 10]
-          ],
-          "base": 1.6
-        },
+        "line-color": "#dedede",
         "line-gap-width": {
+          "base": 1.55,
           "stops": [
             [4, 0.25],
             [20, 30]
-          ],
-          "base": 1.55
+          ]
         },
-        "line-color": "#dedede"
+        "line-width": {
+          "base": 1.6,
+          "stops": [
+            [12, 0.5],
+            [20, 10]
+          ]
+        }
       },
-      "id": "bridge_minor case",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "bridge"], ["in", "class", "primary", "secondary", "tertiary", "trunk"]],
+      "id": "bridge_major case",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter"
       },
       "paint": {
-        "line-width": {
-          "stops": [
-            [12, 0.5],
-            [20, 10]
-          ],
-          "base": 1.6
-        },
+        "line-color": "#dedede",
         "line-gap-width": {
+          "base": 1.55,
           "stops": [
             [4, 0.25],
             [20, 30]
-          ],
-          "base": 1.55
+          ]
         },
-        "line-color": "#dedede"
+        "line-width": {
+          "base": 1.6,
+          "stops": [
+            [12, 0.5],
+            [20, 10]
+          ]
+        }
       },
-      "id": "bridge_major case",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "bridge"], ["==", "class", "minor_road"]],
+      "id": "bridge_minor",
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
       "paint": {
+        "line-color": "#efefef",
         "line-width": {
+          "base": 1.55,
           "stops": [
             [4, 0.25],
             [20, 30]
-          ],
-          "base": 1.55
-        },
-        "line-color": "#efefef"
+          ]
+        }
       },
-      "id": "bridge_minor",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "brunnel", "bridge"], ["in", "class", "primary", "secondary", "tertiary", "trunk"]],
+      "id": "bridge_major",
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
       "paint": {
+        "line-color": "#fff",
         "line-width": {
+          "base": 1.4,
           "stops": [
             [6, 0.5],
             [20, 30]
-          ],
-          "base": 1.4
-        },
-        "line-color": "#fff"
+          ]
+        }
       },
-      "id": "bridge_major",
       "source": "openmaptiles",
       "source-layer": "transportation",
       "type": "line"
     },
     {
       "filter": ["in", "admin_level", 4, 6, 8],
+      "id": "admin_sub",
       "layout": {
         "visibility": "visible"
       },
       "paint": {
-        "line-dasharray": [2, 1],
-        "line-color": "hsla(0, 0%, 60%, 0.5)"
+        "line-color": "hsla(0, 0%, 60%, 0.5)",
+        "line-dasharray": [2, 1]
       },
-      "id": "admin_sub",
       "source": "openmaptiles",
       "source-layer": "boundary",
       "type": "line"
     },
     {
       "filter": ["all", ["<=", "admin_level", 2], ["==", "$type", "LineString"], ["!has", "claimed_by"]],
+      "id": "admin_country_z0-4",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
       "maxzoom": 5,
+      "minzoom": 0,
       "paint": {
+        "line-color": "hsl(0, 0%, 60%)",
         "line-width": {
+          "base": 1.3,
           "stops": [
             [3, 0.5],
             [22, 15]
-          ],
-          "base": 1.3
-        },
-        "line-color": "hsl(0, 0%, 60%)"
+          ]
+        }
       },
-      "id": "admin_country_z0-4",
       "source": "openmaptiles",
       "source-layer": "boundary",
-      "type": "line",
-      "minzoom": 0
+      "type": "line"
     },
     {
       "filter": ["all", ["<=", "admin_level", 2], ["==", "$type", "LineString"]],
+      "id": "admin_country_z5-",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
+      "minzoom": 5,
       "paint": {
+        "line-color": "hsl(0, 0%, 60%)",
         "line-width": {
+          "base": 1.3,
           "stops": [
             [3, 0.5],
             [22, 15]
-          ],
-          "base": 1.3
-        },
-        "line-color": "hsl(0, 0%, 60%)"
+          ]
+        }
       },
-      "id": "admin_country_z5-",
       "source": "openmaptiles",
       "source-layer": "boundary",
-      "type": "line",
-      "minzoom": 5
+      "type": "line"
     },
     {
       "filter": ["all", ["==", "$type", "Point"], ["==", "rank", 1]],
+      "id": "poi_label",
       "layout": {
-        "text-max-width": 8,
-        "visibility": "visible",
-        "text-field": ["get", "name"],
-        "text-offset": [0, 0.5],
-        "text-anchor": "top",
-        "text-size": 11,
         "icon-size": 1,
-        "text-font": ["Noto Sans Regular"]
+        "text-anchor": "top",
+        "text-field": ["get", "name"],
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 8,
+        "text-offset": [0, 0.5],
+        "text-size": 11,
+        "visibility": "visible"
       },
+      "minzoom": 14,
       "paint": {
+        "text-color": "#666",
         "text-halo-blur": 1,
         "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-color": "#666",
         "text-halo-width": 1
       },
-      "id": "poi_label",
       "source": "openmaptiles",
       "source-layer": "poi",
-      "type": "symbol",
-      "minzoom": 14
+      "type": "symbol"
     },
     {
+      "id": "airport-label",
       "layout": {
-        "text-max-width": 8,
-        "visibility": "visible",
-        "text-field": ["get", "name"],
-        "text-offset": [0, 0.5],
-        "text-anchor": "top",
-        "text-size": 11,
         "icon-size": 1,
-        "text-font": ["Noto Sans Regular"]
+        "text-anchor": "top",
+        "text-field": ["get", "name"],
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 8,
+        "text-offset": [0, 0.5],
+        "text-size": 11,
+        "visibility": "visible"
       },
+      "minzoom": 10,
       "paint": {
+        "text-color": "#666",
         "text-halo-blur": 1,
         "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-color": "#666",
         "text-halo-width": 1
       },
-      "id": "airport-label",
       "source": "openmaptiles",
       "source-layer": "aerodrome_label",
-      "type": "symbol",
-      "minzoom": 10
+      "type": "symbol"
     },
     {
       "filter": ["==", "$type", "LineString"],
+      "id": "road_major_label",
       "layout": {
-        "text-transform": "uppercase",
-        "text-letter-spacing": 0.1,
-        "visibility": "visible",
+        "symbol-placement": "line",
         "text-field": ["get", "name"],
+        "text-font": ["Noto Sans Regular"],
+        "text-letter-spacing": 0.1,
         "text-rotation-alignment": "map",
         "text-size": {
+          "base": 1.4,
           "stops": [
             [10, 8],
             [20, 14]
-          ],
-          "base": 1.4
+          ]
         },
-        "symbol-placement": "line",
-        "text-font": ["Noto Sans Regular"]
+        "text-transform": "uppercase",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "text-halo-width": 2,
+        "text-color": "#000",
         "text-halo-color": "hsl(0, 0%, 100%)",
-        "text-color": "#000"
+        "text-halo-width": 2
       },
-      "id": "road_major_label",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "type": "symbol",
-      "minzoom": 13
+      "type": "symbol"
     },
     {
       "filter": ["all", ["==", "$type", "Point"], ["!in", "class", "city", "state", "country", "continent"]],
+      "id": "place_label_other",
       "layout": {
-        "text-max-width": 6,
-        "visibility": "visible",
+        "text-anchor": "center",
         "text-field": ["get", "name"],
         "text-font": ["Noto Sans Regular"],
-        "text-anchor": "center",
+        "text-max-width": 6,
         "text-size": {
           "stops": [
             [6, 10],
             [12, 14]
           ]
-        }
+        },
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
+        "text-color": "hsl(0, 0%, 25%)",
         "text-halo-blur": 0,
         "text-halo-color": "hsl(0, 0%, 100%)",
-        "text-color": "hsl(0, 0%, 25%)",
         "text-halo-width": 2
       },
-      "id": "place_label_other",
       "source": "openmaptiles",
       "source-layer": "place",
-      "type": "symbol",
-      "minzoom": 8
+      "type": "symbol"
     },
     {
       "filter": ["all", ["==", "$type", "Point"], ["==", "class", "city"]],
+      "id": "place_label_city",
       "layout": {
-        "text-max-width": 10,
         "text-field": ["get", "name"],
         "text-font": ["Noto Sans Regular"],
+        "text-max-width": 10,
         "text-size": {
           "stops": [
             [3, 12],
@@ -961,80 +955,86 @@
       },
       "maxzoom": 16,
       "paint": {
+        "text-color": "hsl(0, 0%, 0%)",
         "text-halo-blur": 0,
         "text-halo-color": "hsla(0, 0%, 100%, 0.75)",
-        "text-color": "hsl(0, 0%, 0%)",
         "text-halo-width": 2
       },
-      "id": "place_label_city",
       "source": "openmaptiles",
       "source-layer": "place",
       "type": "symbol"
     },
     {
       "filter": ["all", ["==", "$type", "Point"], ["==", "class", "country"], ["!has", "iso_a2"]],
+      "id": "country_label-other",
       "layout": {
-        "text-max-width": 10,
-        "visibility": "visible",
         "text-field": ["get", "name"],
         "text-font": ["Noto Sans Regular"],
+        "text-max-width": 10,
         "text-size": {
           "stops": [
             [3, 12],
             [8, 22]
           ]
-        }
+        },
+        "visibility": "visible"
       },
       "maxzoom": 12,
       "paint": {
+        "text-color": "hsl(0, 0%, 13%)",
         "text-halo-blur": 0,
         "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-color": "hsl(0, 0%, 13%)",
         "text-halo-width": 2
       },
-      "id": "country_label-other",
       "source": "openmaptiles",
       "source-layer": "place",
       "type": "symbol"
     },
     {
       "filter": ["all", ["==", "$type", "Point"], ["==", "class", "country"], ["has", "iso_a2"]],
+      "id": "country_label",
       "layout": {
-        "text-max-width": 10,
-        "visibility": "visible",
         "text-field": ["get", "name"],
         "text-font": ["Noto Sans Bold"],
+        "text-max-width": 10,
         "text-size": {
           "stops": [
             [3, 12],
             [8, 22]
           ]
-        }
+        },
+        "visibility": "visible"
       },
       "maxzoom": 12,
       "paint": {
+        "text-color": "hsl(0, 0%, 13%)",
         "text-halo-blur": 0,
         "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-color": "hsl(0, 0%, 13%)",
         "text-halo-width": 2
       },
-      "id": "country_label",
       "source": "openmaptiles",
       "source-layer": "place",
       "type": "symbol"
     }
   ],
   "metadata": {
-    "openmaptiles:version": "3.x",
-    "maputnik:renderer": "mbgljs",
-    "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t",
-    "mapbox:type": "template",
-    "openmaptiles:mapbox:owner": "openmaptiles",
+    "license": "https://github.com/openmaptiles/maptiler-basic-gl-style/blob/master/LICENSE.md",
     "mapbox:autocomposite": false,
-    "source": "https://github.com/openmaptiles/maptiler-basic-gl-style",
-    "license": "https://github.com/openmaptiles/maptiler-basic-gl-style/blob/master/LICENSE.md"
+    "mapbox:type": "template",
+    "maputnik:renderer": "mbgljs",
+    "openmaptiles:mapbox:owner": "openmaptiles",
+    "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t",
+    "openmaptiles:version": "3.x",
+    "source": "https://github.com/openmaptiles/maptiler-basic-gl-style"
   },
-  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+  "name": "basic",
+  "sources": {
+    "openmaptiles": {
+      "attribution": "© 2022 Toitū Te Whenua © OpenMapTiles - CC BY 4.0",
+      "type": "vector",
+      "url": "/v1/tiles/topographic/EPSG:3857/tile.json"
+    }
+  },
   "sprite": "",
-  "id": "st_basic"
+  "version": 8
 }

--- a/config/style/positron.json
+++ b/config/style/positron.json
@@ -1,64 +1,52 @@
 {
-  "version": 8,
-  "name": "Positron",
-  "sources": {
-    "LINZ Basemaps": {
-      "type": "vector",
-      "url": "/v1/tiles/topographic/EPSG:3857/tile.json",
-      "attribution": "© 2022 Toitū Te Whenua © OpenMapTiles - CC BY 4.0"
-    }
-  },
-  "sprite": "/v1/sprites/topographic",
   "glyphs": "/v1/fonts/{fontstack}/{range}.pbf",
+  "id": "st_positron",
   "layers": [
     {
       "id": "background",
-      "type": "background",
-      "paint": { "background-color": "rgb(194, 200, 202)" }
+      "paint": { "background-color": "rgb(194, 200, 202)" },
+      "type": "background"
     },
     {
       "id": "coastline-fill",
-      "type": "fill",
+      "paint": { "fill-color": "rgb(242,243,240)" },
       "source": "LINZ Basemaps",
       "source-layer": "coastline",
-      "paint": { "fill-color": "rgb(242,243,240)" }
+      "type": "fill"
     },
     {
+      "filter": ["==", "$type", "Polygon"],
       "id": "park",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "paint": { "fill-color": "rgb(230, 233, 229)" },
       "source": "LINZ Basemaps",
       "source-layer": "park",
-      "filter": ["==", "$type", "Polygon"],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgb(230, 233, 229)" }
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "$type", "Polygon"], ["!=", "brunnel", "tunnel"]],
       "id": "water",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "paint": { "fill-antialias": true, "fill-color": "rgb(194, 200, 202)" },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "filter": ["all", ["==", "$type", "Polygon"], ["!=", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-antialias": true, "fill-color": "rgb(194, 200, 202)" }
+      "type": "fill"
     },
     {
-      "id": "landcover_ice_shelf",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "maxzoom": 8,
       "filter": ["all", ["==", "$type", "Polygon"], ["==", "subclass", "ice_shelf"]],
+      "id": "landcover_ice_shelf",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "hsl(0, 0%, 98%)", "fill-opacity": 0.7 }
-    },
-    {
-      "id": "landcover_glacier",
-      "type": "fill",
+      "maxzoom": 8,
+      "paint": { "fill-color": "hsl(0, 0%, 98%)", "fill-opacity": 0.7 },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "maxzoom": 8,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "$type", "Polygon"], ["==", "subclass", "glacier"]],
+      "id": "landcover_glacier",
       "layout": { "visibility": "visible" },
+      "maxzoom": 8,
       "paint": {
         "fill-color": "hsl(0, 0%, 98%)",
         "fill-opacity": {
@@ -68,16 +56,16 @@
             [8, 0.5]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
     },
     {
-      "id": "landuse_residential",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "maxzoom": 16,
       "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "residential"]],
+      "id": "landuse_residential",
       "layout": { "visibility": "visible" },
+      "maxzoom": 16,
       "paint": {
         "fill-color": "rgb(234, 234, 230)",
         "fill-opacity": {
@@ -87,16 +75,16 @@
             [9, 0.6]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
-      "id": "landcover_wood",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 10,
       "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "wood"]],
+      "id": "landcover_wood",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "fill-color": "rgb(220,224,220)",
         "fill-opacity": {
@@ -106,23 +94,23 @@
             [12, 1]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
     },
     {
+      "filter": ["==", "$type", "LineString"],
       "id": "waterway",
-      "type": "line",
+      "layout": { "visibility": "visible" },
+      "paint": { "line-color": "hsl(195, 17%, 78%)" },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "filter": ["==", "$type", "LineString"],
-      "layout": { "visibility": "visible" },
-      "paint": { "line-color": "hsl(195, 17%, 78%)" }
+      "type": "line"
     },
     {
-      "id": "water_name",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "water_name",
       "filter": ["==", "$type", "LineString"],
+      "id": "water_name",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 500,
@@ -136,14 +124,14 @@
         "text-halo-blur": 1,
         "text-halo-color": "rgb(242,243,240)",
         "text-halo-width": 1
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "water_name",
+      "type": "symbol"
     },
     {
-      "id": "waterway_label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
       "filter": ["==", "$type", "LineString"],
+      "id": "waterway_label",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 500,
@@ -157,33 +145,33 @@
         "text-halo-blur": 1,
         "text-halo-color": "rgb(242,243,240)",
         "text-halo-width": 1
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "symbol"
     },
     {
       "id": "building",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "building",
       "minzoom": 12,
       "paint": {
         "fill-antialias": true,
         "fill-color": "rgb(234, 234, 229)",
         "fill-outline-color": "rgb(219, 219, 218)"
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "building",
+      "type": "fill"
     },
     {
-      "id": "tunnel_motorway_casing",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 6,
       "filter": ["all", ["==", ["geometry-type"], "LineString"], ["all", ["==", ["get", "brunnel"], "tunnel"], ["!=", ["get", "class"], "motorway"]]],
+      "id": "tunnel_motorway_casing",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 6,
       "paint": {
         "line-color": "rgb(213, 213, 213)",
         "line-opacity": 1,
@@ -195,21 +183,21 @@
             [20, 40]
           ]
         }
-      }
-    },
-    {
-      "id": "tunnel_motorway_inner",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 6,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", ["geometry-type"], "LineString"], ["all", ["==", ["get", "brunnel"], "tunnel"], ["==", ["get", "class"], "motorway"]]],
+      "id": "tunnel_motorway_inner",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 6,
       "paint": {
         "line-color": "rgb(234,234,234)",
         "line-width": {
@@ -220,21 +208,21 @@
             [20, 30]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
-      "id": "aeroway-taxiway",
-      "type": "line",
-      "metadata": { "mapbox:group": "1444849345966.4436" },
-      "source": "LINZ Basemaps",
-      "source-layer": "aeroway",
-      "minzoom": 12,
       "filter": ["all", ["in", "class", "taxiway"]],
+      "id": "aeroway-taxiway",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "1444849345966.4436" },
+      "minzoom": 12,
       "paint": {
         "line-color": "hsl(0, 0%, 88%)",
         "line-opacity": 1,
@@ -245,21 +233,21 @@
             [20, 20]
           ]
         }
-      }
-    },
-    {
-      "id": "aeroway-runway-casing",
-      "type": "line",
-      "metadata": { "mapbox:group": "1444849345966.4436" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "aeroway",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["in", "class", "runway"]],
+      "id": "aeroway-runway-casing",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "1444849345966.4436" },
+      "minzoom": 11,
       "paint": {
         "line-color": "hsl(0, 0%, 88%)",
         "line-opacity": 1,
@@ -270,17 +258,17 @@
             [17, 55]
           ]
         }
-      }
-    },
-    {
-      "id": "aeroway-area",
-      "type": "fill",
-      "metadata": { "mapbox:group": "1444849345966.4436" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "aeroway",
-      "minzoom": 4,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "Polygon"], ["in", "class", "runway", "taxiway"]],
+      "id": "aeroway-area",
       "layout": { "visibility": "visible" },
+      "metadata": { "mapbox:group": "1444849345966.4436" },
+      "minzoom": 4,
       "paint": {
         "fill-color": "rgba(255, 255, 255, 1)",
         "fill-opacity": {
@@ -290,21 +278,21 @@
             [14, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "aeroway-runway",
-      "type": "line",
-      "metadata": { "mapbox:group": "1444849345966.4436" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "aeroway",
-      "minzoom": 11,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["in", "class", "runway"], ["==", "$type", "LineString"]],
+      "id": "aeroway-runway",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "1444849345966.4436" },
+      "minzoom": 11,
       "paint": {
         "line-color": "rgba(255, 255, 255, 1)",
         "line-opacity": 1,
@@ -315,26 +303,26 @@
             [17, 50]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "line"
     },
     {
-      "id": "road_area_pier",
-      "type": "fill",
-      "metadata": {},
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
       "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "pier"]],
+      "id": "road_area_pier",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-antialias": true, "fill-color": "rgb(242,243,240)" }
-    },
-    {
-      "id": "road_pier",
-      "type": "line",
       "metadata": {},
+      "paint": { "fill-antialias": true, "fill-color": "rgb(242,243,240)" },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "pier"]],
+      "id": "road_pier",
       "layout": { "line-cap": "round", "line-join": "round" },
+      "metadata": {},
       "paint": {
         "line-color": "rgb(242,243,240)",
         "line-width": {
@@ -344,20 +332,20 @@
             [17, 4]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_path",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "class", "path"]],
+      "id": "highway_path",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
       "paint": {
         "line-color": "rgb(234, 234, 234)",
         "line-opacity": 0.9,
@@ -368,21 +356,21 @@
             [20, 10]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_minor",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "minor", "service", "track"]],
+      "id": "highway_minor",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 8,
       "paint": {
         "line-color": "hsl(0, 0%, 88%)",
         "line-opacity": 0.9,
@@ -393,21 +381,21 @@
             [20, 20]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_major_casing",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "primary", "secondary", "tertiary", "trunk"]],
+      "id": "highway_major_casing",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 11,
       "paint": {
         "line-color": "rgb(213, 213, 213)",
         "line-dasharray": [12, 0],
@@ -418,45 +406,21 @@
             [20, 23]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_major_inner-copy",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["in", "class", "primary", "secondary", "tertiary", "trunk"]],
+      "id": "highway_major_inner-copy",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
-      "paint": {
-        "line-color": "#fff",
-        "line-width": {
-          "base": 1.3,
-          "stops": [
-            [10, 2],
-            [20, 20]
-          ]
-        }
-      }
-    },
-    {
-      "id": "highway_major_inner",
-      "type": "line",
       "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
       "minzoom": 11,
-      "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "primary", "secondary", "tertiary", "trunk"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
       "paint": {
         "line-color": "#fff",
         "line-width": {
@@ -466,36 +430,60 @@
             [20, 20]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_major_subtle",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "maxzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "primary", "secondary", "tertiary", "trunk"]],
+      "id": "highway_major_inner",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
-      "paint": { "line-color": "hsla(0, 0%, 85%, 0.69)", "line-width": 2 }
-    },
-    {
-      "id": "highway_motorway_casing",
-      "type": "line",
       "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 11,
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [10, 2],
+            [20, 20]
+          ]
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 6,
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "primary", "secondary", "tertiary", "trunk"]],
+      "id": "highway_major_subtle",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "maxzoom": 11,
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "paint": { "line-color": "hsla(0, 0%, 85%, 0.69)", "line-width": 2 },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["all", ["!in", "brunnel", "bridge", "tunnel"], ["==", "class", "motorway"]]],
+      "id": "highway_motorway_casing",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 6,
       "paint": {
         "line-color": "rgb(213, 213, 213)",
         "line-dasharray": [2, 0],
@@ -508,21 +496,21 @@
             [20, 40]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_motorway_inner",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 6,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["all", ["!in", "brunnel", "bridge", "tunnel"], ["==", "class", "motorway"]]],
+      "id": "highway_motorway_inner",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 6,
       "paint": {
         "line-color": {
           "base": 1,
@@ -539,21 +527,21 @@
             [20, 30]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_motorway_subtle",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "maxzoom": 6,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "class", "motorway"]],
+      "id": "highway_motorway_subtle",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "maxzoom": 6,
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
       "paint": {
         "line-color": "hsla(0, 0%, 85%, 0.53)",
         "line-width": {
@@ -563,69 +551,69 @@
             [6, 1.3]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
+      "filter": ["all", ["==", "$type", "LineString"], ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]],
       "id": "railway_transit",
-      "type": "line",
+      "layout": { "line-join": "round", "visibility": "visible" },
       "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 16,
+      "paint": { "line-color": "#dddddd", "line-width": 3 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 16,
-      "filter": ["all", ["==", "$type", "LineString"], ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]],
-      "layout": { "line-join": "round", "visibility": "visible" },
-      "paint": { "line-color": "#dddddd", "line-width": 3 }
+      "type": "line"
     },
     {
+      "filter": ["all", ["==", "$type", "LineString"], ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]],
       "id": "railway_transit_dashline",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 16,
-      "filter": ["all", ["==", "$type", "LineString"], ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]],
       "layout": { "line-join": "round", "visibility": "visible" },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 16,
       "paint": {
         "line-color": "#fafafa",
         "line-dasharray": [3, 3],
         "line-width": 2
-      }
-    },
-    {
-      "id": "railway_service",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 16,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["all", ["==", "class", "rail"], ["has", "service"]]],
+      "id": "railway_service",
       "layout": { "line-join": "round", "visibility": "visible" },
-      "paint": { "line-color": "#dddddd", "line-width": 3 }
-    },
-    {
-      "id": "railway_service_dashline",
-      "type": "line",
       "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 16,
+      "paint": { "line-color": "#dddddd", "line-width": 3 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 16,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["==", "class", "rail"], ["has", "service"]],
+      "id": "railway_service_dashline",
       "layout": { "line-join": "round", "visibility": "visible" },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 16,
       "paint": {
         "line-color": "#fafafa",
         "line-dasharray": [3, 3],
         "line-width": 2
-      }
-    },
-    {
-      "id": "railway",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["all", ["!has", "service"], ["==", "class", "rail"]]],
+      "id": "railway",
       "layout": { "line-join": "round", "visibility": "visible" },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 13,
       "paint": {
         "line-color": "#dddddd",
         "line-width": {
@@ -635,17 +623,17 @@
             [20, 7]
           ]
         }
-      }
-    },
-    {
-      "id": "railway_dashline",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["all", ["!has", "service"], ["==", "class", "rail"]]],
+      "id": "railway_dashline",
       "layout": { "line-join": "round", "visibility": "visible" },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 13,
       "paint": {
         "line-color": "#fafafa",
         "line-dasharray": [3, 3],
@@ -656,21 +644,21 @@
             [20, 6]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_motorway_bridge_casing",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 6,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["all", ["==", "brunnel", "bridge"], ["==", "class", "motorway"]]],
+      "id": "highway_motorway_bridge_casing",
       "layout": {
         "line-cap": "butt",
         "line-join": "miter",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 6,
       "paint": {
         "line-color": "rgb(213, 213, 213)",
         "line-dasharray": [2, 0],
@@ -683,21 +671,21 @@
             [20, 45]
           ]
         }
-      }
-    },
-    {
-      "id": "highway_motorway_bridge_inner",
-      "type": "line",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 6,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "$type", "LineString"], ["all", ["==", "brunnel", "bridge"], ["==", "class", "motorway"]]],
+      "id": "highway_motorway_bridge_inner",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "minzoom": 6,
       "paint": {
         "line-color": {
           "base": 1,
@@ -714,14 +702,14 @@
             [20, 30]
           ]
         }
-      }
-    },
-    {
-      "id": "road_label_highway",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["in", "class", "motorway", " highway"], ["==", "$type", "LineString"]],
+      "id": "road_label_highway",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 350,
@@ -740,14 +728,14 @@
         "text-halo-color": "#fff",
         "text-halo-width": 2,
         "text-translate": [0, 0]
-      }
-    },
-    {
-      "id": "road_label_other",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["!=", "class", "motorway"], ["==", "$type", "LineString"]],
+      "id": "road_label_other",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 350,
@@ -766,15 +754,14 @@
         "text-halo-color": "#fff",
         "text-halo-width": 2,
         "text-translate": [0, 0]
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
     },
     {
-      "id": "highway_name_motorway",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation_name",
       "filter": ["all", ["==", "$type", "LineString"], ["==", "class", "motorway"]],
+      "id": "highway_name_motorway",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 350,
@@ -785,21 +772,21 @@
         "text-size": 10,
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
       "paint": {
         "text-color": "rgb(117, 129, 145)",
         "text-halo-blur": 1,
         "text-halo-color": "hsl(0, 0%, 100%)",
         "text-halo-width": 1,
         "text-translate": [0, 2]
-      }
-    },
-    {
-      "id": "highway_name_other",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation_name",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["!=", "class", "motorway"], ["==", "$type", "LineString"]],
+      "id": "highway_name_other",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 350,
@@ -812,26 +799,27 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
       "paint": {
         "text-color": "#bbb",
         "text-halo-blur": 1,
         "text-halo-color": "#fff",
         "text-halo-width": 2,
         "text-translate": [0, 0]
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation_name",
+      "type": "symbol"
     },
     {
-      "id": "boundary_state",
-      "type": "line",
-      "metadata": { "mapbox:group": "a14c9607bc7954ba1df7205bf660433f" },
-      "source": "LINZ Basemaps",
-      "source-layer": "boundary",
       "filter": ["==", "admin_level", 4],
+      "id": "boundary_state",
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
+      "metadata": { "mapbox:group": "a14c9607bc7954ba1df7205bf660433f" },
       "paint": {
         "line-blur": 0.4,
         "line-color": "rgb(230, 204, 207)",
@@ -844,17 +832,17 @@
             [22, 15]
           ]
         }
-      }
-    },
-    {
-      "id": "boundary_country_z0-4",
-      "type": "line",
-      "metadata": { "mapbox:group": "a14c9607bc7954ba1df7205bf660433f" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "boundary",
-      "maxzoom": 5,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "admin_level", 2], ["!has", "claimed_by"]],
+      "id": "boundary_country_z0-4",
       "layout": { "line-cap": "round", "line-join": "round" },
+      "maxzoom": 5,
+      "metadata": { "mapbox:group": "a14c9607bc7954ba1df7205bf660433f" },
       "paint": {
         "line-blur": {
           "base": 1,
@@ -872,17 +860,17 @@
             [22, 20]
           ]
         }
-      }
-    },
-    {
-      "id": "boundary_country_z5-",
-      "type": "line",
-      "metadata": { "mapbox:group": "a14c9607bc7954ba1df7205bf660433f" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "boundary",
-      "minzoom": 5,
+      "type": "line"
+    },
+    {
       "filter": ["==", "admin_level", 2],
+      "id": "boundary_country_z5-",
       "layout": { "line-cap": "round", "line-join": "round" },
+      "metadata": { "mapbox:group": "a14c9607bc7954ba1df7205bf660433f" },
+      "minzoom": 5,
       "paint": {
         "line-blur": {
           "base": 1,
@@ -900,16 +888,14 @@
             [22, 20]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "boundary",
+      "type": "line"
     },
     {
-      "id": "place_other",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
-      "maxzoom": 14,
       "filter": ["all", ["in", "class", "continent", "hamlet", "neighbourhood", "isolated_dwelling"], ["==", "$type", "Point"]],
+      "id": "place_other",
       "layout": {
         "text-anchor": "center",
         "text-field": "{name}",
@@ -920,46 +906,46 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
-      "paint": {
-        "text-color": "rgb(117, 129, 145)",
-        "text-halo-blur": 1,
-        "text-halo-color": "rgb(242,243,240)",
-        "text-halo-width": 1
-      }
-    },
-    {
-      "id": "place_suburb",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
-      "maxzoom": 15,
-      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "suburb"]],
-      "layout": {
-        "text-anchor": "center",
-        "text-field": "{name}",
-        "text-font": ["Open Sans Regular"],
-        "text-justify": "center",
-        "text-offset": [0.5, 0],
-        "text-size": 10,
-        "text-transform": "uppercase",
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "rgb(117, 129, 145)",
-        "text-halo-blur": 1,
-        "text-halo-color": "rgb(242,243,240)",
-        "text-halo-width": 1
-      }
-    },
-    {
-      "id": "place_village",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
       "maxzoom": 14,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "suburb"]],
+      "id": "place_suburb",
+      "layout": {
+        "text-anchor": "center",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Regular"],
+        "text-justify": "center",
+        "text-offset": [0.5, 0],
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "maxzoom": 15,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "$type", "Point"], ["==", "place", "village"]],
+      "id": "place_village",
       "layout": {
         "icon-size": 0.4,
         "text-anchor": "left",
@@ -971,62 +957,22 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
-      "paint": {
-        "icon-opacity": 0.7,
-        "text-color": "rgb(117, 129, 145)",
-        "text-halo-blur": 1,
-        "text-halo-color": "rgb(242,243,240)",
-        "text-halo-width": 1
-      }
-    },
-    {
-      "id": "place_town",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
-      "maxzoom": 15,
-      "filter": ["all", ["==", "class", "town"]],
-      "layout": {
-        "icon-image": {
-          "base": 1,
-          "stops": [
-            [0, "circle-11"],
-            [8, ""]
-          ]
-        },
-        "icon-size": 0.4,
-        "text-anchor": {
-          "base": 1,
-          "stops": [
-            [0, "left"],
-            [8, "center"]
-          ]
-        },
-        "text-field": "{name}",
-        "text-font": ["Open Sans Regular"],
-        "text-justify": "left",
-        "text-offset": [0.5, 0.2],
-        "text-size": 10,
-        "text-transform": "uppercase",
-        "visibility": "visible"
-      },
-      "paint": {
-        "icon-opacity": 0.7,
-        "text-color": "rgb(117, 129, 145)",
-        "text-halo-blur": 1,
-        "text-halo-color": "rgb(242,243,240)",
-        "text-halo-width": 1
-      }
-    },
-    {
-      "id": "place_city",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
       "maxzoom": 14,
-      "filter": ["all", ["==", "class", "city"]],
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "paint": {
+        "icon-opacity": 0.7,
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "town"]],
+      "id": "place_town",
       "layout": {
         "icon-image": {
           "base": 1,
@@ -1051,22 +997,62 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
+      "maxzoom": 15,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
       "paint": {
         "icon-opacity": 0.7,
         "text-color": "rgb(117, 129, 145)",
         "text-halo-blur": 1,
         "text-halo-color": "rgb(242,243,240)",
         "text-halo-width": 1
-      }
-    },
-    {
-      "id": "place_capital",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "place",
-      "maxzoom": 12,
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "city"]],
+      "id": "place_city",
+      "layout": {
+        "icon-image": {
+          "base": 1,
+          "stops": [
+            [0, "circle-11"],
+            [8, ""]
+          ]
+        },
+        "icon-size": 0.4,
+        "text-anchor": {
+          "base": 1,
+          "stops": [
+            [0, "left"],
+            [8, "center"]
+          ]
+        },
+        "text-field": "{name}",
+        "text-font": ["Open Sans Regular"],
+        "text-justify": "left",
+        "text-offset": [0.5, 0.2],
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "maxzoom": 14,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "paint": {
+        "icon-opacity": 0.7,
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", ["geometry-type"], "Point"], ["all", ["==", ["get", "capital"], 2], ["==", ["get", "class"], "city"]]],
+      "id": "place_capital",
       "layout": {
         "icon-image": {
           "base": 1,
@@ -1091,22 +1077,22 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
+      "maxzoom": 12,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
       "paint": {
         "icon-opacity": 0.7,
         "text-color": "rgb(117, 129, 145)",
         "text-halo-blur": 1,
         "text-halo-color": "rgb(242,243,240)",
         "text-halo-width": 1
-      }
-    },
-    {
-      "id": "place_city_large",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "place",
-      "maxzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", ["geometry-type"], "Point"], ["all", ["!=", ["get", "capital"], 2], ["<=", ["get", "rank"], 3], ["==", ["get", "class"], "city"]]],
+      "id": "place_city_large",
       "layout": {
         "icon-image": {
           "base": 1,
@@ -1131,22 +1117,22 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
+      "maxzoom": 12,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
       "paint": {
         "icon-opacity": 0.7,
         "text-color": "rgb(117, 129, 145)",
         "text-halo-blur": 1,
         "text-halo-color": "rgb(242,243,240)",
         "text-halo-width": 1
-      }
-    },
-    {
-      "id": "place_state",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "place",
-      "maxzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "$type", "Point"], ["==", "class", "state"]],
+      "id": "place_state",
       "layout": {
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": ["Open Sans Regular"],
@@ -1154,21 +1140,21 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
+      "maxzoom": 12,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
       "paint": {
         "text-color": "rgb(113, 129, 144)",
         "text-halo-blur": 1,
         "text-halo-color": "rgb(242,243,240)",
         "text-halo-width": 1
-      }
-    },
-    {
-      "id": "place_country_other",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "place",
-      "maxzoom": 8,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "$type", "Point"], ["==", "class", "country"], ["!has", "iso_a2"]],
+      "id": "place_country_other",
       "layout": {
         "text-field": "{name:latin}",
         "text-font": ["Open Sans Light Italic"],
@@ -1182,6 +1168,8 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
+      "maxzoom": 8,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
       "paint": {
         "text-color": {
           "base": 1,
@@ -1192,16 +1180,14 @@
         },
         "text-halo-color": "rgba(236,236,234,0.7)",
         "text-halo-width": 1.4
-      }
-    },
-    {
-      "id": "place_country_minor",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "place",
-      "maxzoom": 8,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "$type", "Point"], ["==", "class", "country"], [">=", "rank", 2], ["has", "iso_a2"]],
+      "id": "place_country_minor",
       "layout": {
         "text-field": "{name:latin}",
         "text-font": ["Open Sans Regular"],
@@ -1215,6 +1201,8 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
+      "maxzoom": 8,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
       "paint": {
         "text-color": {
           "base": 1,
@@ -1225,16 +1213,14 @@
         },
         "text-halo-color": "rgba(236,236,234,0.7)",
         "text-halo-width": 1.4
-      }
-    },
-    {
-      "id": "place_country_major",
-      "type": "symbol",
-      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      },
       "source": "LINZ Basemaps",
       "source-layer": "place",
-      "maxzoom": 6,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "$type", "Point"], ["<=", "rank", 1], ["==", "class", "country"], ["has", "iso_a2"]],
+      "id": "place_country_major",
       "layout": {
         "text-anchor": "center",
         "text-field": "{name:latin}",
@@ -1250,6 +1236,8 @@
         "text-transform": "uppercase",
         "visibility": "visible"
       },
+      "maxzoom": 6,
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
       "paint": {
         "text-color": {
           "base": 1,
@@ -1260,7 +1248,10 @@
         },
         "text-halo-color": "rgba(236,236,234,0.7)",
         "text-halo-width": 1.4
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
     }
   ],
   "metadata": {
@@ -1281,5 +1272,14 @@
     "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t",
     "openmaptiles:version": "3.x"
   },
-  "id": "st_positron"
+  "name": "Positron",
+  "sources": {
+    "LINZ Basemaps": {
+      "attribution": "© 2022 Toitū Te Whenua © OpenMapTiles - CC BY 4.0",
+      "type": "vector",
+      "url": "/v1/tiles/topographic/EPSG:3857/tile.json"
+    }
+  },
+  "sprite": "/v1/sprites/topographic",
+  "version": 8
 }

--- a/config/style/topographic.json
+++ b/config/style/topographic.json
@@ -1,97 +1,86 @@
 {
-  "id": "st_topographic",
-  "version": 8,
-  "name": "topographic",
-  "metadata": { "maputnik:renderer": "mbgljs" },
-  "sources": {
-    "LINZ Basemaps": { "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json", "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0" },
-    "LINZ-Texture-Relief": { "type": "raster", "tiles": ["/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp"], "tileSize": 256, "minzoom": 0, "maxzoom": 20 }
-  },
-  "sprite": "/v1/sprites/topographic",
   "glyphs": "/v1/fonts/{fontstack}/{range}.pbf",
+  "id": "st_topographic",
   "layers": [
     {
-      "id": "Background",
-      "type": "background",
-      "minzoom": 0,
       "filter": ["all", ["==", "class", "dock"]],
+      "id": "Background",
       "layout": { "visibility": "visible" },
-      "paint": { "background-color": "rgba(184, 220, 242, 1)" }
+      "minzoom": 0,
+      "paint": { "background-color": "rgba(184, 220, 242, 1)" },
+      "type": "background"
     },
     {
-      "id": "Landcover-Sand",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 8,
       "filter": ["all", ["==", "class", "sand"]],
+      "id": "Landcover-Sand",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(226, 226, 226, 0.75)" }
-    },
-    {
-      "id": "Landcover-Rock-Ln",
-      "type": "line",
+      "minzoom": 8,
+      "paint": { "fill-color": "rgba(226, 226, 226, 0.75)" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 14,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "rock"], ["!=", "rock_feature", "embankment"]],
-      "layout": { "visibility": "visible", "line-cap": "round", "line-join": "round" },
+      "id": "Landcover-Rock-Ln",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 14,
       "paint": {
         "line-color": "rgba(0, 0, 0, 1)",
-        "line-pattern": "rock_narrow_poly_thin",
-        "line-width": 30,
         "line-opacity": {
           "stops": [
             [14, 0.01],
             [15, 0.75]
           ]
-        }
-      }
+        },
+        "line-pattern": "rock_narrow_poly_thin",
+        "line-width": 30
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "line"
     },
     {
-      "id": "Coastline2",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "coastline",
-      "minzoom": 0,
       "filter": ["all"],
+      "id": "Coastline2",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "stops": [
             [1, "rgba(228, 234, 228, 1)"],
             [10, "rgba(232, 232, 232, 1)"],
             [20, "rgba(232, 232, 232, 1)"]
           ]
-        },
-        "fill-antialias": true
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "coastline",
+      "type": "fill"
     },
     {
+      "filter": ["any", ["==", "class", "mine"], ["==", "class", "quarry"]],
       "id": "Poi-Mine-Quarry-Poly",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 12,
+      "paint": { "fill-color": "rgba(205, 205, 205, 1)", "fill-opacity": 0.5 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
-      "filter": ["any", ["==", "class", "mine"], ["==", "class", "quarry"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-opacity": 0.5, "fill-color": "rgba(205, 205, 205, 1)" }
+      "type": "fill"
     },
     {
-      "id": "Vegetation-Scatteredscrub",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
       "filter": ["all", ["==", "class", "grass"], ["==", "natural", "scrub"], ["==", "distribution", "scattered"]],
+      "id": "Vegetation-Scatteredscrub",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(204, 222, 195, 1)", "fill-antialias": false, "fill-outline-color": "rgba(210, 210, 210, 0.27)" }
-    },
-    {
-      "id": "Vegetation-Scrub",
-      "type": "fill",
+      "paint": { "fill-antialias": false, "fill-color": "rgba(204, 222, 195, 1)", "fill-outline-color": "rgba(210, 210, 210, 0.27)" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "grass"], ["==", "natural", "scrub"], ["!has", "distribution"]],
+      "id": "Vegetation-Scrub",
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": "rgba(199, 228, 183, 1)",
@@ -102,16 +91,16 @@
             [19, "rgba(255, 255, 255, 0.11)"]
           ]
         }
-      }
-    },
-    {
-      "id": "Vegetation-Exotic",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 0,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "tree", "exotic"], ["==", "landuse", "wood"]],
+      "id": "Vegetation-Exotic",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
         "fill-color": {
           "stops": [
@@ -120,18 +109,19 @@
           ]
         },
         "fill-outline-color": "rgba(210, 210, 210, 0.27)"
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "tree", "exotic"], ["==", "landuse", "wood"]],
       "id": "Vegetation-Exotic-Random-Dense-Quarter",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 11,
+      "layout": { "visibility": "visible" },
       "maxzoom": 13,
-      "filter": ["all", ["==", "tree", "exotic"], ["==", "landuse", "wood"]],
-      "layout": { "visibility": "visible" },
+      "minzoom": 11,
       "paint": {
+        "fill-antialias": true,
         "fill-opacity": {
           "stops": [
             [1, 0.2],
@@ -140,21 +130,21 @@
             [19, 0.4]
           ]
         },
-        "fill-antialias": true,
-        "fill-translate-anchor": "viewport",
-        "fill-pattern": "exotic_con_poly_random_dense_quarter"
-      }
+        "fill-pattern": "exotic_con_poly_random_dense_quarter",
+        "fill-translate-anchor": "viewport"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "tree", "exotic"], ["==", "landuse", "wood"]],
       "id": "Vegetation-Exotic-Random-Dense-Half",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 13,
-      "maxzoom": 16,
-      "filter": ["all", ["==", "tree", "exotic"], ["==", "landuse", "wood"]],
       "layout": { "visibility": "visible" },
+      "maxzoom": 16,
+      "minzoom": 13,
       "paint": {
+        "fill-antialias": true,
         "fill-opacity": {
           "stops": [
             [1, 0.2],
@@ -163,20 +153,20 @@
             [19, 0.4]
           ]
         },
-        "fill-antialias": true,
-        "fill-translate-anchor": "viewport",
-        "fill-pattern": "exotic_con_poly_random_dense_half"
-      }
-    },
-    {
-      "id": "Vegetation-Exotic-Random-Dense",
-      "type": "fill",
+        "fill-pattern": "exotic_con_poly_random_dense_half",
+        "fill-translate-anchor": "viewport"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 16,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "tree", "exotic"], ["==", "landuse", "wood"]],
+      "id": "Vegetation-Exotic-Random-Dense",
       "layout": { "visibility": "visible" },
+      "minzoom": 16,
       "paint": {
+        "fill-antialias": true,
         "fill-opacity": {
           "stops": [
             [1, 0.1],
@@ -185,17 +175,16 @@
             [19, 0.4]
           ]
         },
-        "fill-antialias": true,
-        "fill-translate-anchor": "viewport",
-        "fill-pattern": "exotic_con_poly_random_dense"
-      }
-    },
-    {
-      "id": "Vegetation-Native",
-      "type": "fill",
+        "fill-pattern": "exotic_con_poly_random_dense",
+        "fill-translate-anchor": "viewport"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "tree", "native"]],
+      "id": "Vegetation-Native",
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
@@ -207,14 +196,14 @@
           ]
         },
         "fill-outline-color": "rgba(210, 210, 210, 0.27)"
-      }
-    },
-    {
-      "id": "Landcover-Ice",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "ice"]],
+      "id": "Landcover-Ice",
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": "rgba(255, 255, 255, 0.44)",
@@ -225,34 +214,34 @@
             [11, "rgba(57, 158, 158, 0.5)"]
           ]
         }
-      }
-    },
-    {
-      "id": "Landcover-Orchard-Fill",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 10,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "landuse", "orchard"]],
+      "id": "Landcover-Orchard-Fill",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(27, 127, 36, 0.1)", "fill-outline-color": "rgba(255, 255, 255, 1)", "fill-translate-anchor": "viewport" }
-    },
-    {
-      "id": "Landcover-Vineyard-Fill",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
       "minzoom": 10,
-      "filter": ["all", ["==", "landuse", "vineyard"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(27, 127, 36, 0.2)", "fill-translate-anchor": "viewport", "fill-outline-color": "rgba(255, 255, 255, 1)", "fill-antialias": false }
-    },
-    {
-      "id": "Landcover-Swamp-Fill",
-      "type": "fill",
+      "paint": { "fill-color": "rgba(27, 127, 36, 0.1)", "fill-outline-color": "rgba(255, 255, 255, 1)", "fill-translate-anchor": "viewport" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "landuse", "vineyard"]],
+      "id": "Landcover-Vineyard-Fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 10,
+      "paint": { "fill-antialias": false, "fill-color": "rgba(27, 127, 36, 0.2)", "fill-outline-color": "rgba(255, 255, 255, 1)", "fill-translate-anchor": "viewport" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
+      "id": "Landcover-Swamp-Fill",
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
@@ -261,56 +250,56 @@
             [14, "rgba(224, 236, 238, 1)"]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
       "id": "Landcover-Swamp-sparse",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
+      "layout": { "visibility": "visible" },
       "minzoom": 16,
-      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-antialias": true, "fill-opacity": 0.5, "fill-color": "rgba(156, 156, 156, 1)", "fill-pattern": "swamp_poly_sparse" }
+      "paint": { "fill-antialias": true, "fill-color": "rgba(156, 156, 156, 1)", "fill-opacity": 0.5, "fill-pattern": "swamp_poly_sparse" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
       "id": "Landcover-Swamp-sparse-half",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 16,
+      "minzoom": 14,
+      "paint": { "fill-antialias": true, "fill-color": "rgba(156, 156, 156, 1)", "fill-opacity": 0.5, "fill-pattern": "swamp_poly_sparse_half" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 14,
-      "maxzoom": 16,
-      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-antialias": true, "fill-opacity": 0.5, "fill-color": "rgba(156, 156, 156, 1)", "fill-pattern": "swamp_poly_sparse_half" }
+      "type": "fill"
     },
     {
-      "id": "Landcover-Swamp-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 10,
       "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
+      "id": "Landcover-Swamp-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
-        "line-dasharray": [6, 6, 4, 4],
         "line-color": {
           "stops": [
             [10, "rgba(0, 140, 204, 0.1)"],
             [11, "rgba(0, 140, 204, 0.8)"]
           ]
         },
+        "line-dasharray": [6, 6, 4, 4],
         "line-width": 0.5
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "line"
     },
     {
-      "id": "Contours-All",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "contours",
-      "minzoom": 9,
       "filter": ["all", ["!has", "designated"], ["!=", "type", "index"], ["!has", "nat_form"]],
+      "id": "Contours-All",
       "layout": { "visibility": "visible" },
+      "minzoom": 9,
       "paint": {
         "line-color": "rgba(206, 103, 6, 0.75)",
         "line-width": {
@@ -319,26 +308,26 @@
             [16, 0.2]
           ]
         }
-      }
-    },
-    {
-      "id": "Contours-Designated",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "contours",
-      "minzoom": 9,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["has", "designated"]],
+      "id": "Contours-Designated",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(206, 103, 6, 0.75)", "line-width": 0.4, "line-dasharray": [30, 30] }
-    },
-    {
-      "id": "Contours-Index",
-      "type": "line",
+      "minzoom": 9,
+      "paint": { "line-color": "rgba(206, 103, 6, 0.75)", "line-dasharray": [30, 30], "line-width": 0.4 },
       "source": "LINZ Basemaps",
       "source-layer": "contours",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "type", "index"]],
+      "id": "Contours-Index",
       "layout": { "visibility": "visible" },
+      "minzoom": 11,
       "paint": {
         "line-color": {
           "stops": [
@@ -352,57 +341,57 @@
             [15, 1.2]
           ]
         }
-      }
-    },
-    {
-      "id": "Contours-Natural",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "contours",
-      "minzoom": 9,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["has", "nat_form"]],
+      "id": "Contours-Natural",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(206, 103, 6, 0.75)", "line-width": 0.6, "line-dasharray": [30, 10, 10, 10] }
-    },
-    {
-      "id": "Contours-Label",
-      "type": "symbol",
+      "minzoom": 9,
+      "paint": { "line-color": "rgba(206, 103, 6, 0.75)", "line-dasharray": [30, 10, 10, 10], "line-width": 0.6 },
       "source": "LINZ Basemaps",
       "source-layer": "contours",
-      "maxzoom": 16,
+      "type": "line"
+    },
+    {
       "filter": ["any", ["==", "type", "index"], ["has", "designated"]],
+      "id": "Contours-Label",
       "layout": {
         "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [10, 150],
+            [16, 300]
+          ]
+        },
+        "text-allow-overlap": false,
         "text-field": "{elevation}",
-        "visibility": "visible",
+        "text-font": ["Open Sans Bold"],
+        "text-keep-upright": false,
+        "text-line-height": 1,
+        "text-padding": 0,
         "text-size": {
           "stops": [
             [13, 8],
             [15, 12]
           ]
         },
-        "text-line-height": 1,
-        "text-padding": 0,
-        "text-allow-overlap": false,
-        "text-font": ["Open Sans Bold"],
-        "text-keep-upright": false,
-        "symbol-spacing": {
-          "stops": [
-            [10, 150],
-            [16, 300]
-          ]
-        }
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(193, 104, 9, 1)", "text-halo-color": "rgba(243, 243, 242, 1)", "text-halo-width": 1, "text-halo-blur": 0.5 }
+      "maxzoom": 16,
+      "paint": { "text-color": "rgba(193, 104, 9, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(243, 243, 242, 1)", "text-halo-width": 1 },
+      "source": "LINZ Basemaps",
+      "source-layer": "contours",
+      "type": "symbol"
     },
     {
-      "id": "Parcels-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "parcel_boundaries",
-      "minzoom": 15,
       "filter": ["none", ["==", "parcel_intent", "Road"], ["==", "parcel_intent", "Hydro"]],
+      "id": "Parcels-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 15,
       "paint": {
         "line-color": {
           "stops": [
@@ -416,14 +405,14 @@
             [24, 1.5]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "parcel_boundaries",
+      "type": "line"
     },
     {
-      "id": "Landcover-Shingle-pattern-shade",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
       "filter": ["all", ["==", "class", "shingle"]],
+      "id": "Landcover-Shingle-pattern-shade",
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-antialias": false,
@@ -433,46 +422,46 @@
             [19, "rgba(216, 213, 213, 0.75)"]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
     },
     {
-      "id": "Aeroway-Aerodrome",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "aeroway",
-      "minzoom": 10,
       "filter": ["all", ["==", "class", "aerodrome"]],
+      "id": "Aeroway-Aerodrome",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(211, 211, 211, 1)" }
+      "minzoom": 10,
+      "paint": { "fill-color": "rgba(211, 211, 211, 1)" },
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "runway"], ["==", "surface", "sealed"]],
       "id": "Aeroway-Runway-Sealed",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 13,
+      "paint": { "fill-antialias": false, "fill-color": "rgba(193, 193, 193, 0.5)" },
       "source": "LINZ Basemaps",
       "source-layer": "aeroway",
-      "minzoom": 13,
-      "filter": ["all", ["==", "class", "runway"], ["==", "surface", "sealed"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(193, 193, 193, 0.5)", "fill-antialias": false }
+      "type": "fill"
     },
     {
-      "id": "Aeroway-Runway-Grass-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "aeroway",
-      "minzoom": 13,
       "filter": ["all", ["==", "class", "runway"], ["!has", "surface"]],
+      "id": "Aeroway-Runway-Grass-Ln",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(125, 125, 125, 1)", "line-dasharray": [5, 5] }
-    },
-    {
-      "id": "Aeroway-Runway-Sealed-Ln",
-      "type": "line",
+      "minzoom": 13,
+      "paint": { "line-color": "rgba(125, 125, 125, 1)", "line-dasharray": [5, 5] },
       "source": "LINZ Basemaps",
       "source-layer": "aeroway",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "runway"], ["==", "surface", "sealed"]],
+      "id": "Aeroway-Runway-Sealed-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(125, 125, 125, 1)",
         "line-width": {
@@ -482,16 +471,16 @@
             [19, 0.5]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "line"
     },
     {
-      "id": "Water-Polys-Outline",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 11,
       "filter": ["any", ["==", "class", "lake"], ["==", "class", "river"], ["==", "class", "canal"], ["==", "class", "lagoon"]],
+      "id": "Water-Polys-Outline",
       "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 11,
       "paint": {
         "line-color": {
           "stops": [
@@ -500,26 +489,28 @@
             [19, "rgba(0, 140, 204, 1)"]
           ]
         },
+        "line-offset": 0,
         "line-width": {
           "stops": [
             [9, 1],
             [15, 2.5]
           ]
-        },
-        "line-offset": 0
-      }
-    },
-    {
-      "id": "Water-Canal-Poly-Named",
-      "type": "fill",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 9,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "canal"], ["has", "name"]],
+      "id": "Water-Canal-Poly-Named",
       "layout": { "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 9,
       "paint": {
+        "fill-antialias": true,
         "fill-color": "rgba(204, 232, 245, 1)",
+        "fill-opacity": 1,
         "fill-outline-color": {
           "stops": [
             [6, "rgba(184, 220, 242, 1)"],
@@ -527,161 +518,159 @@
             [19, "rgba(0, 140, 204, 1)"]
           ]
         },
-        "fill-opacity": 1,
-        "fill-translate-anchor": "map",
-        "fill-antialias": true
-      }
-    },
-    {
-      "id": "Water-Lagoon",
-      "type": "fill",
+        "fill-translate-anchor": "map"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "lagoon"]],
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-antialias": true }
-    },
-    {
-      "id": "Water-Lake",
-      "type": "fill",
+      "id": "Water-Lagoon",
+      "paint": { "fill-antialias": true, "fill-color": "rgba(184, 220, 242, 1)" },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 13,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "lake"]],
+      "id": "Water-Lake",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map", "fill-antialias": true }
-    },
-    {
-      "id": "Water-Lake-Named",
-      "type": "fill",
+      "minzoom": 13,
+      "paint": { "fill-antialias": true, "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map" },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 0,
-      "maxzoom": 13,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "lake"], ["has", "name"]],
+      "id": "Water-Lake-Named",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map", "fill-antialias": true }
-    },
-    {
-      "id": "Water-River-Poly-Named",
-      "type": "fill",
+      "maxzoom": 13,
+      "minzoom": 0,
+      "paint": { "fill-antialias": true, "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map" },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "river"], ["has", "name"]],
+      "id": "Water-River-Poly-Named",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map", "fill-antialias": true }
-    },
-    {
-      "id": "Water-Canal-Poly",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 13,
-      "filter": ["any", ["==", "class", "canal"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map", "fill-antialias": true }
-    },
-    {
-      "id": "Water-River-Poly",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 13,
-      "filter": ["any", ["==", "class", "river"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map", "fill-antialias": true }
-    },
-    {
-      "id": "Landcover-Sand-pattern",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 11,
       "maxzoom": 13,
-      "filter": ["all", ["==", "class", "sand"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-opacity": 0.8, "fill-color": "rgba(135, 122, 122, 1)", "fill-pattern": "sand_land_poly_quarter" }
+      "minzoom": 8,
+      "paint": { "fill-antialias": true, "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map" },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "fill"
     },
     {
-      "id": "Landcover-Sand-land-pattern-half",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
+      "filter": ["any", ["==", "class", "canal"]],
+      "id": "Water-Canal-Poly",
+      "layout": { "visibility": "visible" },
       "minzoom": 13,
+      "paint": { "fill-antialias": true, "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map" },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "fill"
+    },
+    {
+      "filter": ["any", ["==", "class", "river"]],
+      "id": "Water-River-Poly",
+      "layout": { "visibility": "visible" },
+      "minzoom": 13,
+      "paint": { "fill-antialias": true, "fill-color": "rgba(184, 220, 242, 1)", "fill-opacity": 1, "fill-translate-anchor": "map" },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "sand"]],
+      "id": "Landcover-Sand-pattern",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-opacity": 0.45, "fill-color": "rgba(135, 122, 122, 1)", "fill-pattern": "sand_land_poly_half" }
-    },
-    {
-      "id": "Landcover-Scree-poly-half",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 12,
-      "maxzoom": 15,
-      "filter": ["all", ["==", "class", "scree"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-pattern": "gravel_poly_half", "fill-opacity": 0.25 }
-    },
-    {
-      "id": "Landcover-Scree-poly",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 15,
-      "filter": ["all", ["==", "class", "scree"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-pattern": "gravel_poly", "fill-opacity": 0.25 }
-    },
-    {
-      "id": "Landcover-Shingle-poly-quarter",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
+      "maxzoom": 13,
       "minzoom": 11,
+      "paint": { "fill-color": "rgba(135, 122, 122, 1)", "fill-opacity": 0.8, "fill-pattern": "sand_land_poly_quarter" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "sand"]],
+      "id": "Landcover-Sand-land-pattern-half",
+      "layout": { "visibility": "visible" },
+      "minzoom": 13,
+      "paint": { "fill-color": "rgba(135, 122, 122, 1)", "fill-opacity": 0.45, "fill-pattern": "sand_land_poly_half" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "scree"]],
+      "id": "Landcover-Scree-poly-half",
+      "layout": { "visibility": "visible" },
       "maxzoom": 15,
-      "filter": ["all", ["==", "class", "shingle"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-antialias": false, "fill-color": "rgba(211, 207, 207, 0.75)", "fill-opacity": 0.85, "fill-pattern": "sand_land_poly_quarter" }
-    },
-    {
-      "id": "Landcover-Shingle-poly",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 15,
-      "filter": ["all", ["==", "class", "shingle"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-antialias": false, "fill-color": "rgba(211, 207, 207, 0.75)", "fill-opacity": 0.85, "fill-pattern": "sand_land_poly_half" }
-    },
-    {
-      "id": "Landcover-Moraine-poly-half",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
       "minzoom": 12,
-      "maxzoom": 15,
-      "filter": ["all", ["==", "class", "moraine"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-opacity": 0.6, "fill-pattern": "moraine_poly_half" }
-    },
-    {
-      "id": "Landcover-Moraine-poly",
-      "type": "fill",
+      "paint": { "fill-opacity": 0.25, "fill-pattern": "gravel_poly_half" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "scree"]],
+      "id": "Landcover-Scree-poly",
+      "layout": { "visibility": "visible" },
       "minzoom": 15,
-      "filter": ["all", ["==", "class", "moraine"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-opacity": 0.8, "fill-pattern": "moraine_poly" }
-    },
-    {
-      "id": "Landcover-Moraine-Wall-pattern",
-      "type": "fill",
+      "paint": { "fill-opacity": 0.25, "fill-pattern": "gravel_poly" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "shingle"]],
+      "id": "Landcover-Shingle-poly-quarter",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 15,
+      "minzoom": 11,
+      "paint": { "fill-antialias": false, "fill-color": "rgba(211, 207, 207, 0.75)", "fill-opacity": 0.85, "fill-pattern": "sand_land_poly_quarter" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "shingle"]],
+      "id": "Landcover-Shingle-poly",
+      "layout": { "visibility": "visible" },
+      "minzoom": 15,
+      "paint": { "fill-antialias": false, "fill-color": "rgba(211, 207, 207, 0.75)", "fill-opacity": 0.85, "fill-pattern": "sand_land_poly_half" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "moraine"]],
+      "id": "Landcover-Moraine-poly-half",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 15,
+      "minzoom": 12,
+      "paint": { "fill-opacity": 0.6, "fill-pattern": "moraine_poly_half" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "moraine"]],
+      "id": "Landcover-Moraine-poly",
+      "layout": { "visibility": "visible" },
+      "minzoom": 15,
+      "paint": { "fill-opacity": 0.8, "fill-pattern": "moraine_poly" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "moraine_wall"]],
+      "id": "Landcover-Moraine-Wall-pattern",
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-opacity": 1,
@@ -691,16 +680,16 @@
             [15, "moraine_poly"]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "fill"
     },
     {
-      "id": "Water-Reef",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 10,
       "filter": ["all", ["==", "class", "reef"]],
+      "id": "Water-Reef",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": "rgba(0, 140, 204, 1)",
         "line-dasharray": [12, 2],
@@ -710,16 +699,16 @@
             [10, 1]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "line"
     },
     {
-      "id": "Waterway-Canal-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 13,
       "filter": ["all", ["==", "class", "canal"]],
+      "id": "Waterway-Canal-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": {
           "stops": [
@@ -736,17 +725,17 @@
             [18, 0.5]
           ]
         }
-      }
-    },
-    {
-      "id": "Waterway-Canal-Ln-Named",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "canal"], ["has", "name"]],
+      "id": "Waterway-Canal-Ln-Named",
       "layout": { "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
         "line-color": {
           "stops": [
@@ -764,16 +753,16 @@
             [13, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "Waterway-Drain-Ln",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "drain"]],
+      "id": "Waterway-Drain-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": {
           "stops": [
@@ -790,17 +779,17 @@
             [18, 0.5]
           ]
         }
-      }
-    },
-    {
-      "id": "Waterway-Drain-Ln-Named",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "drain"], ["has", "name"]],
+      "id": "Waterway-Drain-Ln-Named",
       "layout": { "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
         "line-color": {
           "stops": [
@@ -818,16 +807,16 @@
             [13, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "Waterway-River-Ln",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "river"]],
+      "id": "Waterway-River-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": {
           "stops": [
@@ -842,17 +831,17 @@
             [18, 0.75]
           ]
         }
-      }
-    },
-    {
-      "id": "Waterway-River-Ln-Named",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "river"], ["has", "name"]],
+      "id": "Waterway-River-Ln-Named",
       "layout": { "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
         "line-color": {
           "stops": [
@@ -870,64 +859,64 @@
             [13, 1]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "line"
     },
     {
-      "id": "Water-Dry-Dock-ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "dock"]],
+      "id": "Water-Dry-Dock-ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 12,
       "paint": {
+        "line-color": "rgba(73, 73, 73, 1)",
         "line-width": {
           "stops": [
             [10, 0.75],
             [14, 1.5],
             [18, 2]
           ]
-        },
-        "line-color": "rgba(73, 73, 73, 1)"
-      }
-    },
-    {
-      "id": "Water-Shoal-ln",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 12,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "shoal"]],
+      "id": "Water-Shoal-ln",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(0, 140, 204, 1)", "line-dasharray": [10, 4] }
+      "minzoom": 12,
+      "paint": { "line-color": "rgba(0, 140, 204, 1)", "line-dasharray": [10, 4] },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "line"
     },
     {
-      "id": "Waterway-Waterfall-Poly",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
       "filter": ["all", ["==", "class", "waterfall"]],
+      "id": "Waterway-Waterfall-Poly",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(63, 117, 150, 1)", "fill-antialias": true }
-    },
-    {
-      "id": "Waterway-Flume",
-      "type": "line",
+      "paint": { "fill-antialias": true, "fill-color": "rgba(63, 117, 150, 1)" },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 13,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "channel"], ["==", "channel_type", "flume_cl"]],
+      "id": "Waterway-Flume",
       "layout": { "visibility": "visible" },
-      "paint": { "line-width": 0.75, "line-color": "rgba(73, 71, 71, 1)" }
-    },
-    {
-      "id": "Waterway-Rapid",
-      "type": "line",
+      "minzoom": 13,
+      "paint": { "line-color": "rgba(73, 71, 71, 1)", "line-width": 0.75 },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "stream"], ["==", "stream_feature", "rapid_cl"]],
+      "id": "Waterway-Rapid",
       "layout": { "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(0, 140, 204, 1)",
         "line-dasharray": [0.15, 12],
@@ -937,33 +926,33 @@
             [15, 10]
           ]
         }
-      }
-    },
-    {
-      "id": "Waterway-Rapid-Poly",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 12,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "stream"], ["==", "stream_feature", "rapid"]],
+      "id": "Waterway-Rapid-Poly",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-antialias": false, "fill-pattern": "moraine_poly_half" }
-    },
-    {
-      "id": "Waterway-Spillway-Edge",
-      "type": "line",
+      "minzoom": 12,
+      "paint": { "fill-antialias": false, "fill-color": "rgba(184, 220, 242, 1)", "fill-pattern": "moraine_poly_half" },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "spillway"]],
+      "id": "Waterway-Spillway-Edge",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(78, 78, 78, 1)", "line-width": 1.5 }
-    },
-    {
-      "id": "Waterway-Waterfall-Edge",
-      "type": "line",
+      "paint": { "line-color": "rgba(78, 78, 78, 1)", "line-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "waterfall_edge"]],
+      "id": "Waterway-Waterfall-Edge",
       "layout": { "visibility": "visible" },
       "paint": {
         "line-color": "rgba(0, 140, 204, 1)",
@@ -973,41 +962,41 @@
             [15, 1.25]
           ]
         }
-      }
-    },
-    {
-      "id": "Waterway-Waterfall-Ln",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "waterfall_ln"]],
+      "id": "Waterway-Waterfall-Ln",
       "layout": { "visibility": "visible" },
       "paint": {
         "line-color": "rgba(0, 140, 204, 1)",
+        "line-dasharray": [0.1, 2.5],
         "line-width": {
           "stops": [
             [12, 6],
             [15, 14]
           ]
-        },
-        "line-dasharray": [0.1, 2.5]
-      }
-    },
-    {
-      "id": "Waterway-Waterfall-Ln-lines",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "waterfall_ln"]],
+      "id": "Waterway-Waterfall-Ln-lines",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(0, 140, 204, 1)" }
-    },
-    {
-      "id": "Waterway-WaterRace",
-      "type": "line",
+      "paint": { "line-color": "rgba(0, 140, 204, 1)" },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "channel"], ["==", "channel_type", "water_race"]],
+      "id": "Waterway-WaterRace",
       "layout": { "visibility": "visible" },
       "paint": {
         "line-color": {
@@ -1017,14 +1006,17 @@
           ]
         },
         "line-width": 0.5
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "line"
     },
     {
       "id": "texture-relief-combined",
-      "type": "raster",
-      "source": "LINZ-Texture-Relief",
       "layout": { "visibility": "visible" },
       "paint": {
+        "raster-brightness-min": 0,
+        "raster-contrast": 0,
         "raster-opacity": {
           "stops": [
             [1, 0.35],
@@ -1034,130 +1026,127 @@
             [16, 0.3]
           ]
         },
-        "raster-resampling": "nearest",
-        "raster-brightness-min": 0,
-        "raster-contrast": 0
-      }
+        "raster-resampling": "nearest"
+      },
+      "source": "LINZ-Texture-Relief",
+      "type": "raster"
     },
     {
-      "id": "Landuse-Cemetery-poly-half",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "cemetery"]],
+      "id": "Landuse-Cemetery-poly-half",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(187, 179, 159, 0.75)", "fill-opacity": 0.5, "fill-pattern": "cemetery_poly_half" }
+      "minzoom": 12,
+      "paint": { "fill-color": "rgba(187, 179, 159, 0.75)", "fill-opacity": 0.5, "fill-pattern": "cemetery_poly_half" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "gravel_pit"]],
       "id": "Landuse-GravelPit-shade",
-      "type": "fill",
+      "paint": { "fill-color": "rgba(216, 213, 213, 0.75)" },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "filter": ["all", ["==", "class", "gravel_pit"]],
-      "paint": { "fill-color": "rgba(216, 213, 213, 0.75)" }
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "gravel_pit"]],
       "id": "Landuse-GravelPit-poly-quarter",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 11,
+      "layout": { "visibility": "visible" },
       "maxzoom": 13,
-      "filter": ["all", ["==", "class", "gravel_pit"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-pattern": "gravel_poly_quarter" }
+      "minzoom": 11,
+      "paint": { "fill-pattern": "gravel_poly_quarter" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "gravel_pit"]],
       "id": "Landuse-GravelPit-poly-half",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 15,
       "minzoom": 13,
-      "maxzoom": 15,
-      "filter": ["all", ["==", "class", "gravel_pit"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-pattern": "gravel_poly_half" }
+      "paint": { "fill-pattern": "gravel_poly_half" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "gravel_pit"]],
       "id": "Landuse-GravelPit-poly",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 15,
+      "paint": { "fill-pattern": "gravel_poly" },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 15,
-      "filter": ["all", ["==", "class", "gravel_pit"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-pattern": "gravel_poly" }
+      "type": "fill"
     },
     {
-      "id": "Landuse-Landfill",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "landfill"]],
-      "paint": { "fill-color": "rgba(247, 165, 66, 0.65)", "fill-antialias": true }
+      "id": "Landuse-Landfill",
+      "minzoom": 12,
+      "paint": { "fill-antialias": true, "fill-color": "rgba(247, 165, 66, 0.65)" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
       "id": "Landuse-Mangrove-poly-sparse",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 15,
+      "paint": { "fill-pattern": "mangrove_poly_sparse" },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 15,
-      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-pattern": "mangrove_poly_sparse" }
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
       "id": "Landuse-Mangrove-poly-sparse-half",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 15,
       "minzoom": 14,
-      "maxzoom": 15,
-      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-pattern": "mangrove_poly_sparse_half" }
+      "paint": { "fill-pattern": "mangrove_poly_sparse_half" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
       "id": "Landuse-Mangrove",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 12,
+      "paint": { "fill-color": "rgba(96, 154, 101, 0.34)" },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 12,
-      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(96, 154, 101, 0.34)" }
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "marine_farm"]],
       "id": "Landuse-MarineFarm-half",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
+      "layout": { "visibility": "visible" },
       "maxzoom": 15,
-      "filter": ["all", ["==", "class", "marine_farm"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(25, 114, 242, 0.45)", "fill-pattern": "marine_farm_poly_half", "fill-opacity": 0.5 }
+      "minzoom": 12,
+      "paint": { "fill-color": "rgba(25, 114, 242, 0.45)", "fill-opacity": 0.5, "fill-pattern": "marine_farm_poly_half" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "marine_farm"]],
       "id": "Landuse-MarineFarm",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 15,
+      "paint": { "fill-color": "rgba(25, 114, 242, 0.45)", "fill-opacity": 0.5, "fill-pattern": "marine_farm_poly" },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 15,
-      "filter": ["all", ["==", "class", "marine_farm"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(25, 114, 242, 0.45)", "fill-pattern": "marine_farm_poly", "fill-opacity": 0.5 }
+      "type": "fill"
     },
     {
-      "id": "Landuse-Pond",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 10,
       "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_feature", "pond"]],
+      "id": "Landuse-Pond",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "fill-color": "rgba(184, 220, 242, 1)",
         "fill-outline-color": {
@@ -1167,45 +1156,45 @@
             [19, "rgba(0, 140, 204, 1)"]
           ]
         }
-      }
-    },
-    {
-      "id": "Landuse-PumicePit",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "pumice_pit"]],
+      "id": "Landuse-PumicePit",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(185, 172, 172, 1)", "fill-pattern": "gravel_poly_quarter" }
-    },
-    {
-      "id": "Landuse-Reservoir-Covered",
-      "type": "fill",
+      "paint": { "fill-color": "rgba(185, 172, 172, 1)", "fill-pattern": "gravel_poly_quarter" },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 10,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "reservoir"], ["==", "lid_type", "covered"]],
+      "id": "Landuse-Reservoir-Covered",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(148, 148, 148, 1)", "fill-outline-color": "rgba(18, 18, 18, 1)" }
-    },
-    {
-      "id": "Landuse-Reservoir-Empty",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
       "minzoom": 10,
-      "filter": ["all", ["==", "class", "reservoir"], ["!=", "lid_type", "covered"]],
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-outline-color": "rgba(18, 18, 18, 1)" }
-    },
-    {
-      "id": "Landuse-Residential",
-      "type": "fill",
+      "paint": { "fill-color": "rgba(148, 148, 148, 1)", "fill-outline-color": "rgba(18, 18, 18, 1)" },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 8,
-      "maxzoom": 15,
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "reservoir"], ["!=", "lid_type", "covered"]],
+      "id": "Landuse-Reservoir-Empty",
+      "minzoom": 10,
+      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-outline-color": "rgba(18, 18, 18, 1)" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "residential"]],
+      "id": "Landuse-Residential",
       "layout": { "visibility": "visible" },
+      "maxzoom": 15,
+      "minzoom": 8,
       "paint": {
         "fill-color": {
           "stops": [
@@ -1218,85 +1207,85 @@
           ]
         },
         "fill-outline-color": "rgba(164, 164, 164, 0.01)"
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
-      "id": "Landcover-Cliff-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 13,
       "filter": ["all", ["==", "class", "relief"], ["==", "sand_feature", "cliff"]],
+      "id": "Landcover-Cliff-Ln",
       "layout": { "visibility": "visible" },
-      "paint": { "line-pattern": "cliff_edge", "line-opacity": 0.7, "line-width": 20 }
-    },
-    {
-      "id": "Landcover-Cutting-Ln",
-      "type": "line",
+      "minzoom": 13,
+      "paint": { "line-opacity": 0.7, "line-pattern": "cliff_edge", "line-width": 20 },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "relief"], ["==", "sand_feature", "cutting"]],
+      "id": "Landcover-Cutting-Ln",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(81, 79, 79, 1)", "line-pattern": "cutting_edge", "line-width": 20, "line-offset": -3 }
-    },
-    {
-      "id": "Landcover-Embankment",
-      "type": "line",
+      "minzoom": 13,
+      "paint": { "line-color": "rgba(81, 79, 79, 1)", "line-offset": -3, "line-pattern": "cutting_edge", "line-width": 20 },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rock"], ["==", "rock_feature", "embankment"], ["!=", "embkmt_use", "stopbank"]],
+      "id": "Landcover-Embankment",
       "layout": { "visibility": "visible" },
-      "paint": { "line-opacity": 1, "line-pattern": "embankment_gap_cl_thick", "line-width": 30 }
-    },
-    {
-      "id": "Landcover-GolfCourse",
-      "type": "fill",
+      "minzoom": 13,
+      "paint": { "line-opacity": 1, "line-pattern": "embankment_gap_cl_thick", "line-width": 30 },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "grass"], ["==", "grass_type", "golf_course"]],
+      "id": "Landcover-GolfCourse",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" }
-    },
-    {
-      "id": "Landcover-Slip-Ln",
-      "type": "line",
+      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 13,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "relief"], ["==", "sand_feature", "slip"]],
-      "layout": { "line-join": "round", "line-cap": "round", "visibility": "visible" },
-      "paint": { "line-color": "rgba(81, 79, 79, 1)", "line-width": 15, "line-offset": 0, "line-pattern": "cliff_edge" }
-    },
-    {
-      "id": "Landcover-Stopbank",
-      "type": "line",
+      "id": "Landcover-Slip-Ln",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 13,
+      "paint": { "line-color": "rgba(81, 79, 79, 1)", "line-offset": 0, "line-pattern": "cliff_edge", "line-width": 15 },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rock"], ["==", "rock_feature", "embankment"], ["==", "embkmt_use", "stopbank"]],
+      "id": "Landcover-Stopbank",
+      "minzoom": 13,
       "paint": {
-        "line-opacity": 1,
         "line-color": "rgba(61, 58, 58, 1)",
+        "line-dasharray": [0.1, 0.5],
+        "line-opacity": 1,
         "line-width": {
           "stops": [
             [13, 8],
             [15, 14],
             [18, 16]
           ]
-        },
-        "line-dasharray": [0.1, 0.5]
-      }
-    },
-    {
-      "id": "Fence-Ln",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 14,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "barrier", "fence"], ["==", "class", "farmland"]],
+      "id": "Fence-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 14,
       "paint": {
         "line-color": {
           "stops": [
@@ -1305,16 +1294,16 @@
           ]
         },
         "line-width": 1
-      }
-    },
-    {
-      "id": "Fence-Posts",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 16.5,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "barrier", "fence"], ["==", "class", "farmland"]],
+      "id": "Fence-Posts",
       "layout": { "visibility": "visible" },
+      "minzoom": 16.5,
       "paint": {
         "line-color": {
           "stops": [
@@ -1322,28 +1311,28 @@
             [19, "rgba(160, 90, 26, 0.6)"]
           ]
         },
-        "line-width": 1.5,
         "line-dasharray": [1, 7],
-        "line-offset": 1
-      }
-    },
-    {
-      "id": "Vegetation-Ln",
-      "type": "line",
+        "line-offset": 1,
+        "line-width": 1.5
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 14,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "natural", "tree_row"]],
+      "id": "Vegetation-Ln",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(148, 199, 111, 0.75)", "line-width": 4, "line-translate-anchor": "map" }
+      "minzoom": 14,
+      "paint": { "line-color": "rgba(148, 199, 111, 0.75)", "line-translate-anchor": "map", "line-width": 4 },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "line"
     },
     {
       "id": "Coastline-Ln-2",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "coastline",
-      "minzoom": 0,
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
         "line-color": {
           "stops": [
@@ -1353,6 +1342,7 @@
             [16, "rgba(34, 164, 212, 1)"]
           ]
         },
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [6, 0.5],
@@ -1360,225 +1350,224 @@
             [15, 1.25],
             [20, 3.5]
           ]
-        },
-        "line-translate-anchor": "map"
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "coastline",
+      "type": "line"
     },
     {
-      "id": "Poi-FishFarm",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
       "filter": ["all", ["==", "class", "fish_farm"]],
+      "id": "Poi-FishFarm",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgb(112,172,242)" }
+      "paint": { "fill-color": "rgb(112,172,242)" },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "rifle_range"]],
       "id": "Poi-RifleRange-Fill",
-      "type": "fill",
+      "paint": { "fill-color": "rgba(208, 208, 208, 0.85)" },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "filter": ["all", ["==", "class", "rifle_range"]],
-      "paint": { "fill-color": "rgba(208, 208, 208, 0.85)" }
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "rifle_range"]],
       "id": "Poi-RifleRange-Outline",
-      "type": "line",
+      "paint": { "line-color": "rgba(55, 54, 54, 0.85)", "line-dasharray": [5, 3], "line-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "filter": ["all", ["==", "class", "rifle_range"]],
-      "paint": { "line-color": "rgba(55, 54, 54, 0.85)", "line-dasharray": [5, 3], "line-width": 1.5 }
+      "type": "line"
     },
     {
-      "id": "Poi-Showground",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "showground"]],
-      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" }
-    },
-    {
-      "id": "Poi-SportsField",
-      "type": "fill",
+      "id": "Poi-Showground",
+      "minzoom": 12,
+      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "sports_field"]],
-      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" }
-    },
-    {
-      "id": "Poi-Storage-Tank-Empty",
-      "type": "fill",
+      "id": "Poi-SportsField",
+      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 0,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "storage_tank"], ["!has", "store_item"]],
+      "id": "Poi-Storage-Tank-Empty",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "stops": [
             [6, "rgba(240, 240, 240, 0.85)"],
             [10, "rgba(240, 240, 240, 0.85)"]
           ]
         },
-        "fill-outline-color": "rgba(67, 67, 67, 1)",
-        "fill-antialias": true,
         "fill-opacity": {
           "stops": [
             [14, 1],
             [20, 0.2]
           ]
-        }
-      }
-    },
-    {
-      "id": "Poi-Storage-Tank-Fuel",
-      "type": "fill",
+        },
+        "fill-outline-color": "rgba(67, 67, 67, 1)"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 0,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "storage_tank"], ["==", "store_item", "fuel"]],
+      "id": "Poi-Storage-Tank-Fuel",
       "layout": { "visibility": "visible" },
-      "paint": {
-        "fill-color": "rgba(67, 67, 67, 1)",
-        "fill-outline-color": "rgba(67, 67, 67, 1)",
-        "fill-antialias": false,
-        "fill-opacity": {
-          "stops": [
-            [14, 1],
-            [20, 0.2]
-          ]
-        }
-      }
-    },
-    {
-      "id": "Poi-Storage-Tank-Water",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
       "minzoom": 0,
-      "filter": ["all", ["==", "class", "storage_tank"], ["==", "store_item", "water"]],
-      "layout": { "visibility": "visible" },
       "paint": {
-        "fill-color": "rgba(110, 167, 205, 1)",
-        "fill-outline-color": "rgba(67, 67, 67, 1)",
-        "fill-antialias": true,
+        "fill-antialias": false,
+        "fill-color": "rgba(67, 67, 67, 1)",
         "fill-opacity": {
           "stops": [
             [14, 1],
             [20, 0.2]
           ]
-        }
-      }
-    },
-    { "id": "Poi-Siphon", "type": "fill", "source": "LINZ Basemaps", "source-layer": "poi", "minzoom": 12, "filter": ["all", ["==", "class", "siphon"]] },
-    {
-      "id": "Poi-Tank-Pt-Background",
-      "type": "circle",
+        },
+        "fill-outline-color": "rgba(67, 67, 67, 1)"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 10,
-      "filter": ["all", ["==", "class", "storage_tank_pt"]],
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "storage_tank"], ["==", "store_item", "water"]],
+      "id": "Poi-Storage-Tank-Water",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
+        "fill-antialias": true,
+        "fill-color": "rgba(110, 167, 205, 1)",
+        "fill-opacity": {
+          "stops": [
+            [14, 1],
+            [20, 0.2]
+          ]
+        },
+        "fill-outline-color": "rgba(67, 67, 67, 1)"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "fill"
+    },
+    { "filter": ["all", ["==", "class", "siphon"]], "id": "Poi-Siphon", "minzoom": 12, "source": "LINZ Basemaps", "source-layer": "poi", "type": "fill" },
+    {
+      "filter": ["all", ["==", "class", "storage_tank_pt"]],
+      "id": "Poi-Tank-Pt-Background",
+      "layout": { "visibility": "visible" },
+      "minzoom": 10,
+      "paint": {
+        "circle-opacity": {
+          "stops": [
+            [14, 1],
+            [20, 0.2]
+          ]
+        },
+        "circle-pitch-alignment": "map",
         "circle-radius": {
           "stops": [
             [12, 2],
             [15, 5]
           ]
         },
-        "circle-pitch-alignment": "map",
-        "circle-stroke-color": "rgba(67, 67, 67, 1)",
-        "circle-opacity": {
-          "stops": [
-            [14, 1],
-            [20, 0.2]
-          ]
-        }
-      }
-    },
-    {
-      "id": "Poi-Tank-Pt-Fill-Empty",
-      "type": "circle",
+        "circle-stroke-color": "rgba(67, 67, 67, 1)"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 10,
+      "type": "circle"
+    },
+    {
       "filter": ["all", ["==", "class", "storage_tank_pt"], ["!has", "store_item"]],
+      "id": "Poi-Tank-Pt-Fill-Empty",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "circle-color": "rgba(255, 255, 255, 1)",
-        "circle-radius": {
-          "stops": [
-            [12, 1.5],
-            [15, 3.5]
-          ]
-        },
-        "circle-pitch-alignment": "map",
         "circle-opacity": {
           "stops": [
             [14, 1],
             [20, 0.2]
           ]
+        },
+        "circle-pitch-alignment": "map",
+        "circle-radius": {
+          "stops": [
+            [12, 1.5],
+            [15, 3.5]
+          ]
         }
-      }
-    },
-    {
-      "id": "Poi-Tank-Pt-Fill-Fuel",
-      "type": "circle",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 10,
+      "type": "circle"
+    },
+    {
       "filter": ["all", ["==", "class", "storage_tank_pt"], ["==", "store_item", "fuel"]],
+      "id": "Poi-Tank-Pt-Fill-Fuel",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "circle-color": "rgba(67, 67, 67, 1)",
-        "circle-radius": {
-          "stops": [
-            [12, 1.5],
-            [15, 3.5]
-          ]
-        },
-        "circle-pitch-alignment": "map",
         "circle-opacity": {
           "stops": [
             [14, 1],
             [20, 0.2]
           ]
+        },
+        "circle-pitch-alignment": "map",
+        "circle-radius": {
+          "stops": [
+            [12, 1.5],
+            [15, 3.5]
+          ]
         }
-      }
-    },
-    {
-      "id": "Poi-Tank-Pt-Fill-Water",
-      "type": "circle",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 10,
+      "type": "circle"
+    },
+    {
       "filter": ["all", ["==", "class", "storage_tank_pt"], ["==", "store_item", "water"]],
+      "id": "Poi-Tank-Pt-Fill-Water",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "circle-color": "rgba(110, 167, 205, 1)",
-        "circle-radius": {
-          "stops": [
-            [12, 1.5],
-            [15, 3.5]
-          ]
-        },
-        "circle-pitch-alignment": "map",
         "circle-opacity": {
           "stops": [
             [14, 1],
             [20, 0.2]
           ]
+        },
+        "circle-pitch-alignment": "map",
+        "circle-radius": {
+          "stops": [
+            [12, 1.5],
+            [15, 3.5]
+          ]
         }
-      }
-    },
-    {
-      "id": "Poi-Boatramp-Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "circle"
+    },
+    {
       "filter": ["all", ["==", "class", "boatramp"]],
+      "id": "Poi-Boatramp-Casing",
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(78, 78, 78, 1)",
         "line-width": {
@@ -1588,15 +1577,15 @@
             [19, 8]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Boatramp-Fill",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "boatramp"]],
+      "id": "Poi-Boatramp-Fill",
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(255, 255, 255, 1)",
         "line-width": {
@@ -1606,59 +1595,59 @@
             [19, 6.5]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Dredge-Tailing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "dredge_tailing"]],
-      "paint": { "line-color": "rgba(55, 55, 55, 1)", "line-pattern": "dredge_tailing_pnt", "line-width": 10, "line-opacity": 0.9 }
-    },
-    {
-      "id": "Poi-Mine-Quarry-Outline",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
+      "id": "Poi-Dredge-Tailing",
       "minzoom": 12,
-      "filter": ["any", ["==", "class", "mine"], ["==", "class", "quarry"]],
-      "paint": { "line-color": "rgba(59, 59, 59, 1)", "line-width": 1.5, "line-dasharray": [2, 2] }
-    },
-    {
-      "id": "Poi-Pipeline",
-      "type": "line",
+      "paint": { "line-color": "rgba(55, 55, 55, 1)", "line-opacity": 0.9, "line-pattern": "dredge_tailing_pnt", "line-width": 10 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
+      "filter": ["any", ["==", "class", "mine"], ["==", "class", "quarry"]],
+      "id": "Poi-Mine-Quarry-Outline",
+      "minzoom": 12,
+      "paint": { "line-color": "rgba(59, 59, 59, 1)", "line-dasharray": [2, 2], "line-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "pipeline"]],
+      "id": "Poi-Pipeline",
+      "minzoom": 10,
       "paint": {
+        "line-color": "rgb(235,137,133)",
         "line-width": {
           "stops": [
             [6, 0.75],
             [10, 1],
             [19, 1.5]
           ]
-        },
-        "line-color": "rgb(235,137,133)"
-      }
-    },
-    {
-      "id": "Poi-Racetrack",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["any", ["==", "class", "racetrack"], ["==", "class", "racetrack_ln"]],
-      "paint": { "line-color": "rgba(84, 84, 84, 1)", "line-width": 0.75 }
-    },
-    {
-      "id": "Poi-Slipway-Symbol-Dash",
-      "type": "line",
+      "id": "Poi-Racetrack",
+      "minzoom": 13,
+      "paint": { "line-color": "rgba(84, 84, 84, 1)", "line-width": 0.75 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "slipway"]],
+      "id": "Poi-Slipway-Symbol-Dash",
       "paint": {
         "line-color": "rgba(64, 64, 64, 1)",
         "line-width": {
@@ -1667,14 +1656,14 @@
             [16, 4]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Slipway-Symbol-Line",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "slipway"]],
+      "id": "Poi-Slipway-Symbol-Line",
       "layout": { "visibility": "visible" },
       "paint": {
         "line-color": "rgba(64, 64, 64, 1)",
@@ -1685,53 +1674,53 @@
             [16, 18]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Wharf-Edge",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "wharf_edge"]],
+      "id": "Poi-Wharf-Edge",
       "layout": { "visibility": "visible" },
-      "paint": { "line-color": "rgba(73, 73, 73, 1)", "line-width": 1.3 }
-    },
-    {
-      "id": "Poi-Wharf-Ln",
-      "type": "line",
+      "minzoom": 10,
+      "paint": { "line-color": "rgba(73, 73, 73, 1)", "line-width": 1.3 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "wharf"]],
+      "id": "Poi-Wharf-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
+        "line-color": "rgba(73, 73, 73, 1)",
         "line-width": {
           "stops": [
             [10, 0.75],
             [14, 1.5],
             [18, 2]
           ]
-        },
-        "line-color": "rgba(73, 73, 73, 1)"
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "line"
     },
     {
       "id": "Buildings-Shadow",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "building",
-      "minzoom": 17,
-      "maxzoom": 18,
       "layout": { "visibility": "visible" },
+      "maxzoom": 18,
+      "minzoom": 17,
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "stops": [
             [15, "rgba(199, 199, 199, 0.75)"],
             [19, "rgba(125, 125, 125, 1)"]
           ]
         },
-        "fill-antialias": true,
         "fill-opacity": 1,
         "fill-translate": {
           "base": 1,
@@ -1740,16 +1729,17 @@
             [19, [3, 3]]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "building",
+      "type": "fill"
     },
     {
       "id": "Buildings",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "building",
-      "minzoom": 14,
       "layout": { "visibility": "visible" },
+      "minzoom": 14,
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "stops": [
             [14, "rgba(148, 148, 148, 0.1)"],
@@ -1759,18 +1749,17 @@
             [19, "rgba(190, 190, 190, 0.7)"]
           ]
         },
-        "fill-antialias": true,
         "fill-opacity": 1
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "building",
+      "type": "fill"
     },
     {
       "id": "Buildings-Outline",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "building",
-      "minzoom": 17,
-      "maxzoom": 18,
       "layout": { "visibility": "visible" },
+      "maxzoom": 18,
+      "minzoom": 17,
       "paint": {
         "line-color": "rgba(152, 145, 145,0.75)",
         "line-width": {
@@ -1779,65 +1768,65 @@
             [24, 1]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "building",
+      "type": "line"
     },
     {
+      "filter": ["all", ["==", "class", "peak"]],
       "id": "Height-Point",
-      "type": "circle",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 18,
+      "minzoom": 13,
+      "paint": { "circle-color": "rgba(47, 47, 46, 1)", "circle-radius": 2 },
       "source": "LINZ Basemaps",
       "source-layer": "contours",
-      "minzoom": 13,
-      "maxzoom": 18,
-      "filter": ["all", ["==", "class", "peak"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "circle-color": "rgba(47, 47, 46, 1)", "circle-radius": 2 }
+      "type": "circle"
     },
     {
-      "id": "Height-Point-Labels",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "contours",
-      "minzoom": 13,
-      "maxzoom": 18,
       "filter": ["all", ["==", "class", "peak"]],
+      "id": "Height-Point-Labels",
       "layout": {
-        "text-font": ["Open Sans Italic"],
-        "text-field": "{elevation}",
-        "text-justify": "auto",
+        "icon-pitch-alignment": "auto",
+        "text-allow-overlap": false,
         "text-anchor": "bottom-left",
+        "text-field": "{elevation}",
+        "text-font": ["Open Sans Italic"],
+        "text-ignore-placement": false,
+        "text-justify": "auto",
+        "text-offset": [0.2, -0.2],
+        "text-optional": false,
         "text-size": {
           "stops": [
             [13, 8],
             [15, 11]
           ]
         },
-        "text-offset": [0.2, -0.2],
-        "visibility": "visible",
-        "icon-pitch-alignment": "auto",
-        "text-allow-overlap": false,
-        "text-ignore-placement": false,
         "text-variable-anchor": ["bottom-left", "bottom-right"],
-        "text-optional": false
+        "visibility": "visible"
       },
-      "paint": { "text-halo-color": "rgba(243, 243, 242, 0.75)", "text-halo-width": 1, "text-halo-blur": 0.5, "text-translate-anchor": "map" }
+      "maxzoom": 18,
+      "minzoom": 13,
+      "paint": { "text-halo-blur": 0.5, "text-halo-color": "rgba(243, 243, 242, 0.75)", "text-halo-width": 1, "text-translate-anchor": "map" },
+      "source": "LINZ Basemaps",
+      "source-layer": "contours",
+      "type": "symbol"
     },
     {
-      "id": "Transport-FerryCrossing",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 10,
       "filter": ["all", ["==", "class", "ferry"]],
-      "paint": { "line-dasharray": [15, 10], "line-color": "rgba(0, 140, 204, 1)" }
+      "id": "Transport-FerryCrossing",
+      "minzoom": 10,
+      "paint": { "line-color": "rgba(0, 140, 204, 1)", "line-dasharray": [15, 10] },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
+      "filter": ["all", ["==", "class", "track"], ["==", "track_use", "cycle only"]],
       "id": "Transport-CycleTracks-Shadow",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
       "minzoom": 13,
-      "filter": ["all", ["==", "class", "track"], ["==", "track_use", "cycle only"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
       "paint": {
         "line-color": "rgba(231, 231, 231, 0.4)",
         "line-width": {
@@ -1847,16 +1836,16 @@
             [19, 5]
           ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
+      "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
       "id": "Transport-FootTracks-Shadow",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
       "minzoom": 13,
-      "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
       "paint": {
         "line-color": "rgba(231, 231, 231, 0.4)",
         "line-width": {
@@ -1866,16 +1855,16 @@
             [19, 5]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-ClosedFootRouteTracks-Shadow",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "subclass", "foot_route_closed"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-ClosedFootRouteTracks-Shadow",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(205, 53, 53, 0.4)",
         "line-width": {
@@ -1885,16 +1874,16 @@
             [19, 5]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-ClosedFootTracks-Shadow",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "subclass", "foot_closed"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-ClosedFootTracks-Shadow",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(205, 53, 53, 0.4)",
         "line-width": {
@@ -1904,25 +1893,18 @@
             [19, 5]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-CycleTracks",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "cycle only"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-CycleTracks",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(78, 78, 78, 0.8)",
-        "line-width": {
-          "stops": [
-            [13, 1],
-            [15, 1.5],
-            [19, 3]
-          ]
-        },
         "line-dasharray": {
           "base": 1,
           "stops": [
@@ -1930,26 +1912,26 @@
             [15, [2.5, 3]],
             [16, [2.5, 3]]
           ]
+        },
+        "line-width": {
+          "stops": [
+            [13, 1],
+            [15, 1.5],
+            [19, 3]
+          ]
         }
-      }
-    },
-    {
-      "id": "Transport-FootTracks",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-FootTracks",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(78, 78, 78, 0.8)",
-        "line-width": {
-          "stops": [
-            [13, 1],
-            [15, 1.5],
-            [19, 3]
-          ]
-        },
         "line-dasharray": {
           "base": 1,
           "stops": [
@@ -1957,49 +1939,48 @@
             [15, [2.5, 3]],
             [16, [2.5, 3]]
           ]
+        },
+        "line-width": {
+          "stops": [
+            [13, 1],
+            [15, 1.5],
+            [19, 3]
+          ]
         }
-      }
-    },
-    {
-      "id": "Transport-VehicleTracks-Shadow",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "vehicle"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-VehicleTracks-Shadow",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
+        "line-blur": 0.75,
         "line-color": "rgba(231, 231, 231, 0.4)",
+        "line-dasharray": [8],
         "line-width": {
+          "base": 1,
           "stops": [
             [13, 2],
             [15, 3],
             [19, 5]
-          ],
-          "base": 1
-        },
-        "line-dasharray": [8],
-        "line-blur": 0.75
-      }
-    },
-    {
-      "id": "Transport-VehicleTracks",
-      "type": "line",
+          ]
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "vehicle"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-VehicleTracks",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(78, 78, 78, 0.8)",
-        "line-width": {
-          "stops": [
-            [13, 1.25],
-            [15, 2],
-            [19, 4]
-          ],
-          "base": 1
-        },
         "line-dasharray": {
           "base": 1,
           "stops": [
@@ -2008,17 +1989,25 @@
             [16, [6, 6]],
             [17, [8, 8]]
           ]
+        },
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [13, 1.25],
+            [15, 2],
+            [19, 4]
+          ]
         }
-      }
-    },
-    {
-      "id": "Transport-1Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-1Casing",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": {
           "stops": [
@@ -2038,16 +2027,16 @@
             [22, 200]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-2Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["in", "lane_count", 2, 3, 4, 5, 6, 7, 8], ["!=", "class", "motorway"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-2Casing",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": {
           "stops": [
@@ -2067,16 +2056,16 @@
             [22, 400]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-1HWY-Casing-14",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 1]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-1HWY-Casing-14",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
@@ -2091,16 +2080,16 @@
             [22, 220]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-2HWY-Casing-14",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-2HWY-Casing-14",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
@@ -2115,16 +2104,16 @@
             [22, 450]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-HWY-Casing-14",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-HWY-Casing-14",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
@@ -2139,18 +2128,20 @@
             [22, 470]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-UnMetalled",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "unmetalled"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-UnMetalled",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": "rgba(255, 254, 252, 1)",
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [10, 0.5],
@@ -2161,21 +2152,21 @@
             [19, 35],
             [22, 180]
           ]
-        },
-        "line-gap-width": 0,
-        "line-translate-anchor": "map"
-      }
-    },
-    {
-      "id": "Transport-1Metalled-White",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "metalled"], ["==", "lane_count", 1]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-1Metalled-White",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": "rgba(255, 254, 252, 1)",
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [10, 0.5],
@@ -2186,19 +2177,17 @@
             [19, 35],
             [22, 180]
           ]
-        },
-        "line-gap-width": 0,
-        "line-translate-anchor": "map"
-      }
-    },
-    {
-      "id": "Transport-1Metalled-Orange",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "metalled"], ["==", "lane_count", 1]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-1Metalled-Orange",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": {
           "stops": [
@@ -2207,6 +2196,9 @@
             [19, "rgba(217, 184, 127, 1)"]
           ]
         },
+        "line-dasharray": [8, 5],
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [10, 0.5],
@@ -2216,23 +2208,52 @@
             [18, 8],
             [19, 35],
             [22, 180]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"], ["==", "status", "under construction"]],
+      "id": "Transport-1-UnderCons",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
+      "paint": {
+        "line-color": "rgba(133, 130, 130, 1)",
+        "line-dasharray": [1, 5],
+        "line-width": {
+          "stops": [
+            [10, 0.5],
+            [11, 1],
+            [13, 2],
+            [15, 3],
+            [18, 8],
+            [19, 35],
+            [22, 180]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "sealed"], ["==", "lane_count", 1], ["!=", "class", "motorway"]],
+      "id": "Transport-1Sealed",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [10, "rgba(210, 162, 84, 1)"],
+            [17, "rgba(210, 162, 84, 1)"],
+            [19, "rgba(217, 184, 127, 1)"]
           ]
         },
         "line-gap-width": 0,
         "line-translate-anchor": "map",
-        "line-dasharray": [8, 5]
-      }
-    },
-    {
-      "id": "Transport-1-UnderCons",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 10,
-      "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"], ["==", "status", "under construction"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
-      "paint": {
-        "line-color": "rgba(133, 130, 130, 1)",
         "line-width": {
           "stops": [
             [10, 0.5],
@@ -2243,51 +2264,21 @@
             [19, 35],
             [22, 180]
           ]
-        },
-        "line-dasharray": [1, 5]
-      }
-    },
-    {
-      "id": "Transport-1Sealed",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
-      "filter": ["all", ["==", "surface", "sealed"], ["==", "lane_count", 1], ["!=", "class", "motorway"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
-      "paint": {
-        "line-color": {
-          "stops": [
-            [10, "rgba(210, 162, 84, 1)"],
-            [17, "rgba(210, 162, 84, 1)"],
-            [19, "rgba(217, 184, 127, 1)"]
-          ]
-        },
-        "line-width": {
-          "stops": [
-            [10, 0.5],
-            [11, 1],
-            [13, 2],
-            [15, 3],
-            [18, 8],
-            [19, 35],
-            [22, 180]
-          ]
-        },
-        "line-gap-width": 0,
-        "line-translate-anchor": "map"
-      }
+      "type": "line"
     },
     {
-      "id": "Transport-2UnMetalled",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 10,
       "filter": ["all", ["==", "surface", "unmetalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-2UnMetalled",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": "rgba(255, 255, 255, 1)",
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [10, 1.35],
@@ -2298,21 +2289,21 @@
             [19, 55],
             [22, 380]
           ]
-        },
-        "line-gap-width": 0,
-        "line-translate-anchor": "map"
-      }
-    },
-    {
-      "id": "Transport-2Metalled-White",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "metalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-2Metalled-White",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": "rgba(255, 255, 255, 1)",
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [10, 1.35],
@@ -2323,19 +2314,17 @@
             [19, 55],
             [22, 380]
           ]
-        },
-        "line-gap-width": 0,
-        "line-translate-anchor": "map"
-      }
-    },
-    {
-      "id": "Transport-2-UnderCons",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["in", "lane_count", 2, 3, 4, 5, 6, 7, 8], ["!=", "class", "motorway"], ["==", "status", "under construction"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-2-UnderCons",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": "rgba(133, 130, 130, 1)",
         "line-width": {
@@ -2349,18 +2338,21 @@
             [22, 380]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-2UnderContruction",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "status", "under construction"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-2UnderContruction",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": "rgba(255, 254, 252, 1)",
+        "line-dasharray": [5, 1],
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [10, 1.35],
@@ -2371,20 +2363,17 @@
             [19, 55],
             [22, 380]
           ]
-        },
-        "line-gap-width": 0,
-        "line-translate-anchor": "map",
-        "line-dasharray": [5, 1]
-      }
-    },
-    {
-      "id": "Transport-2Metalled-Orange",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "metalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-2Metalled-Orange",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": {
           "stops": [
@@ -2393,6 +2382,9 @@
             [19, "rgba(217, 184, 127, 1)"]
           ]
         },
+        "line-dasharray": [8, 5],
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [10, 1.35],
@@ -2402,29 +2394,28 @@
             [18, 14],
             [19, 55],
             [22, 380]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "sealed"], ["in", "lane_count", 2, 3, 4, 5, 6, 7], ["!=", "class", "motorway"]],
+      "id": "Transport-2+Sealed",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [10, "rgba(210, 162, 84, 1)"],
+            [17, "rgba(210, 162, 84, 1)"],
+            [19, "rgba(217, 184, 127, 1)"]
           ]
         },
         "line-gap-width": 0,
         "line-translate-anchor": "map",
-        "line-dasharray": [8, 5]
-      }
-    },
-    {
-      "id": "Transport-2+Sealed",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 10,
-      "filter": ["all", ["==", "surface", "sealed"], ["in", "lane_count", 2, 3, 4, 5, 6, 7], ["!=", "class", "motorway"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
-      "paint": {
-        "line-color": {
-          "stops": [
-            [10, "rgba(210, 162, 84, 1)"],
-            [17, "rgba(210, 162, 84, 1)"],
-            [19, "rgba(217, 184, 127, 1)"]
-          ]
-        },
         "line-width": {
           "stops": [
             [10, 1.35],
@@ -2435,71 +2426,69 @@
             [19, 55],
             [22, 380]
           ]
-        },
-        "line-gap-width": 0,
-        "line-translate-anchor": "map"
-      }
-    },
-    {
-      "id": "Transport-Cable-Car-People",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "cable_car"], ["==", "feature_type", "people"]],
-      "paint": { "line-color": "rgba(24, 23, 23, 0.80)", "line-width": 1.25 }
-    },
-    {
-      "id": "Transport-Cable-Car-Industrial",
-      "type": "line",
+      "id": "Transport-Cable-Car-People",
+      "paint": { "line-color": "rgba(24, 23, 23, 0.80)", "line-width": 1.25 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "cable_car"], ["==", "feature_type", "industrial"]],
-      "paint": { "line-color": "rgba(24, 23, 23, 0.80)", "line-width": 2.5 }
-    },
-    {
-      "id": "Transport-Ski-Tow",
-      "type": "line",
+      "id": "Transport-Cable-Car-Industrial",
+      "paint": { "line-color": "rgba(24, 23, 23, 0.80)", "line-width": 2.5 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "ski_tow"]],
-      "paint": { "line-color": "rgba(24, 23, 23, 0.80)", "line-width": 1.25 }
-    },
-    {
-      "id": "Transport-Ski-Lift",
-      "type": "line",
+      "id": "Transport-Ski-Tow",
+      "paint": { "line-color": "rgba(24, 23, 23, 0.80)", "line-width": 1.25 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "ski_lift"]],
-      "paint": { "line-color": "rgba(24, 23, 23, 0.80)", "line-width": 2.5 }
-    },
-    {
-      "id": "Transport-Railway-Siding",
-      "type": "line",
+      "id": "Transport-Ski-Lift",
+      "paint": { "line-color": "rgba(24, 23, 23, 0.80)", "line-width": 2.5 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rail"], ["has", "rway_use"]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
-      "paint": { "line-color": "rgba(67, 61, 61, 0.95)", "line-width": 1 }
-    },
-    {
-      "id": "Transport-Railway-Single",
-      "type": "line",
+      "id": "Transport-Railway-Siding",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 11,
+      "paint": { "line-color": "rgba(67, 61, 61, 0.95)", "line-width": 1 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rail"], ["==", "track_type", "single"], ["!has", "rway_use"]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
-      "paint": { "line-color": "rgba(67, 61, 61, 0.95)", "line-width": 2 }
-    },
-    {
-      "id": "Transport-Railway-Multiple",
-      "type": "line",
+      "id": "Transport-Railway-Single",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 11,
+      "paint": { "line-color": "rgba(67, 61, 61, 0.95)", "line-width": 2 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rail"], ["==", "track_type", "multiple"]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-Railway-Multiple",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 11,
       "paint": {
         "line-color": "rgba(67, 61, 61, 0.95)",
         "line-width": {
@@ -2509,17 +2498,17 @@
             [20, 4]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-Railway-High",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
-      "maxzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rail"]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "butt" },
+      "id": "Transport-Railway-High",
+      "layout": { "line-cap": "butt", "line-join": "round", "visibility": "visible" },
+      "maxzoom": 11,
+      "minzoom": 8,
       "paint": {
         "line-color": {
           "stops": [
@@ -2528,17 +2517,17 @@
           ]
         },
         "line-width": 2
-      }
-    },
-    {
-      "id": "Transport-1HWY-Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 1]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-1HWY-Casing",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
         "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
@@ -2553,17 +2542,17 @@
             [22, 220]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-2HWY-Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-2HWY-Casing",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
         "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
@@ -2578,17 +2567,17 @@
             [22, 450]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-HWY-Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-HWY-Casing",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
         "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
@@ -2603,17 +2592,17 @@
             [22, 470]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-Roads-9-Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 0,
-      "maxzoom": 9,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"]],
+      "id": "Transport-Roads-9-Casing",
       "layout": { "visibility": "visible" },
+      "maxzoom": 9,
+      "minzoom": 0,
       "paint": {
         "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
@@ -2624,16 +2613,16 @@
             [8, 3.5]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-1HWY",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["==", "lane_count", 1]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-1HWY",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 8,
       "paint": {
         "line-color": "rgba(240, 164, 82, 1)",
         "line-width": {
@@ -2648,17 +2637,18 @@
             [22, 200]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-2HWY",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-2HWY",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 8,
       "paint": {
+        "line-blur": 0,
         "line-color": "rgba(240, 164, 82, 1)",
         "line-width": {
           "stops": [
@@ -2671,18 +2661,17 @@
             [19, 60],
             [22, 420]
           ]
-        },
-        "line-blur": 0
-      }
-    },
-    {
-      "id": "Transport-HWY",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
-      "layout": { "visibility": "visible", "line-join": "round", "line-cap": "round" },
+      "id": "Transport-HWY",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "minzoom": 8,
       "paint": {
         "line-color": "rgba(240, 164, 82, 1)",
         "line-width": {
@@ -2697,17 +2686,17 @@
             [22, 440]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-Roads-9",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 0,
-      "maxzoom": 9,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"]],
-      "layout": { "visibility": "visible", "line-cap": "round", "line-join": "round" },
+      "id": "Transport-Roads-9",
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "visible" },
+      "maxzoom": 9,
+      "minzoom": 0,
       "paint": {
         "line-color": "rgba(210, 162, 84, 1)",
         "line-width": {
@@ -2718,16 +2707,16 @@
             [8, 2.5]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-Bridge-Foot",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "brunnel", "bridge"], ["==", "use_1", "foot traffic"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-Bridge-Foot",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(78, 78, 78, 1)",
         "line-width": {
@@ -2737,16 +2726,16 @@
             [19, 6]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-Bridge-VT",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "brunnel", "bridge"], ["in", "use_1", "train", "vehicle"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-Bridge-VT",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "line-color": "rgba(78, 78, 78, 1)",
         "line-width": {
@@ -2758,169 +2747,142 @@
             [22, 450]
           ]
         }
-      }
-    },
-    {
-      "id": "Transport-Fords",
-      "type": "circle",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 12,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "brunnel", "ford"]],
+      "id": "Transport-Fords",
+      "minzoom": 12,
       "paint": {
         "circle-color": "rgba(0, 140, 204, 1)",
+        "circle-pitch-alignment": "map",
+        "circle-pitch-scale": "map",
         "circle-radius": {
           "stops": [
             [12, 3],
             [20, 8]
           ]
         },
-        "circle-pitch-alignment": "map",
-        "circle-pitch-scale": "map",
         "circle-translate-anchor": "map"
-      }
-    },
-    {
-      "id": "All-ClosedFootRouteTrack-Labels",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "circle"
+    },
+    {
       "filter": ["all", ["has", "name"], ["==", "class", "track"], ["in", "subclass", "foot_route_closed"]],
+      "id": "All-ClosedFootRouteTrack-Labels",
       "layout": {
-        "symbol-placement": "point",
-        "text-field": "{name} {status}",
-        "text-font": ["Open Sans Regular"],
-        "icon-text-fit": "none",
-        "text-size": {
-          "stops": [
-            [13, 8],
-            [15, 11],
-            [18, 10],
-            [19, 30],
-            [22, 140]
-          ]
-        },
-        "symbol-spacing": 100,
-        "visibility": "visible",
-        "text-anchor": "top",
-        "text-justify": "center",
-        "text-transform": "none",
-        "icon-pitch-alignment": "auto",
+        "icon-allow-overlap": false,
+        "icon-anchor": "bottom",
         "icon-ignore-placement": false,
         "icon-image": "track_walking_pnt_fill",
-        "icon-anchor": "bottom",
         "icon-offset": [0, -3],
-        "text-allow-overlap": true,
-        "icon-allow-overlap": false,
-        "text-pitch-alignment": "viewport",
-        "text-rotation-alignment": "viewport",
+        "icon-pitch-alignment": "auto",
         "icon-rotation-alignment": "viewport",
-        "text-ignore-placement": false,
-        "text-max-width": 4
-      },
-      "paint": { "text-halo-width": 2.5, "text-halo-color": "rgba(205, 53, 53, 0.4)", "text-opacity": 0.9 }
-    },
-    {
-      "id": "All-ClosedFootTrack-Labels",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 13,
-      "filter": ["all", ["has", "name"], ["==", "class", "track"], ["in", "subclass", "foot_closed"]],
-      "layout": {
+        "icon-text-fit": "none",
         "symbol-placement": "point",
+        "symbol-spacing": 100,
+        "text-allow-overlap": true,
+        "text-anchor": "top",
         "text-field": "{name} {status}",
         "text-font": ["Open Sans Regular"],
-        "icon-text-fit": "none",
-        "text-size": {
-          "stops": [
-            [13, 8],
-            [15, 11],
-            [18, 10],
-            [19, 30],
-            [22, 140]
-          ]
-        },
-        "symbol-spacing": 100,
-        "visibility": "visible",
-        "text-anchor": "top",
-        "text-justify": "center",
-        "text-transform": "none",
-        "icon-pitch-alignment": "auto",
-        "icon-ignore-placement": false,
-        "icon-image": "track_walking_pnt_fill",
-        "icon-anchor": "bottom",
-        "icon-offset": [0, -3],
-        "text-allow-overlap": true,
-        "icon-allow-overlap": false,
-        "text-pitch-alignment": "viewport",
-        "text-rotation-alignment": "viewport",
-        "icon-rotation-alignment": "viewport",
         "text-ignore-placement": false,
-        "text-max-width": 4
-      },
-      "paint": { "text-halo-width": 2.5, "text-halo-color": "rgba(205, 53, 53, 0.4)", "text-opacity": 0.9, "icon-halo-color": "rgba(205, 53, 53, 0.4)", "icon-halo-width": 10, "icon-halo-blur": 0.5 }
-    },
-    {
-      "id": "All-CycleTrack-Labels",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 13,
-      "filter": ["all", ["has", "name"], ["==", "class", "track"], ["==", "track_use", "cycle only"]],
-      "layout": {
-        "symbol-placement": "point",
-        "text-field": "{name}",
-        "text-font": ["Open Sans Regular"],
-        "icon-text-fit": "none",
-        "text-size": {
-          "stops": [
-            [13, 8],
-            [15, 11],
-            [18, 10],
-            [19, 30],
-            [22, 140]
-          ]
-        },
-        "symbol-spacing": 100,
-        "visibility": "visible",
-        "text-anchor": "top",
         "text-justify": "center",
-        "text-transform": "none",
-        "icon-pitch-alignment": "auto",
-        "icon-ignore-placement": false,
-        "icon-anchor": "bottom",
-        "icon-offset": [0, -3],
-        "text-allow-overlap": true,
-        "icon-allow-overlap": false,
-        "text-pitch-alignment": "viewport",
-        "text-rotation-alignment": "viewport",
-        "icon-rotation-alignment": "viewport",
-        "text-ignore-placement": false,
         "text-max-width": 4,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [13, 8],
+            [15, 11],
+            [18, 10],
+            [19, 30],
+            [22, 140]
+          ]
+        },
+        "text-transform": "none",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": { "text-halo-color": "rgba(205, 53, 53, 0.4)", "text-halo-width": 2.5, "text-opacity": 0.9 },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "name"], ["==", "class", "track"], ["in", "subclass", "foot_closed"]],
+      "id": "All-ClosedFootTrack-Labels",
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-anchor": "bottom",
+        "icon-ignore-placement": false,
+        "icon-image": "track_walking_pnt_fill",
+        "icon-offset": [0, -3],
+        "icon-pitch-alignment": "auto",
+        "icon-rotation-alignment": "viewport",
+        "icon-text-fit": "none",
+        "symbol-placement": "point",
+        "symbol-spacing": 100,
+        "text-allow-overlap": true,
+        "text-anchor": "top",
+        "text-field": "{name} {status}",
+        "text-font": ["Open Sans Regular"],
+        "text-ignore-placement": false,
+        "text-justify": "center",
+        "text-max-width": 4,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [13, 8],
+            [15, 11],
+            [18, 10],
+            [19, 30],
+            [22, 140]
+          ]
+        },
+        "text-transform": "none",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": { "icon-halo-blur": 0.5, "icon-halo-color": "rgba(205, 53, 53, 0.4)", "icon-halo-width": 10, "text-halo-color": "rgba(205, 53, 53, 0.4)", "text-halo-width": 2.5, "text-opacity": 0.9 },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "name"], ["==", "class", "track"], ["==", "track_use", "cycle only"]],
+      "id": "All-CycleTrack-Labels",
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-anchor": "bottom",
+        "icon-ignore-placement": false,
         "icon-image": "racetrack_cycle_pnt",
+        "icon-offset": [0, -3],
+        "icon-pitch-alignment": "auto",
+        "icon-rotation-alignment": "viewport",
         "icon-size": {
           "stops": [
             [10, 1],
             [17, 1.3]
           ]
-        }
-      },
-      "paint": { "text-halo-width": 2.5, "text-halo-color": "rgba(243, 243, 242, 0.9)", "text-opacity": 0.9 }
-    },
-    {
-      "id": "All-FootTrack-Labels",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 13,
-      "filter": ["all", ["has", "name"], ["==", "class", "track"], ["==", "track_use", "foot"], ["!=", "subclass", "foot_route_closed"], ["!=", "subclass", "foot_closed"]],
-      "layout": {
-        "symbol-placement": "point",
-        "text-field": "{name} {status}",
-        "text-font": ["Open Sans Regular"],
+        },
         "icon-text-fit": "none",
+        "symbol-placement": "point",
+        "symbol-spacing": 100,
+        "text-allow-overlap": true,
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Regular"],
+        "text-ignore-placement": false,
+        "text-justify": "center",
+        "text-max-width": 4,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
         "text-size": {
           "stops": [
             [13, 8],
@@ -2930,68 +2892,95 @@
             [22, 140]
           ]
         },
-        "symbol-spacing": 100,
-        "visibility": "visible",
-        "text-anchor": "top",
-        "text-justify": "center",
         "text-transform": "none",
-        "icon-pitch-alignment": "auto",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": { "text-halo-color": "rgba(243, 243, 242, 0.9)", "text-halo-width": 2.5, "text-opacity": 0.9 },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "name"], ["==", "class", "track"], ["==", "track_use", "foot"], ["!=", "subclass", "foot_route_closed"], ["!=", "subclass", "foot_closed"]],
+      "id": "All-FootTrack-Labels",
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-anchor": "bottom",
         "icon-ignore-placement": false,
         "icon-image": "track_walking_pnt_fill",
-        "icon-anchor": "bottom",
         "icon-offset": [0, -3],
+        "icon-pitch-alignment": "auto",
+        "icon-rotation-alignment": "viewport",
+        "icon-text-fit": "none",
+        "symbol-placement": "point",
+        "symbol-spacing": 100,
         "text-allow-overlap": true,
-        "icon-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name} {status}",
+        "text-font": ["Open Sans Regular"],
+        "text-ignore-placement": false,
+        "text-justify": "center",
+        "text-max-width": 4,
         "text-pitch-alignment": "viewport",
         "text-rotation-alignment": "viewport",
-        "icon-rotation-alignment": "viewport",
-        "text-ignore-placement": false,
-        "text-max-width": 4
+        "text-size": {
+          "stops": [
+            [13, 8],
+            [15, 11],
+            [18, 10],
+            [19, 30],
+            [22, 140]
+          ]
+        },
+        "text-transform": "none",
+        "visibility": "visible"
       },
-      "paint": { "text-halo-width": 2.5, "text-halo-color": "rgba(243, 243, 242, 0.9)", "text-opacity": 0.9 }
+      "minzoom": 13,
+      "paint": { "text-halo-color": "rgba(243, 243, 242, 0.9)", "text-halo-width": 2.5, "text-opacity": 0.9 },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
     },
     {
-      "id": "Landuse-Boom",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "boom"]],
-      "paint": {
-        "line-width": {
-          "stops": [
-            [10, 1.5],
-            [13, 2],
-            [15, 4]
-          ]
-        },
-        "line-color": "rgba(73, 73, 73, 1)"
-      }
-    },
-    {
-      "id": "Landuse-Breakwater",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
+      "id": "Landuse-Boom",
       "minzoom": 12,
-      "filter": ["all", ["==", "class", "breakwater"]],
       "paint": {
+        "line-color": "rgba(73, 73, 73, 1)",
         "line-width": {
           "stops": [
             [10, 1.5],
             [13, 2],
             [15, 4]
           ]
-        },
-        "line-color": "rgba(73, 73, 73, 1)"
-      }
-    },
-    {
-      "id": "Landuse-Dam",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "breakwater"]],
+      "id": "Landuse-Breakwater",
+      "minzoom": 12,
+      "paint": {
+        "line-color": "rgba(73, 73, 73, 1)",
+        "line-width": {
+          "stops": [
+            [10, 1.5],
+            [13, 2],
+            [15, 4]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "dam_ln"]],
+      "id": "Landuse-Dam",
       "paint": {
         "line-color": "rgba(78, 78, 78, 1)",
         "line-width": {
@@ -3001,153 +2990,153 @@
             [19, 14.5]
           ]
         }
-      }
-    },
-    { "id": "Landuse-Ladder", "type": "line", "source": "LINZ Basemaps", "source-layer": "landuse", "filter": ["all", ["==", "class", "ladder"]], "paint": { "line-color": "rgba(65, 63, 63, 1)" } },
-    {
-      "id": "Landuse-MarineFarm-Ln",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
+      "type": "line"
+    },
+    { "filter": ["all", ["==", "class", "ladder"]], "id": "Landuse-Ladder", "paint": { "line-color": "rgba(65, 63, 63, 1)" }, "source": "LINZ Basemaps", "source-layer": "landuse", "type": "line" },
+    {
       "filter": ["all", ["==", "class", "marine_farm_ln"]],
-      "paint": { "line-color": "rgba(25, 114, 242, 0.45)", "line-width": 3 }
+      "id": "Landuse-MarineFarm-Ln",
+      "paint": { "line-color": "rgba(25, 114, 242, 0.45)", "line-width": 3 },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "line"
     },
     {
-      "id": "Poi-Beacon",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "beacon"], ["!has", "type"]],
+      "id": "Poi-Beacon",
       "layout": {
-        "text-font": ["Open Sans Italic"],
-        "text-field": "{name}",
-        "text-size": 8,
-        "text-justify": "right",
-        "text-anchor": "left",
         "icon-anchor": "right",
-        "visibility": "visible",
+        "icon-image": "beacon_beacon_water_pnt",
         "icon-size": {
           "stops": [
             [12, 1.3],
             [15, 1.6]
           ]
         },
-        "icon-image": "beacon_beacon_water_pnt"
-      },
-      "paint": { "text-color": "rgba(224, 168, 33, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 2, "text-halo-blur": 0.5, "icon-opacity": 0.9 }
-    },
-    {
-      "id": "Poi-Beacon-Lighthouse",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "beacon"], ["==", "type", "lighthouse"]],
-      "layout": {
-        "text-font": ["Open Sans Italic"],
-        "text-field": "{name}",
-        "text-size": 12,
-        "text-justify": "right",
         "text-anchor": "left",
-        "icon-anchor": "center",
-        "text-allow-overlap": true,
-        "icon-allow-overlap": true,
-        "icon-size": 1.3,
-        "icon-image": "beacon_lighthouse_land_pnt"
+        "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-justify": "right",
+        "text-size": 8,
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(131, 82, 19, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 2, "text-halo-blur": 0.5, "text-translate": [15, 0] }
-    },
-    {
-      "id": "Poi-Bivouac-Rock",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.9, "text-color": "rgba(224, 168, 33, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 2 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "filter": ["all", ["==", "class", "bivouac_pt"], ["==", "materials", "rock"]],
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "beacon"], ["==", "type", "lighthouse"]],
+      "id": "Poi-Beacon-Lighthouse",
       "layout": {
+        "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "icon-image": "beacon_lighthouse_land_pnt",
+        "icon-size": 1.3,
+        "text-allow-overlap": true,
+        "text-anchor": "left",
         "text-field": "{name}",
-        "text-font": ["Roboto Light"],
+        "text-font": ["Open Sans Italic"],
+        "text-justify": "right",
+        "text-size": 12
+      },
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(131, 82, 19, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 2, "text-translate": [15, 0] },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "bivouac_pt"], ["==", "materials", "rock"]],
+      "id": "Poi-Bivouac-Rock",
+      "layout": {
         "icon-image": "cave_pnt",
         "icon-size": 1,
-        "text-size": 10,
         "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Roboto Light"],
+        "text-max-width": 3,
         "text-offset": [0, 0.5],
-        "text-max-width": 3
+        "text-size": 10
       },
-      "paint": { "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-halo-blur": 1 }
-    },
-    {
-      "id": "Poi-Bivouac",
-      "type": "symbol",
+      "paint": { "text-halo-blur": 1, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "bivouac_pt"], ["!=", "materials", "rock"]],
+      "id": "Poi-Bivouac",
       "layout": {
-        "text-field": "{name} {status}",
-        "text-font": ["Roboto Light"],
         "icon-image": "building_pnt_hut",
         "icon-size": 1,
-        "text-size": 10,
         "text-anchor": "top",
+        "text-field": "{name} {status}",
+        "text-font": ["Roboto Light"],
+        "text-max-width": 3,
         "text-offset": [0, 0.5],
-        "text-max-width": 3
+        "text-size": 10
       },
-      "paint": { "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-halo-blur": 1 }
-    },
-    {
-      "id": "Poi-Buoy",
-      "type": "symbol",
+      "paint": { "text-halo-blur": 1, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "buoy"]],
-      "layout": { "icon-image": "circle_pnt_line", "text-field": "Buoy", "text-font": ["Open Sans Regular"], "text-size": 12, "text-offset": [1.5, -1], "icon-size": 0.7 }
-    },
-    {
-      "id": "Poi-Cave-Pt",
-      "type": "symbol",
+      "id": "Poi-Buoy",
+      "layout": { "icon-image": "circle_pnt_line", "icon-size": 0.7, "text-field": "Buoy", "text-font": ["Open Sans Regular"], "text-offset": [1.5, -1], "text-size": 12 },
+      "minzoom": 12,
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["any", ["==", "class", "cave"]],
+      "id": "Poi-Cave-Pt",
       "layout": {
-        "visibility": "visible",
         "icon-image": "cave_pnt",
+        "text-anchor": "left",
         "text-field": "{name}",
         "text-font": ["Open Sans Regular"],
-        "text-size": 10,
         "text-justify": "left",
-        "text-anchor": "left",
-        "text-max-width": 4
+        "text-max-width": 4,
+        "text-size": 10,
+        "visibility": "visible"
       },
-      "paint": { "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-halo-blur": 0.5, "text-translate": [15, 0] }
-    },
-    {
-      "id": "Poi-Cemetery-Pt",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-translate": [15, 0] },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "cemetery"]],
+      "id": "Poi-Cemetery-Pt",
       "layout": {
+        "icon-image": "grave_pnt",
         "icon-size": {
           "stops": [
             [12, 0.8],
             [18, 1.2]
           ]
         },
-        "icon-image": "grave_pnt",
-        "text-font": ["Open Sans Regular"],
+        "text-anchor": "top",
         "text-field": {
           "stops": [
             [12, ""],
             [13, "{class}"]
           ]
         },
-        "text-size": 10,
-        "text-anchor": "top",
-        "text-offset": [0, 0.5]
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "text-size": 10
       },
+      "minzoom": 12,
       "paint": {
         "icon-opacity": {
           "stops": [
@@ -3155,82 +3144,74 @@
             [13, 0.9]
           ]
         },
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 1.5,
         "text-opacity": {
           "stops": [
             [13, 0.1],
             [14, 1]
           ]
-        },
-        "text-halo-width": 1.5,
-        "text-halo-blur": 0.5,
-        "text-halo-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "Poi-Chimney",
-      "type": "symbol",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "chimney"]],
-      "layout": { "icon-image": "chimney_pnt", "text-font": ["Open Sans Regular"], "text-field": "", "text-justify": "right", "text-anchor": "left", "text-offset": [1, 0], "icon-size": 1.5 }
-    },
-    {
-      "id": "Poi-Dredge",
-      "type": "symbol",
+      "id": "Poi-Chimney",
+      "layout": { "icon-image": "chimney_pnt", "icon-size": 1.5, "text-anchor": "left", "text-field": "", "text-font": ["Open Sans Regular"], "text-justify": "right", "text-offset": [1, 0] },
+      "minzoom": 12,
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "dredge"]],
-      "layout": { "text-field": "", "text-font": ["Open Sans Regular"], "text-justify": "left", "text-anchor": "bottom-left", "icon-image": "square_pnt_fill", "icon-size": 0.8 }
-    },
-    {
-      "id": "Poi-FishFarm-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 16,
-      "filter": ["all", ["==", "class", "fish_farm"]],
-      "layout": { "text-font": ["Roboto Bold Italic"], "text-field": "{species}", "text-size": 10 },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 1.5, "text-halo-blur": 0.5 }
-    },
-    {
-      "id": "Poi-Flare",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
+      "id": "Poi-Dredge",
+      "layout": { "icon-image": "square_pnt_fill", "icon-size": 0.8, "text-anchor": "bottom-left", "text-field": "", "text-font": ["Open Sans Regular"], "text-justify": "left" },
       "minzoom": 12,
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "fish_farm"]],
+      "id": "Poi-FishFarm-Label",
+      "layout": { "text-field": "{species}", "text-font": ["Roboto Bold Italic"], "text-size": 10 },
+      "minzoom": 16,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "flare"]],
-      "layout": { "icon-image": "square_pnt_fill", "text-field": "{class}", "icon-size": 0.8, "text-font": ["Open Sans Regular"], "text-size": 12, "text-anchor": "top", "text-offset": [0, 0.5] },
+      "id": "Poi-Flare",
+      "layout": { "icon-image": "square_pnt_fill", "icon-size": 0.8, "text-anchor": "top", "text-field": "{class}", "text-font": ["Open Sans Regular"], "text-offset": [0, 0.5], "text-size": 12 },
+      "minzoom": 12,
       "paint": {
-        "text-halo-width": 1,
-        "text-halo-blur": 0.5,
-        "text-color": "rgba(0, 0, 0, 1)",
         "icon-opacity": 0.9,
+        "text-color": "rgba(0, 0, 0, 1)",
+        "text-halo-blur": 0.5,
         "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 1,
         "text-opacity": {
           "stops": [
             [14, 0.2],
             [15, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Floodgate",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "floodgate"]],
+      "id": "Poi-Floodgate",
       "layout": {
-        "text-field": {
-          "stops": [
-            [12, ""],
-            [16, "floodgate"]
-          ]
-        },
-        "text-font": ["Open Sans Regular"],
         "icon-image": "gate_pnt",
         "icon-size": {
           "stops": [
@@ -3238,6 +3219,13 @@
             [15, 1.5]
           ]
         },
+        "text-field": {
+          "stops": [
+            [12, ""],
+            [16, "floodgate"]
+          ]
+        },
+        "text-font": ["Open Sans Regular"],
         "text-offset": [2.5, -0.8],
         "text-size": {
           "stops": [
@@ -3245,49 +3233,50 @@
             [16, 18]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-GasValve",
-      "type": "symbol",
+      },
+      "minzoom": 13,
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "gas_valve"]],
+      "id": "Poi-GasValve",
       "layout": {
+        "icon-image": "circle_pnt_line",
+        "text-field": "{class}",
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 1],
         "text-size": {
           "stops": [
             [12, 8],
             [14, 10]
           ]
-        },
-        "text-field": "{class}",
-        "text-font": ["Open Sans Regular"],
-        "text-offset": [0, 1],
-        "icon-image": "circle_pnt_line"
-      }
-    },
-    {
-      "id": "Poi-Gate",
-      "type": "symbol",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "gate"]],
+      "id": "Poi-Gate",
       "layout": {
-        "text-field": "",
-        "text-font": [],
+        "icon-allow-overlap": false,
         "icon-image": "gate_pnt",
+        "icon-pitch-alignment": "map",
+        "icon-rotate": 0,
         "icon-size": {
           "stops": [
             [12, 1],
             [16, 1.5]
           ]
         },
-        "icon-allow-overlap": false,
-        "icon-pitch-alignment": "map",
         "text-allow-overlap": true,
-        "icon-rotate": 0
+        "text-field": "",
+        "text-font": []
       },
+      "minzoom": 12,
       "paint": {
         "icon-opacity": {
           "stops": [
@@ -3295,41 +3284,40 @@
             [13, 0.9]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-GeoBore",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "geo_bore"]],
-      "layout": { "icon-allow-overlap": true, "text-font": [], "icon-image": "geobore_pnt_thick", "icon-size": 0.85 },
+      "id": "Poi-GeoBore",
+      "layout": { "icon-allow-overlap": true, "icon-image": "geobore_pnt_thick", "icon-size": 0.85, "text-font": [] },
       "paint": {
-        "text-opacity": 1,
         "icon-opacity": {
           "stops": [
             [12, 0.25],
             [13, 1]
           ]
-        }
-      }
-    },
-    {
-      "id": "Poi-GeoBore-Label",
-      "type": "symbol",
+        },
+        "text-opacity": 1
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 19,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "geo_bore"]],
-      "layout": { "icon-allow-overlap": true, "visibility": "visible", "icon-size": 1, "text-font": ["Open Sans Regular"], "text-field": "{class}", "text-size": 10, "text-offset": [0, 1] }
-    },
-    {
-      "id": "Poi-Grave-Pt",
-      "type": "symbol",
+      "id": "Poi-GeoBore-Label",
+      "layout": { "icon-allow-overlap": true, "icon-size": 1, "text-field": "{class}", "text-font": ["Open Sans Regular"], "text-offset": [0, 1], "text-size": 10, "visibility": "visible" },
+      "minzoom": 19,
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "grave"]],
+      "id": "Poi-Grave-Pt",
       "layout": {
         "icon-image": "grave_pnt",
         "icon-size": {
@@ -3340,42 +3328,47 @@
         },
         "visibility": "visible"
       },
-      "paint": { "icon-opacity": 0.9 }
-    },
-    {
-      "id": "Poi-Historic-Site",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.9 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "historic_site"]],
-      "layout": { "text-field": "{ref}", "icon-image": "historic_site_pnt", "text-font": ["Open Sans Regular"], "text-justify": "left", "text-anchor": "left", "text-offset": [1, 0], "text-size": 10 },
+      "id": "Poi-Historic-Site",
+      "layout": { "icon-image": "historic_site_pnt", "text-anchor": "left", "text-field": "{ref}", "text-font": ["Open Sans Regular"], "text-justify": "left", "text-offset": [1, 0], "text-size": 10 },
+      "minzoom": 12,
       "paint": {
-        "text-color": "rgba(203, 12, 12, 1)",
         "icon-opacity": {
           "stops": [
             [12, 0.1],
             [14, 1]
           ]
         },
+        "text-color": "rgba(203, 12, 12, 1)",
+        "text-halo-blur": 0.5,
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1.5,
-        "text-halo-blur": 0.5,
         "text-opacity": {
           "stops": [
             [16, 0.1],
             [17, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Hut-Label",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
       "filter": ["any", ["==", "class", "hut"]],
+      "id": "Poi-Hut-Label",
       "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": "building_pnt_hut",
+        "icon-size": 1,
+        "text-anchor": "left",
         "text-field": {
           "stops": [
             [6, ""],
@@ -3383,142 +3376,138 @@
           ]
         },
         "text-font": ["Roboto Bold"],
-        "text-size": 10,
-        "icon-size": 1,
         "text-justify": "left",
-        "text-anchor": "left",
-        "icon-allow-overlap": true,
-        "text-offset": [1, 0],
         "text-max-width": 5,
-        "icon-image": "building_pnt_hut"
+        "text-offset": [1, 0],
+        "text-size": 10
       },
-      "paint": { "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-color": "rgba(73, 68, 68, 1)", "text-opacity": 1 }
-    },
-    {
-      "id": "Poi-Kiln",
-      "type": "symbol",
+      "paint": { "text-color": "rgba(73, 68, 68, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-opacity": 1 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "kiln"]],
-      "layout": {
-        "text-font": ["Roboto Light"],
-        "icon-image": "circle_pnt_line",
-        "text-field": "{class}",
-        "text-size": 10,
-        "text-anchor": "left",
-        "text-justify": "right",
-        "icon-size": 0.75,
-        "text-offset": [1, 0]
-      },
-      "paint": { "text-color": "rgba(0, 0, 0, 1)", "text-halo-width": 1.5, "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)" }
+      "type": "symbol"
     },
     {
+      "filter": ["all", ["==", "class", "kiln"]],
+      "id": "Poi-Kiln",
+      "layout": {
+        "icon-image": "circle_pnt_line",
+        "icon-size": 0.75,
+        "text-anchor": "left",
+        "text-field": "{class}",
+        "text-font": ["Roboto Light"],
+        "text-justify": "right",
+        "text-offset": [1, 0],
+        "text-size": 10
+      },
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(0, 0, 0, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "ladder"]],
       "id": "Poi-Ladder",
-      "type": "symbol",
+      "layout": { "symbol-placement": "line", "text-anchor": "top", "text-field": "ladder", "text-font": ["Roboto Light"] },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "filter": ["all", ["==", "class", "ladder"]],
-      "layout": { "text-font": ["Roboto Light"], "text-field": "ladder", "symbol-placement": "line", "text-anchor": "top" }
+      "type": "symbol"
     },
     {
-      "id": "Poi-Ladder-Pt",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
       "filter": ["all", ["==", "class", "ladder_pt"]],
+      "id": "Poi-Ladder-Pt",
       "layout": {
         "icon-image": "circle_pnt_fill",
-        "text-field": "ladder",
-        "text-font": ["Roboto Light"],
-        "text-size": 13,
+        "icon-size": 0.5,
         "text-allow-overlap": true,
         "text-anchor": "top",
+        "text-field": "ladder",
+        "text-font": ["Roboto Light"],
         "text-offset": [0, 0.5],
-        "icon-size": 0.5
+        "text-size": 13
       },
-      "paint": { "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-blur": 1, "text-halo-width": 1.5 }
-    },
-    {
-      "id": "Poi-Mast-Label-Triangle",
-      "type": "symbol",
+      "paint": { "text-halo-blur": 1, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "mast"]],
+      "id": "Poi-Mast-Label-Triangle",
       "layout": {
-        "icon-image": "mast_pnt",
-        "text-allow-overlap": false,
-        "visibility": "visible",
         "icon-allow-overlap": true,
+        "icon-image": "mast_pnt",
+        "icon-size": 1.1,
+        "text-allow-overlap": false,
         "text-field": "",
         "text-font": ["Open Sans Regular"],
-        "text-size": 10,
         "text-offset": [0, 1],
-        "icon-size": 1.1
-      },
-      "paint": { "icon-opacity": 0.85 }
-    },
-    {
-      "id": "Poi-Mine-Pt",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 13,
-      "filter": ["all", ["==", "class", "mine"]],
-      "layout": {
-        "text-font": ["Open Sans Bold Italic"],
-        "text-field": "{name} {substance} {visibility} {status} ",
         "text-size": 10,
-        "text-justify": "left",
-        "text-anchor": "left",
-        "text-offset": [1, 0],
-        "icon-anchor": "center",
-        "icon-size": 0.7,
-        "text-max-width": 4,
-        "visibility": "visible",
-        "icon-image": "square_pnt_fill"
+        "visibility": "visible"
       },
-      "paint": { "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 0.75, "text-halo-blur": 0.75, "icon-opacity": 0.8, "text-opacity": 0.9 }
-    },
-    {
-      "id": "Poi-Monument",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.85 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "monument"]],
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "mine"]],
+      "id": "Poi-Mine-Pt",
       "layout": {
-        "text-font": ["Open Sans Italic"],
-        "text-field": "{name}",
-        "text-size": 9,
-        "text-justify": "left",
-        "text-anchor": "left",
         "icon-anchor": "center",
-        "visibility": "visible",
+        "icon-image": "square_pnt_fill",
+        "icon-size": 0.7,
+        "text-anchor": "left",
+        "text-field": "{name} {substance} {visibility} {status} ",
+        "text-font": ["Open Sans Bold Italic"],
+        "text-justify": "left",
+        "text-max-width": 4,
+        "text-offset": [1, 0],
+        "text-size": 10,
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": { "icon-opacity": 0.8, "text-halo-blur": 0.75, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 0.75, "text-opacity": 0.9 },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "monument"]],
+      "id": "Poi-Monument",
+      "layout": {
         "icon-allow-overlap": true,
-        "text-offset": [1.5, 0],
-        "text-allow-overlap": true,
-        "text-max-width": 5,
+        "icon-anchor": "center",
+        "icon-image": "monument_pnt",
         "icon-size": {
           "stops": [
             [12, 1.2],
             [16, 1.6]
           ]
         },
+        "text-allow-overlap": true,
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-justify": "left",
+        "text-max-width": 5,
+        "text-offset": [1.5, 0],
         "text-radial-offset": 0,
-        "icon-image": "monument_pnt"
+        "text-size": 9,
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(98, 53, 0, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 2, "text-halo-blur": 0.5, "icon-opacity": 0.85 }
-    },
-    {
-      "id": "Poi-Pa",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.85, "text-color": "rgba(98, 53, 0, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 2 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "pa"]],
-      "layout": { "text-ignore-placement": true, "icon-image": "pa_pnt", "icon-allow-overlap": true, "text-anchor": "center" },
+      "id": "Poi-Pa",
+      "layout": { "icon-allow-overlap": true, "icon-image": "pa_pnt", "text-anchor": "center", "text-ignore-placement": true },
+      "minzoom": 12,
       "paint": {
         "icon-opacity": {
           "stops": [
@@ -3528,16 +3517,16 @@
             [19, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Pylon",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 15,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "pylon"]],
-      "layout": { "text-font": [], "text-pitch-alignment": "map", "text-rotation-alignment": "map", "icon-pitch-alignment": "map", "icon-rotation-alignment": "auto", "icon-image": "square_pnt_line" },
+      "id": "Poi-Pylon",
+      "layout": { "icon-image": "square_pnt_line", "icon-pitch-alignment": "map", "icon-rotation-alignment": "auto", "text-font": [], "text-pitch-alignment": "map", "text-rotation-alignment": "map" },
+      "minzoom": 15,
       "paint": {
         "icon-opacity": {
           "stops": [
@@ -3545,107 +3534,123 @@
             [16, 0.6]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Quarry-Poly-NoName",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "quarry"], ["!has", "name"]],
+      "id": "Poi-Quarry-Poly-NoName",
       "layout": {
-        "text-font": ["Open Sans Bold Italic"],
-        "text-field": "{class} {substance} {status}",
-        "text-size": 10,
-        "icon-anchor": "center",
-        "visibility": "visible",
-        "text-justify": "center",
-        "text-anchor": "top",
-        "icon-image": "square_pnt_fill",
         "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "icon-image": "square_pnt_fill",
         "icon-size": 0.6,
+        "text-anchor": "top",
+        "text-field": "{class} {substance} {status}",
+        "text-font": ["Open Sans Bold Italic"],
+        "text-justify": "center",
         "text-max-width": 4,
-        "text-offset": [0, 0.5]
+        "text-offset": [0, 0.5],
+        "text-size": 10,
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(47, 47, 47, 1)", "text-halo-width": 1, "text-halo-blur": 0.75, "text-halo-color": "rgba(255, 255, 255, 1)", "icon-opacity": 0.65 }
-    },
-    {
-      "id": "Poi-Quarry-Poly-Name",
-      "type": "symbol",
+      "minzoom": 13,
+      "paint": { "icon-opacity": 0.65, "text-color": "rgba(47, 47, 47, 1)", "text-halo-blur": 0.75, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "quarry"], ["has", "name"]],
+      "id": "Poi-Quarry-Poly-Name",
       "layout": {
-        "text-font": ["Open Sans Bold Italic"],
-        "text-field": "{name} {substance} {status}",
-        "text-size": 10,
-        "icon-anchor": "center",
-        "visibility": "visible",
-        "text-justify": "left",
-        "text-anchor": "left",
-        "icon-image": "square_pnt_fill",
         "icon-allow-overlap": true,
-        "icon-size": 0.6,
+        "icon-anchor": "center",
+        "icon-image": "square_pnt_fill",
         "icon-offset": [0, 0],
+        "icon-size": 0.6,
         "text-allow-overlap": true,
+        "text-anchor": "left",
+        "text-field": "{name} {substance} {status}",
+        "text-font": ["Open Sans Bold Italic"],
+        "text-justify": "left",
+        "text-max-width": 4,
         "text-offset": [1, 0],
-        "text-max-width": 4
+        "text-size": 10,
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "icon-opacity": 0.65,
+        "icon-translate-anchor": "viewport",
         "text-color": "rgba(47, 47, 47, 1)",
-        "text-halo-width": 0.75,
         "text-halo-blur": 0.75,
         "text-halo-color": "rgba(255, 255, 255, 1)",
-        "icon-opacity": 0.65,
-        "icon-translate-anchor": "viewport"
-      }
-    },
-    {
-      "id": "Poi-Racetrack-Label",
-      "type": "symbol",
+        "text-halo-width": 0.75
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["any", ["==", "class", "racetrack"], ["==", "class", "racetrack_ln"]],
-      "layout": { "text-field": "{name}", "text-font": ["Open Sans Bold"], "text-size": 10, "text-pitch-alignment": "viewport", "text-rotation-alignment": "viewport" },
+      "id": "Poi-Racetrack-Label",
+      "layout": { "text-field": "{name}", "text-font": ["Open Sans Bold"], "text-pitch-alignment": "viewport", "text-rotation-alignment": "viewport", "text-size": 10 },
+      "minzoom": 13,
       "paint": {
-        "text-translate-anchor": "viewport",
+        "icon-translate-anchor": "viewport",
         "text-color": "rgba(129, 123, 123, 1)",
+        "text-halo-blur": 0.5,
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-        "text-halo-blur": 0.5,
-        "icon-translate-anchor": "viewport"
-      }
-    },
-    {
-      "id": "Poi-Radar-Dome",
-      "type": "symbol",
+        "text-translate-anchor": "viewport"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "radar_dome"]],
-      "layout": { "icon-image": "circle_pnt_fill", "icon-size": 0.5 }
-    },
-    {
-      "id": "Poi-Railway-Symbol",
-      "type": "symbol",
+      "id": "Poi-Radar-Dome",
+      "layout": { "icon-image": "circle_pnt_fill", "icon-size": 0.5 },
+      "minzoom": 12,
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "railway"]],
+      "id": "Poi-Railway-Symbol",
       "layout": {
-        "text-font": ["Open Sans Bold Italic"],
+        "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "icon-image": {
+          "stops": [
+            [12, "rail_station_pnt_red"],
+            [13, "rail_station_train_diesel_pnt_red"]
+          ]
+        },
+        "icon-optional": true,
+        "icon-size": {
+          "stops": [
+            [12, 0.4],
+            [13, 1],
+            [20, 2]
+          ]
+        },
+        "text-anchor": "left",
         "text-field": {
           "stops": [
             [12, "{name}"],
             [13, "{name}"]
           ]
         },
+        "text-font": ["Open Sans Bold Italic"],
         "text-justify": "left",
-        "text-anchor": "left",
-        "icon-anchor": "center",
+        "text-max-width": 5,
+        "text-offset": [1.25, 1.5],
         "text-size": {
           "stops": [
             [13, 10],
@@ -3654,53 +3659,37 @@
             [18, 19]
           ]
         },
-        "icon-allow-overlap": true,
-        "icon-size": {
-          "stops": [
-            [12, 0.4],
-            [13, 1],
-            [20, 2]
-          ]
-        },
-        "text-max-width": 5,
-        "icon-image": {
-          "stops": [
-            [12, "rail_station_pnt_red"],
-            [13, "rail_station_train_diesel_pnt_red"]
-          ]
-        },
-        "text-offset": [1.25, 1.5],
-        "icon-optional": true,
         "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(94, 94, 94, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-halo-blur": 0.5, "text-translate": [0, -15] }
-    },
-    {
-      "id": "Poi-Redoubt",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
       "minzoom": 12,
-      "filter": ["all", ["==", "class", "redoubt"]],
-      "layout": { "icon-image": "redoubt_pnt" }
-    },
-    {
-      "id": "Poi-RifleRange-Label",
-      "type": "symbol",
+      "paint": { "text-color": "rgba(94, 94, 94, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-translate": [0, -15] },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "redoubt"]],
+      "id": "Poi-Redoubt",
+      "layout": { "icon-image": "redoubt_pnt" },
+      "minzoom": 12,
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "rifle_range"]],
+      "id": "Poi-RifleRange-Label",
       "layout": {
-        "text-font": ["Open Sans Regular"],
-        "text-field": "",
-        "text-size": 9,
         "icon-image": "rifle_range_pnt",
         "icon-size": {
           "stops": [
             [12, 1.2],
             [15, 1.5]
           ]
-        }
+        },
+        "text-field": "",
+        "text-font": ["Open Sans Regular"],
+        "text-size": 9
       },
       "paint": {
         "icon-opacity": {
@@ -3709,87 +3698,85 @@
             [13, 0.9]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Satellite-Station-Pt",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "satellite_pt"]],
+      "id": "Poi-Satellite-Station-Pt",
       "layout": {
-        "visibility": "visible",
-        "icon-image": "satellite_station_pnt",
         "icon-allow-overlap": false,
+        "icon-image": "satellite_station_pnt",
         "icon-size": {
           "stops": [
             [12, 1.2],
             [15, 1.5],
             [17, 1.7]
           ]
-        }
-      }
-    },
-    {
-      "id": "Poi-Shaft",
-      "type": "symbol",
+        },
+        "visibility": "visible"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "shaft"]],
+      "id": "Poi-Shaft",
       "layout": { "icon-image": "shaft_pnt", "icon-size": 0.85 },
-      "paint": { "icon-opacity": 0.9 }
-    },
-    {
-      "id": "Poi-Sinkhole",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.9 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "sinkhole"]],
-      "layout": { "icon-image": "sinkhole_pnt" }
-    },
-    {
-      "id": "Poi-Siphon-Pt",
-      "type": "symbol",
+      "id": "Poi-Sinkhole",
+      "layout": { "icon-image": "sinkhole_pnt" },
+      "minzoom": 12,
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "siphon_pt"]],
+      "id": "Poi-Siphon-Pt",
       "layout": { "icon-image": "circle_pnt_fill", "icon-size": 0.8 },
-      "paint": { "icon-opacity": 0.85 }
-    },
-    {
-      "id": "Poi-Showground-Symbol",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.85 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "showground"]],
+      "id": "Poi-Showground-Symbol",
       "layout": {
-        "text-font": ["Open Sans Bold Italic"],
-        "text-size": 9,
-        "text-field": "",
         "icon-image": "showground_pnt",
         "icon-size": {
           "stops": [
             [12, 1.2],
             [15, 1.5]
           ]
-        }
+        },
+        "text-field": "",
+        "text-font": ["Open Sans Bold Italic"],
+        "text-size": 9
       },
-      "paint": { "text-color": "rgba(121, 195, 128, 0.2)", "text-halo-color": "rgba(255, 255, 255, 1)" }
-    },
-    {
-      "id": "Poi-Soakhole",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(121, 195, 128, 0.2)", "text-halo-color": "rgba(255, 255, 255, 1)" },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "soakhole"]],
+      "id": "Poi-Soakhole",
       "layout": {
-        "visibility": "visible",
-        "text-field": "",
+        "icon-image": "well_pnt_small_fill",
         "icon-size": {
           "stops": [
             [12, 0.25],
@@ -3797,29 +3784,30 @@
             [19, 1]
           ]
         },
+        "text-field": "",
         "text-font": [],
         "text-size": 10,
-        "icon-image": "well_pnt_small_fill"
+        "visibility": "visible"
       },
-      "paint": { "icon-opacity": 0.8 }
-    },
-    {
-      "id": "Poi-SportsField-Label",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.8 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "sports_field"]],
-      "layout": { "text-font": ["Open Sans Bold Italic"], "text-field": "{name}", "text-size": 9 },
-      "paint": { "text-color": "rgba(37, 108, 41, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1 }
-    },
-    {
-      "id": "Poi-Stockyard",
-      "type": "symbol",
+      "id": "Poi-SportsField-Label",
+      "layout": { "text-field": "{name}", "text-font": ["Open Sans Bold Italic"], "text-size": 9 },
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(37, 108, 41, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "stockyard"]],
+      "id": "Poi-Stockyard",
       "layout": {
         "icon-image": "stockyard_pnt",
         "icon-size": {
@@ -3829,6 +3817,7 @@
           ]
         }
       },
+      "minzoom": 12,
       "paint": {
         "icon-opacity": {
           "stops": [
@@ -3836,65 +3825,58 @@
             [13, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Trig-Elevation",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 15,
-      "filter": ["all", ["==", "class", "trig"]],
-      "layout": { "text-font": ["Open Sans Italic"], "text-size": 9, "text-field": "{elevation} m", "text-justify": "center", "text-anchor": "top", "visibility": "visible", "text-offset": [0, 1.3] },
-      "paint": { "text-halo-width": 0.75, "text-halo-blur": 0.75, "text-halo-color": "rgba(255, 255, 255, 1)" }
-    },
-    {
-      "id": "Poi-Trig-Symbol",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "trig"]],
-      "layout": {
-        "text-font": ["Open Sans Bold Italic"],
-        "text-size": 10,
-        "text-field": "{name}",
-        "text-justify": "left",
-        "text-anchor": "bottom",
-        "text-offset": [0, -0.7],
-        "visibility": "visible",
-        "icon-size": 0.75,
-        "icon-image": "triangle_pnt_fill"
       },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "trig"]],
+      "id": "Poi-Trig-Elevation",
+      "layout": { "text-anchor": "top", "text-field": "{elevation} m", "text-font": ["Open Sans Italic"], "text-justify": "center", "text-offset": [0, 1.3], "text-size": 9, "visibility": "visible" },
+      "minzoom": 15,
+      "paint": { "text-halo-blur": 0.75, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 0.75 },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "trig"]],
+      "id": "Poi-Trig-Symbol",
+      "layout": {
+        "icon-image": "triangle_pnt_fill",
+        "icon-size": 0.75,
+        "text-anchor": "bottom",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Bold Italic"],
+        "text-justify": "left",
+        "text-offset": [0, -0.7],
+        "text-size": 10,
+        "visibility": "visible"
+      },
+      "minzoom": 12,
       "paint": {
+        "icon-opacity": 0.6,
+        "text-color": "rgba(69, 50, 50, 1)",
+        "text-halo-blur": 0.75,
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 0.75,
-        "text-halo-blur": 0.75,
-        "text-color": "rgba(69, 50, 50, 1)",
-        "icon-opacity": 0.6,
         "text-opacity": {
           "stops": [
             [12, 0.2],
             [13, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Well",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "well"]],
+      "id": "Poi-Well",
       "layout": {
         "icon-anchor": "center",
-        "text-field": "{status}",
-        "text-font": ["Open Sans Italic"],
-        "text-size": 10,
-        "text-justify": "left",
-        "text-anchor": "left",
-        "text-offset": [0.75, 0],
         "icon-image": {
           "stops": [
             [12, "well_pnt_small_line"],
@@ -3910,89 +3892,100 @@
             [15, 1],
             [17, 1.4]
           ]
-        }
+        },
+        "text-anchor": "left",
+        "text-field": "{status}",
+        "text-font": ["Open Sans Italic"],
+        "text-justify": "left",
+        "text-offset": [0.75, 0],
+        "text-size": 10
       },
-      "paint": { "text-halo-width": 0.75, "text-halo-blur": 0.75, "text-color": "rgba(133, 112, 112, 1)", "text-halo-color": "rgba(242, 242, 242, 1)" }
-    },
-    {
-      "id": "Poi-Windmill",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(133, 112, 112, 1)", "text-halo-blur": 0.75, "text-halo-color": "rgba(242, 242, 242, 1)", "text-halo-width": 0.75 },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "power"], ["==", "power_source", "wind_turbine"]],
+      "id": "Poi-Windmill",
       "layout": {
-        "text-font": ["Open Sans Italic"],
-        "text-field": "",
-        "visibility": "visible",
-        "text-justify": "center",
-        "text-anchor": "top",
-        "icon-offset": [0, 0],
-        "text-offset": [0, 0],
         "icon-anchor": "bottom",
         "icon-image": "windmill_pnt",
-        "text-size": 8.5,
+        "icon-offset": [0, 0],
         "icon-size": {
           "stops": [
             [11, 1.2],
             [15, 1.5],
             [18, 1.8]
           ]
-        }
+        },
+        "text-anchor": "top",
+        "text-field": "",
+        "text-font": ["Open Sans Italic"],
+        "text-justify": "center",
+        "text-offset": [0, 0],
+        "text-size": 8.5,
+        "visibility": "visible"
       },
       "paint": {
-        "text-color": "rgba(63, 44, 44, 1)",
-        "text-halo-color": "rgba(252, 249, 249, 1)",
-        "text-halo-width": 1,
         "icon-opacity": {
           "stops": [
             [12, 0.25],
             [13, 1]
           ]
-        }
-      }
-    },
-    {
-      "id": "Poi-Wreck",
-      "type": "symbol",
+        },
+        "text-color": "rgba(63, 44, 44, 1)",
+        "text-halo-color": "rgba(252, 249, 249, 1)",
+        "text-halo-width": 1
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "wreck"]],
+      "id": "Poi-Wreck",
       "layout": {
-        "text-font": ["Open Sans Italic"],
-        "text-field": "{name}",
-        "text-size": 11,
+        "icon-allow-overlap": true,
         "icon-anchor": "center",
-        "text-justify": "left",
-        "text-anchor": "left",
         "icon-image": "wreck_ship_pnt",
+        "icon-rotation-alignment": "viewport",
         "icon-size": {
           "stops": [
             [12, 1.3],
             [14, 1.5]
           ]
         },
-        "icon-allow-overlap": true,
-        "icon-rotation-alignment": "viewport",
-        "text-max-width": 7
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-justify": "left",
+        "text-max-width": 7,
+        "text-size": 11
       },
-      "paint": { "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1, "text-color": "rgba(69, 50, 50, 1)", "text-translate": [10, 0] }
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(69, 50, 50, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1, "text-translate": [10, 0] },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
     },
     {
-      "id": "Orchard-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 14,
       "filter": ["all", ["==", "landuse", "orchard"]],
+      "id": "Orchard-Label",
       "layout": {
-        "text-font": ["Open Sans Italic"],
+        "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "icon-image": "orchard_pnt_dual",
+        "icon-pitch-alignment": "viewport",
+        "text-anchor": "top",
         "text-field": {
           "stops": [
             [6, ""],
             [16, "{landuse}"]
           ]
         },
+        "text-font": ["Open Sans Italic"],
         "text-justify": "auto",
         "text-size": {
           "stops": [
@@ -4000,38 +3993,37 @@
             [20, 16]
           ]
         },
-        "visibility": "visible",
-        "icon-pitch-alignment": "viewport",
-        "icon-image": "orchard_pnt_dual",
-        "icon-anchor": "center",
-        "icon-allow-overlap": true,
-        "text-anchor": "top"
+        "visibility": "visible"
       },
+      "minzoom": 14,
       "paint": {
+        "icon-opacity": 0.9,
         "text-color": "rgba(27, 77, 29, 1)",
-        "text-translate-anchor": "viewport",
+        "text-halo-blur": 0.5,
         "text-halo-color": "rgba(255, 255, 255, 0.59)",
         "text-halo-width": 1,
-        "text-halo-blur": 0.5,
         "text-translate": [0, 6],
-        "icon-opacity": 0.9
-      }
-    },
-    {
-      "id": "Vineyard-Label",
-      "type": "symbol",
+        "text-translate-anchor": "viewport"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 14,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "landuse", "vineyard"]],
+      "id": "Vineyard-Label",
       "layout": {
-        "text-font": ["Open Sans Italic"],
+        "icon-anchor": "center",
+        "icon-image": "vineyard_pnt_dual",
+        "icon-pitch-alignment": "viewport",
+        "text-anchor": "top",
         "text-field": {
           "stops": [
             [6, ""],
             [16, "{landuse}"]
           ]
         },
+        "text-font": ["Open Sans Italic"],
         "text-justify": "auto",
         "text-size": {
           "stops": [
@@ -4039,31 +4031,29 @@
             [20, 16]
           ]
         },
-        "visibility": "visible",
-        "icon-pitch-alignment": "viewport",
-        "icon-image": "vineyard_pnt_dual",
-        "icon-anchor": "center",
-        "text-anchor": "top"
+        "visibility": "visible"
       },
+      "minzoom": 14,
       "paint": {
+        "icon-opacity": 0.9,
         "text-color": "rgba(17, 63, 29, 0.85)",
-        "text-translate-anchor": "viewport",
+        "text-halo-blur": 0.5,
         "text-halo-color": "rgba(255, 255, 255, 0.59)",
         "text-halo-width": 1,
-        "text-halo-blur": 0.5,
         "text-translate": [0, 6],
-        "icon-opacity": 0.9
-      }
+        "text-translate-anchor": "viewport"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
     },
     {
-      "id": "Building3D",
-      "type": "fill-extrusion",
-      "source": "LINZ Basemaps",
-      "source-layer": "building",
-      "minzoom": 18,
       "filter": ["none"],
+      "id": "Building3D",
       "layout": { "visibility": "visible" },
+      "minzoom": 18,
       "paint": {
+        "fill-extrusion-color": "rgba(190, 190, 190, 1)",
         "fill-extrusion-height": {
           "base": 1,
           "stops": [
@@ -4071,233 +4061,151 @@
             [14, 2.5]
           ]
         },
-        "fill-extrusion-color": "rgba(190, 190, 190, 1)",
+        "fill-extrusion-opacity": 0.5,
         "fill-extrusion-translate-anchor": "viewport",
-        "fill-extrusion-vertical-gradient": true,
-        "fill-extrusion-opacity": 0.5
-      }
+        "fill-extrusion-vertical-gradient": true
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "building",
+      "type": "fill-extrusion"
     },
     {
-      "id": "Transport-Tunnel-VT",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 10,
       "filter": ["all", ["==", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "bevel" },
+      "id": "Transport-Tunnel-VT",
+      "layout": { "line-cap": "butt", "line-join": "bevel", "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
+        "line-blur": 0,
         "line-color": "rgba(98, 88, 13, 1)",
+        "line-dasharray": [4, 2.5],
+        "line-gap-width": 8,
+        "line-opacity": 1,
         "line-width": {
           "stops": [
             [10, 0.5],
             [15, 1.5],
             [19, 4]
           ]
-        },
-        "line-dasharray": [4, 2.5],
-        "line-gap-width": 8,
-        "line-blur": 0,
-        "line-opacity": 1
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
-      "id": "Landuse-Powerline",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 14,
       "filter": ["all", ["==", "class", "powerline"], ["has", "support_ty"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "miter" },
+      "id": "Landuse-Powerline",
+      "layout": { "line-cap": "butt", "line-join": "miter", "visibility": "visible" },
+      "minzoom": 14,
       "paint": {
+        "line-blur": 0.75,
         "line-color": "rgba(57, 57, 57, 1)",
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [9, 0.75],
             [12, 1]
           ]
-        },
-        "line-translate-anchor": "map",
-        "line-gap-width": 0,
-        "line-blur": 0.75
-      }
-    },
-    {
-      "id": "Landuse-Powerline-Pylon",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 11,
-      "maxzoom": 14,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "powerline"], ["==", "support_ty", "pylon"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "miter" },
+      "id": "Landuse-Powerline-Pylon",
+      "layout": { "line-cap": "butt", "line-join": "miter", "visibility": "visible" },
+      "maxzoom": 14,
+      "minzoom": 11,
       "paint": {
+        "line-blur": 0.75,
         "line-color": "rgba(57, 57, 57, 1)",
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [9, 0.75],
             [12, 1]
           ]
-        },
-        "line-translate-anchor": "map",
-        "line-gap-width": 0,
-        "line-blur": 0.75
-      }
-    },
-    {
-      "id": "Landuse-Telephone",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 14,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "telephone"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "miter" },
+      "id": "Landuse-Telephone",
+      "layout": { "line-cap": "butt", "line-join": "miter", "visibility": "visible" },
+      "minzoom": 14,
       "paint": {
+        "line-blur": 0.75,
         "line-color": "rgba(57, 57, 57, 1)",
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [9, 0.75],
             [12, 1]
           ]
-        },
-        "line-translate-anchor": "map",
-        "line-gap-width": 0,
-        "line-blur": 0.75
-      }
-    },
-    {
-      "id": "Landuse-Walkwire",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 14,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "walkwire"]],
-      "layout": { "visibility": "visible", "line-cap": "butt", "line-join": "miter" },
+      "id": "Landuse-Walkwire",
+      "layout": { "line-cap": "butt", "line-join": "miter", "visibility": "visible" },
+      "minzoom": 14,
       "paint": {
+        "line-blur": 0.75,
         "line-color": "rgba(57, 57, 57, 1)",
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
         "line-width": {
           "stops": [
             [9, 0.75],
             [12, 3],
             [18, 5]
           ]
-        },
-        "line-translate-anchor": "map",
-        "line-gap-width": 0,
-        "line-blur": 0.75
-      }
-    },
-    {
-      "id": "Landuse-Dam-Label",
-      "type": "symbol",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 14,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "dam_ln"]],
+      "id": "Landuse-Dam-Label",
       "layout": {
-        "text-font": ["Roboto Black Italic"],
-        "text-field": "{name}",
-        "text-justify": "center",
-        "text-anchor": "bottom",
-        "text-pitch-alignment": "viewport",
-        "text-rotation-alignment": "auto",
-        "symbol-placement": "line",
-        "text-offset": [0, 0],
         "icon-keep-upright": false,
-        "icon-offset": [0, 0]
-      },
-      "paint": { "text-color": "rgba(78, 78, 78, 1)", "text-halo-color": "rgba(252, 252, 252, 1)", "text-halo-width": 0.75, "text-halo-blur": 0.75 }
-    },
-    {
-      "id": "Landuse-GravelPit-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "gravel_pit"]],
-      "layout": {
-        "text-font": ["Open Sans Regular"],
-        "text-field": "",
-        "text-size": {
-          "stops": [
-            [12, 6],
-            [15, 10]
-          ]
-        },
-        "icon-size": 0.8
-      }
-    },
-    {
-      "id": "Landuse-Grave-Pt",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "grave"]],
-      "layout": { "text-field": "", "text-font": ["Open Sans Regular"], "icon-size": 1, "visibility": "visible", "icon-image": "grave_pnt" }
-    },
-    {
-      "id": "Landuse-Landfill-Symbol",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "landfill"]],
-      "layout": {
-        "text-justify": "left",
-        "text-anchor": "left",
+        "icon-offset": [0, 0],
+        "symbol-placement": "line",
+        "text-anchor": "bottom",
         "text-field": "{name}",
-        "text-font": ["Roboto Light Italic"],
-        "icon-anchor": "right",
-        "text-size": 12,
-        "text-offset": [0.5, 0],
-        "icon-size": {
-          "stops": [
-            [12, 1.2],
-            [16, 1.5]
-          ]
-        },
-        "text-max-width": 4,
-        "visibility": "visible",
-        "icon-image": "landfill_pnt"
+        "text-font": ["Roboto Black Italic"],
+        "text-justify": "center",
+        "text-offset": [0, 0],
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "auto"
       },
-      "paint": { "text-color": "rgba(28, 25, 17, 1)", "text-halo-width": 1.5, "text-halo-blur": 0.5, "text-halo-color": "rgba(247, 165, 66, 0.75)" }
-    },
-    {
-      "id": "Landuse-Mangrove-Symbol",
-      "type": "symbol",
+      "minzoom": 14,
+      "paint": { "text-color": "rgba(78, 78, 78, 1)", "text-halo-blur": 0.75, "text-halo-color": "rgba(252, 252, 252, 1)", "text-halo-width": 0.75 },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 13,
-      "maxzoom": 14,
-      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
-      "layout": { "text-font": [], "icon-image": "mangrove_pnt" },
-      "paint": { "icon-opacity": 0.8 }
+      "type": "symbol"
     },
     {
-      "id": "Landuse-MarineFarm-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 15,
-      "filter": ["all", ["==", "class", "marine_farm"]],
-      "layout": { "text-field": "{species}", "text-font": ["Roboto Bold Italic"], "text-size": 10 },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 1.5 }
-    },
-    {
-      "id": "Landuse-PumicePit-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "pumice_pit"]],
+      "filter": ["all", ["==", "class", "gravel_pit"]],
+      "id": "Landuse-GravelPit-Label",
       "layout": {
+        "icon-size": 0.8,
+        "text-field": "",
         "text-font": ["Open Sans Regular"],
-        "text-field": {
-          "stops": [
-            [6, ""],
-            [15, "{class}"]
-          ]
-        },
         "text-size": {
           "stops": [
             [12, 6],
@@ -4305,40 +4213,121 @@
           ]
         }
       },
-      "paint": { "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5, "text-color": "rgba(34, 34, 34, 1)" }
-    },
-    {
-      "id": "Landuse-Tower",
-      "type": "symbol",
+      "minzoom": 12,
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "tower"]],
-      "layout": { "text-field": "", "text-font": ["Open Sans Regular"], "icon-image": "tower_pnt", "icon-size": 1 }
+      "type": "symbol"
     },
     {
-      "id": "Landcover-Tree-Pt",
-      "type": "circle",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
+      "filter": ["all", ["==", "class", "grave"]],
+      "id": "Landuse-Grave-Pt",
+      "layout": { "icon-image": "grave_pnt", "icon-size": 1, "text-field": "", "text-font": ["Open Sans Regular"], "visibility": "visible" },
       "minzoom": 12,
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "landfill"]],
+      "id": "Landuse-Landfill-Symbol",
+      "layout": {
+        "icon-anchor": "right",
+        "icon-image": "landfill_pnt",
+        "icon-size": {
+          "stops": [
+            [12, 1.2],
+            [16, 1.5]
+          ]
+        },
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Roboto Light Italic"],
+        "text-justify": "left",
+        "text-max-width": 4,
+        "text-offset": [0.5, 0],
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(28, 25, 17, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(247, 165, 66, 0.75)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
+      "id": "Landuse-Mangrove-Symbol",
+      "layout": { "icon-image": "mangrove_pnt", "text-font": [] },
+      "maxzoom": 14,
+      "minzoom": 13,
+      "paint": { "icon-opacity": 0.8 },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "marine_farm"]],
+      "id": "Landuse-MarineFarm-Label",
+      "layout": { "text-field": "{species}", "text-font": ["Roboto Bold Italic"], "text-size": 10 },
+      "minzoom": 15,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "pumice_pit"]],
+      "id": "Landuse-PumicePit-Label",
+      "layout": {
+        "text-field": {
+          "stops": [
+            [6, ""],
+            [15, "{class}"]
+          ]
+        },
+        "text-font": ["Open Sans Regular"],
+        "text-size": {
+          "stops": [
+            [12, 6],
+            [15, 10]
+          ]
+        }
+      },
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(34, 34, 34, 1)", "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "tower"]],
+      "id": "Landuse-Tower",
+      "layout": { "icon-image": "tower_pnt", "icon-size": 1, "text-field": "", "text-font": ["Open Sans Regular"] },
+      "minzoom": 12,
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "tree_pt"]],
+      "id": "Landcover-Tree-Pt",
+      "minzoom": 12,
       "paint": {
+        "circle-color": "rgba(121, 160, 72, 0.4)",
         "circle-radius": {
           "stops": [
             [8, 1.5],
             [12, 2.5]
           ]
-        },
-        "circle-color": "rgba(121, 160, 72, 0.4)"
-      }
-    },
-    {
-      "id": "Landcover-Fumarole",
-      "type": "symbol",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "circle"
+    },
+    {
       "filter": ["all", ["==", "class", "fumarole"]],
+      "id": "Landcover-Fumarole",
       "layout": {
         "icon-image": "fumarole_pnt",
         "icon-size": {
@@ -4348,7 +4337,7 @@
             [14, 0.7]
           ]
         },
-        "text-font": ["Open Sans Regular"],
+        "text-anchor": "top",
         "text-field": {
           "stops": [
             [15, ""],
@@ -4356,9 +4345,9 @@
             [17, "{class}"]
           ]
         },
-        "text-anchor": "top",
-        "text-size": 12,
-        "text-offset": [0, 0.5]
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "text-size": 12
       },
       "paint": {
         "icon-opacity": {
@@ -4374,99 +4363,98 @@
             [17, 1]
           ]
         }
-      }
-    },
-    {
-      "id": "Landcover-GolfCourse-Symbol",
-      "type": "symbol",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "grass"], ["==", "grass_type", "golf_course"]],
+      "id": "Landcover-GolfCourse-Symbol",
       "layout": {
-        "text-font": ["Open Sans Italic"],
+        "icon-anchor": "right",
+        "icon-image": "golf_course_pnt_dual",
+        "icon-pitch-alignment": "viewport",
         "icon-rotation-alignment": "viewport",
+        "icon-size": 1.2,
+        "text-anchor": "left",
         "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-justify": "left",
+        "text-max-width": 6,
         "text-offset": [0.5, 0],
         "text-size": 9,
-        "text-anchor": "left",
-        "text-justify": "left",
-        "visibility": "visible",
-        "icon-anchor": "right",
-        "icon-pitch-alignment": "viewport",
-        "icon-size": 1.2,
-        "icon-image": "golf_course_pnt_dual",
-        "text-max-width": 6
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(27, 77, 29, 1)", "text-halo-width": 1.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-blur": 0.5 }
-    },
-    {
-      "id": "Landcover-Rock-Pt",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "filter": ["all", ["==", "class", "rock_pt"]],
-      "layout": { "icon-size": 1, "icon-image": "rock_pnt_dual" }
-    },
-    {
-      "id": "Landcover_RockOutcrop",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "filter": ["all", ["==", "class", "rock_outcrop"]],
-      "layout": { "icon-allow-overlap": false, "icon-offset": [-3, -6], "visibility": "visible", "icon-image": "rock_outcrop_large_pnt" }
-    },
-    {
-      "id": "Landcover-Swamp-Name",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 14,
-      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"], ["has", "name"]],
-      "layout": {
-        "visibility": "visible",
-        "text-font": ["Open Sans Light Italic"],
-        "text-field": "{name}",
-        "text-size": 12,
-        "text-justify": "center",
-        "text-anchor": "center",
-        "icon-anchor": "center",
-        "text-allow-overlap": true,
-        "icon-allow-overlap": true
-      },
-      "paint": { "text-color": "rgba(2, 46, 39, 1)", "text-halo-width": 0.5, "text-halo-color": "rgba(252, 252, 252, 1)", "text-halo-blur": 0.5, "text-translate": [8, 0] }
-    },
-    {
-      "id": "Landcover-Swamp-Symbol",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
-      "minzoom": 13,
-      "maxzoom": 14,
-      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
-      "layout": {
-        "visibility": "visible",
-        "icon-image": "swamp_pnt",
-        "text-font": ["Open Sans Light Italic"],
-        "text-field": "{name}",
-        "text-size": 12,
-        "text-justify": "right",
-        "text-anchor": "left",
-        "icon-anchor": "center",
-        "text-allow-overlap": true,
-        "icon-allow-overlap": true
-      },
-      "paint": { "text-color": "rgba(2, 46, 39, 1)", "text-halo-width": 0.5, "text-halo-color": "rgba(252, 252, 252, 1)", "text-halo-blur": 0.5, "text-translate": [8, 0] }
-    },
-    {
-      "id": "Landcover-Swamp-pt",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
       "minzoom": 12,
-      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp_pt"]],
+      "paint": { "text-color": "rgba(27, 77, 29, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "rock_pt"]],
+      "id": "Landcover-Rock-Pt",
+      "layout": { "icon-image": "rock_pnt_dual", "icon-size": 1 },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "rock_outcrop"]],
+      "id": "Landcover_RockOutcrop",
+      "layout": { "icon-allow-overlap": false, "icon-image": "rock_outcrop_large_pnt", "icon-offset": [-3, -6], "visibility": "visible" },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"], ["has", "name"]],
+      "id": "Landcover-Swamp-Name",
       "layout": {
-        "visibility": "visible",
+        "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "text-allow-overlap": true,
+        "text-anchor": "center",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Light Italic"],
+        "text-justify": "center",
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "minzoom": 14,
+      "paint": { "text-color": "rgba(2, 46, 39, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(252, 252, 252, 1)", "text-halo-width": 0.5, "text-translate": [8, 0] },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
+      "id": "Landcover-Swamp-Symbol",
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "icon-image": "swamp_pnt",
+        "text-allow-overlap": true,
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Light Italic"],
+        "text-justify": "right",
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "maxzoom": 14,
+      "minzoom": 13,
+      "paint": { "text-color": "rgba(2, 46, 39, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(252, 252, 252, 1)", "text-halo-width": 0.5, "text-translate": [8, 0] },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp_pt"]],
+      "id": "Landcover-Swamp-pt",
+      "layout": {
+        "icon-image": "swamp_pnt",
         "icon-size": {
           "stops": [
             [6, 0.4],
@@ -4475,89 +4463,83 @@
             [19, 1.3]
           ]
         },
-        "icon-image": "swamp_pnt"
-      }
+        "visibility": "visible"
+      },
+      "minzoom": 12,
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
     },
     {
       "id": "Housenumber",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "housenumber",
-      "minzoom": 17,
       "layout": {
-        "text-font": ["Roboto Bold Italic"],
+        "text-allow-overlap": false,
+        "text-anchor": "bottom",
         "text-field": "{housenumber}",
+        "text-font": ["Roboto Bold Italic"],
         "text-size": {
           "stops": [
             [17, 8],
             [19, 10]
           ]
-        },
-        "text-anchor": "bottom",
-        "text-allow-overlap": false
+        }
       },
-      "paint": { "text-color": "rgba(47, 47, 47, 1)", "text-halo-color": "rgba(255, 255, 255, 0.7)", "text-halo-blur": 20, "text-halo-width": 0.25, "icon-color": "rgba(0, 0, 0, 1)" }
+      "minzoom": 17,
+      "paint": { "icon-color": "rgba(0, 0, 0, 1)", "text-color": "rgba(47, 47, 47, 1)", "text-halo-blur": 20, "text-halo-color": "rgba(255, 255, 255, 0.7)", "text-halo-width": 0.25 },
+      "source": "LINZ Basemaps",
+      "source-layer": "housenumber",
+      "type": "symbol"
     },
     {
-      "id": "Waterway-Flume-Name",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 13,
       "filter": ["all", ["==", "class", "channel"], ["==", "channel_type", "flume_cl"]],
+      "id": "Waterway-Flume-Name",
       "layout": {
+        "icon-anchor": "center",
+        "icon-image": "flume_pnt_blue",
+        "icon-pitch-alignment": "map",
+        "icon-rotation-alignment": "map",
+        "icon-text-fit": "none",
+        "symbol-placement": "line-center",
+        "symbol-z-order": "auto",
+        "text-anchor": "center",
         "text-field": "",
         "text-font": ["Open Sans Italic"],
-        "text-size": 14,
-        "icon-anchor": "center",
-        "text-anchor": "center",
-        "visibility": "visible",
-        "symbol-placement": "line-center",
+        "text-justify": "center",
+        "text-offset": [0, 0.015],
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
-        "text-justify": "center",
-        "icon-text-fit": "none",
-        "symbol-z-order": "auto",
-        "text-offset": [0, 0.015],
-        "icon-image": "flume_pnt_blue",
-        "icon-rotation-alignment": "map",
-        "icon-pitch-alignment": "map"
-      },
-      "paint": { "text-color": "rgba(44, 44, 44, 1)", "text-halo-color": "rgba(239, 239, 239, 0.80)" }
-    },
-    {
-      "id": "Waterway-Rapid-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 13,
-      "filter": ["all", ["==", "class", "stream"], ["==", "stream_feature", "rapid_cl"], ["has", "name"]],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": ["Open Sans Italic"],
-        "symbol-placement": "line",
-        "text-size": 12,
-        "symbol-spacing": 750,
-        "icon-anchor": "center",
-        "text-anchor": "bottom",
+        "text-size": 14,
         "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5, "text-halo-blur": 1 }
+      "minzoom": 13,
+      "paint": { "text-color": "rgba(44, 44, 44, 1)", "text-halo-color": "rgba(239, 239, 239, 0.80)" },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "symbol"
     },
     {
-      "id": "Water-Spring-Cold",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "filter": ["all", ["==", "class", "spring"], ["==", "temp", "cold"]],
+      "filter": ["all", ["==", "class", "stream"], ["==", "stream_feature", "rapid_cl"], ["has", "name"]],
+      "id": "Waterway-Rapid-Names",
       "layout": {
-        "text-font": ["Open Sans Regular"],
-        "text-field": {
-          "stops": [
-            [16, ""],
-            [17, "cold spring"]
-          ]
-        },
+        "icon-anchor": "center",
+        "symbol-placement": "line",
+        "symbol-spacing": 750,
+        "text-anchor": "bottom",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 1, "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "spring"], ["==", "temp", "cold"]],
+      "id": "Water-Spring-Cold",
+      "layout": {
         "icon-image": "spring_cold_pnt",
         "icon-size": {
           "stops": [
@@ -4565,28 +4547,27 @@
             [15, 0.7]
           ]
         },
-        "text-size": 12,
-        "text-justify": "center",
         "text-anchor": "top",
-        "text-offset": [0, 0.5]
-      },
-      "paint": { "icon-color": "rgba(5, 0, 168, 1)", "text-color": "rgba(20, 125, 228, 1)" }
-    },
-    {
-      "id": "Water-Spring-Hot",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "filter": ["all", ["==", "class", "spring"], ["==", "temp", "hot"]],
-      "layout": {
-        "visibility": "visible",
-        "text-font": ["Open Sans Regular"],
         "text-field": {
           "stops": [
-            [14, ""],
-            [15, "hot spring"]
+            [16, ""],
+            [17, "cold spring"]
           ]
         },
+        "text-font": ["Open Sans Regular"],
+        "text-justify": "center",
+        "text-offset": [0, 0.5],
+        "text-size": 12
+      },
+      "paint": { "icon-color": "rgba(5, 0, 168, 1)", "text-color": "rgba(20, 125, 228, 1)" },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "spring"], ["==", "temp", "hot"]],
+      "id": "Water-Spring-Hot",
+      "layout": {
         "icon-image": "spring_hot_pnt",
         "icon-size": {
           "stops": [
@@ -4594,50 +4575,35 @@
             [15, 0.7]
           ]
         },
-        "text-size": 10,
         "text-anchor": "top",
-        "text-offset": [0, 0.5]
+        "text-field": {
+          "stops": [
+            [14, ""],
+            [15, "hot spring"]
+          ]
+        },
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "text-size": 10,
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(141, 0, 3, 1)" }
+      "paint": { "text-color": "rgba(141, 0, 3, 1)" },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "symbol"
     },
     {
-      "id": "All-Highway-Labels-three",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 8,
       "filter": ["all", ["in", "hway_num", "25A", "20A", "20B", "29A", "30A", "74A", "67A"]],
+      "id": "All-Highway-Labels-three",
       "layout": {
-        "symbol-placement": "line",
-        "text-field": "{hway_num}",
-        "text-font": ["Open Sans Bold"],
-        "icon-text-fit": "none",
-        "text-size": {
-          "stops": [
-            [8, 9],
-            [11, 10],
-            [15, 14]
-          ]
-        },
-        "symbol-spacing": {
-          "stops": [
-            [6, 500],
-            [13, 400]
-          ]
-        },
-        "visibility": "visible",
-        "text-justify": "center",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "icon-rotation-alignment": "viewport",
-        "icon-offset": [0, 1],
-        "icon-pitch-alignment": "viewport",
         "icon-anchor": "center",
+        "icon-image": "highway_pnt_wide",
         "icon-keep-upright": false,
-        "text-keep-upright": true,
-        "icon-rotate": 0,
+        "icon-offset": [0, 1],
         "icon-padding": 2,
-        "icon-text-fit-padding": [1, 4, 3, 3],
+        "icon-pitch-alignment": "viewport",
+        "icon-rotate": 0,
+        "icon-rotation-alignment": "viewport",
         "icon-size": {
           "stops": [
             [8, 1.2],
@@ -4645,48 +4611,48 @@
             [15, 1.7]
           ]
         },
-        "icon-image": "highway_pnt_wide"
+        "icon-text-fit": "none",
+        "icon-text-fit-padding": [1, 4, 3, 3],
+        "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [6, 500],
+            [13, 400]
+          ]
+        },
+        "text-field": "{hway_num}",
+        "text-font": ["Open Sans Bold"],
+        "text-justify": "center",
+        "text-keep-upright": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [8, 9],
+            [11, 10],
+            [15, 14]
+          ]
+        },
+        "visibility": "visible"
       },
-      "paint": { "text-translate-anchor": "map", "text-color": "rgba(255, 255, 255, 1)", "icon-translate-anchor": "map" }
-    },
-    {
-      "id": "All-Highway-Labels-standard",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
       "minzoom": 8,
+      "paint": { "icon-translate-anchor": "map", "text-color": "rgba(255, 255, 255, 1)", "text-translate-anchor": "map" },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["has", "hway_num"], ["!in", "hway_num", "6,94", "2,50", "1,3", "12,15", "14,15", "6,96", "25A", "20A", "20B", "29A", "30A", "74A", "67A"], ["!=", "lane_count", 1]],
+      "id": "All-Highway-Labels-standard",
       "layout": {
-        "symbol-placement": "line",
-        "text-field": "{hway_num}",
-        "text-font": ["Open Sans Bold"],
-        "icon-text-fit": "none",
-        "text-size": {
-          "stops": [
-            [8, 9],
-            [11, 10],
-            [15, 14]
-          ]
-        },
-        "symbol-spacing": {
-          "stops": [
-            [6, 500],
-            [13, 400]
-          ]
-        },
-        "visibility": "visible",
-        "text-justify": "center",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "icon-rotation-alignment": "viewport",
-        "icon-offset": [0, 1],
-        "icon-pitch-alignment": "viewport",
         "icon-anchor": "center",
+        "icon-image": "highway_pnt_standard",
         "icon-keep-upright": false,
-        "text-keep-upright": true,
-        "icon-rotate": 0,
+        "icon-offset": [0, 1],
         "icon-padding": 2,
-        "icon-text-fit-padding": [1, 4, 3, 3],
+        "icon-pitch-alignment": "viewport",
+        "icon-rotate": 0,
+        "icon-rotation-alignment": "viewport",
         "icon-size": {
           "stops": [
             [8, 1.2],
@@ -4694,44 +4660,65 @@
             [15, 1.7]
           ]
         },
-        "icon-image": "highway_pnt_standard"
+        "icon-text-fit": "none",
+        "icon-text-fit-padding": [1, 4, 3, 3],
+        "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [6, 500],
+            [13, 400]
+          ]
+        },
+        "text-field": "{hway_num}",
+        "text-font": ["Open Sans Bold"],
+        "text-justify": "center",
+        "text-keep-upright": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [8, 9],
+            [11, 10],
+            [15, 14]
+          ]
+        },
+        "visibility": "visible"
       },
-      "paint": { "text-translate-anchor": "map", "text-color": "rgba(255, 255, 255, 1)", "icon-translate-anchor": "map" }
-    },
-    {
-      "id": "Transport-Ferry-Symbol",
-      "type": "symbol",
+      "minzoom": 8,
+      "paint": { "icon-translate-anchor": "map", "text-color": "rgba(255, 255, 255, 1)", "text-translate-anchor": "map" },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "ferry"]],
+      "id": "Transport-Ferry-Symbol",
       "layout": {
-        "icon-text-fit": "none",
-        "icon-ignore-placement": false,
         "icon-allow-overlap": false,
-        "text-justify": "center",
-        "text-pitch-alignment": "auto",
-        "text-font": [],
+        "icon-ignore-placement": false,
+        "icon-image": "star_pnt_fill",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 0.5,
+        "icon-text-fit": "none",
         "symbol-placement": "line-center",
         "symbol-z-order": "auto",
-        "icon-rotation-alignment": "viewport",
-        "icon-image": "star_pnt_fill",
-        "icon-size": 0.5
-      }
-    },
-    {
-      "id": "Transport-Tunnel-Label",
-      "type": "symbol",
+        "text-font": [],
+        "text-justify": "center",
+        "text-pitch-alignment": "auto"
+      },
+      "minzoom": 11,
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 15,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "brunnel", "tunnel"]],
+      "id": "Transport-Tunnel-Label",
       "layout": {
-        "text-font": ["Roboto Black"],
-        "text-field": "{brunnel}",
         "symbol-placement": "line",
-        "text-size": 10,
         "symbol-spacing": 100,
+        "text-field": "{brunnel}",
+        "text-font": ["Roboto Black"],
         "text-offset": {
           "stops": [
             [15, [0, -1.25]],
@@ -4741,22 +4728,28 @@
             [22, [0, -16]]
           ]
         },
+        "text-size": 10,
         "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(80, 75, 75, 1)", "text-halo-color": "rgba(230, 230, 230, 0.5)", "text-halo-width": 2 }
-    },
-    {
-      "id": "All-Road-Labels",
-      "type": "symbol",
+      "minzoom": 15,
+      "paint": { "text-color": "rgba(80, 75, 75, 1)", "text-halo-color": "rgba(230, 230, 230, 0.5)", "text-halo-width": 2 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["has", "name"], ["!=", "subclass", "foot_route_closed"], ["!=", "subclass", "foot_closed"]],
+      "id": "All-Road-Labels",
       "layout": {
+        "icon-ignore-placement": false,
+        "icon-pitch-alignment": "auto",
+        "icon-text-fit": "both",
         "symbol-placement": "line",
+        "symbol-spacing": 250,
+        "text-anchor": "center",
         "text-field": "{name}",
         "text-font": ["Open Sans Regular"],
-        "icon-text-fit": "both",
+        "text-justify": "center",
         "text-size": {
           "stops": [
             [13, 8],
@@ -4766,219 +4759,216 @@
             [22, 140]
           ]
         },
-        "symbol-spacing": 250,
-        "visibility": "visible",
-        "text-anchor": "center",
-        "text-justify": "center",
         "text-transform": "none",
-        "icon-pitch-alignment": "auto",
-        "icon-ignore-placement": false
+        "visibility": "visible"
       },
-      "paint": { "text-halo-width": 2.5, "text-halo-color": "rgba(243, 243, 242, 0.9)", "text-opacity": 0.9 }
+      "minzoom": 13,
+      "paint": { "text-halo-color": "rgba(243, 243, 242, 0.9)", "text-halo-width": 2.5, "text-opacity": 0.9 },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
     },
     {
       "id": "Aeroway-Aerodrome-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "aerodrome_label",
-      "minzoom": 12,
       "layout": {
+        "icon-anchor": "bottom",
+        "icon-ignore-placement": false,
+        "icon-image": "airport_airport_pnt_fill",
+        "icon-offset": [0, 0],
+        "icon-pitch-alignment": "viewport",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1.2,
+        "icon-text-fit": "none",
+        "symbol-spacing": 250,
+        "text-allow-overlap": false,
+        "text-anchor": "top",
         "text-field": "{name}",
-        "visibility": "visible",
-        "text-size": 10,
+        "text-font": ["Open Sans Bold Italic"],
+        "text-justify": "center",
+        "text-max-width": 5,
+        "text-padding": 2,
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
-        "text-font": ["Open Sans Bold Italic"],
-        "icon-rotation-alignment": "viewport",
-        "icon-ignore-placement": false,
-        "icon-text-fit": "none",
-        "text-justify": "center",
-        "symbol-spacing": 250,
-        "text-padding": 2,
-        "icon-offset": [0, 0],
-        "text-allow-overlap": false,
-        "icon-pitch-alignment": "viewport",
-        "text-anchor": "top",
-        "icon-anchor": "bottom",
-        "icon-size": 1.2,
-        "icon-image": "airport_airport_pnt_fill",
-        "text-max-width": 5
+        "text-size": 10,
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(129, 123, 123, 1)", "text-halo-width": 1, "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "icon-opacity": 0.8 }
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.8, "text-color": "rgba(129, 123, 123, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(255, 255, 255, 1)", "text-halo-width": 1 },
+      "source": "LINZ Basemaps",
+      "source-layer": "aerodrome_label",
+      "type": "symbol"
     },
     {
-      "id": "Aeroway-Runway-Grass-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "aeroway",
-      "minzoom": 15,
       "filter": ["all", ["==", "class", "runway"], ["!has", "surface"]],
-      "layout": { "text-font": ["Roboto Light"], "text-field": "airstrip", "text-size": 10, "text-justify": "left", "text-anchor": "left" },
-      "paint": { "text-halo-color": "rgba(246, 246, 246, 1)", "text-halo-width": 1.5, "text-halo-blur": 0.5 }
-    },
-    {
-      "id": "Aeroway-Helipads",
-      "type": "symbol",
+      "id": "Aeroway-Runway-Grass-Label",
+      "layout": { "text-anchor": "left", "text-field": "airstrip", "text-font": ["Roboto Light"], "text-justify": "left", "text-size": 10 },
+      "minzoom": 15,
+      "paint": { "text-halo-blur": 0.5, "text-halo-color": "rgba(246, 246, 246, 1)", "text-halo-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "aeroway",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "helipad"]],
-      "layout": { "text-font": ["Open Sans Regular"], "icon-size": 1.25, "icon-image": "helipad_pnt_fill" },
-      "paint": { "icon-opacity": 0.8 }
+      "id": "Aeroway-Helipads",
+      "layout": { "icon-image": "helipad_pnt_fill", "icon-size": 1.25, "text-font": ["Open Sans Regular"] },
+      "minzoom": 12,
+      "paint": { "icon-opacity": 0.8 },
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "symbol"
     },
     {
-      "id": "All-Reef-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 13,
       "filter": ["all", ["==", "class", "reef"], ["has", "name"]],
-      "layout": { "visibility": "visible", "text-field": "{name}", "text-font": ["Open Sans Italic"], "text-size": 12, "text-max-width": 4, "text-anchor": "center", "text-offset": [0, 1] },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 2 }
-    },
-    {
-      "id": "All-Lake-Names",
-      "type": "symbol",
+      "id": "All-Reef-Names",
+      "layout": { "text-anchor": "center", "text-field": "{name}", "text-font": ["Open Sans Italic"], "text-max-width": 4, "text-offset": [0, 1], "text-size": 12, "visibility": "visible" },
+      "minzoom": 13,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 2 },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 11,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "lake"], ["has", "name"]],
-      "layout": { "visibility": "visible", "text-field": "{name}", "text-font": ["Open Sans Italic"], "text-size": 12, "text-max-width": 4 },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 2 }
+      "id": "All-Lake-Names",
+      "layout": { "text-field": "{name}", "text-font": ["Open Sans Italic"], "text-max-width": 4, "text-size": 12, "visibility": "visible" },
+      "minzoom": 11,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 2 },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "symbol"
     },
     {
+      "filter": ["all", ["==", "class", "canal"], ["has", "name"]],
       "id": "All-Canal-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "canal"], ["has", "name"]],
       "layout": {
+        "icon-allow-overlap": false,
+        "icon-anchor": "center",
+        "icon-ignore-placement": false,
+        "symbol-placement": "line",
+        "symbol-spacing": 1000,
+        "text-allow-overlap": true,
+        "text-anchor": "bottom",
         "text-field": "{name}",
         "text-font": ["Open Sans Italic"],
-        "symbol-placement": "line",
-        "text-size": 12,
-        "symbol-spacing": 1000,
-        "icon-anchor": "center",
-        "text-anchor": "bottom",
-        "visibility": "visible",
-        "icon-allow-overlap": false,
-        "icon-ignore-placement": false,
-        "text-allow-overlap": true,
         "text-ignore-placement": true,
-        "text-justify": "center"
+        "text-justify": "center",
+        "text-size": 12,
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5, "text-halo-blur": 1 }
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 1, "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "symbol"
     },
     {
+      "filter": ["all", ["==", "class", "river"], ["has", "name"]],
       "id": "All-River-Names",
-      "type": "symbol",
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-anchor": "center",
+        "icon-ignore-placement": false,
+        "symbol-placement": "line",
+        "symbol-spacing": 1000,
+        "text-allow-overlap": true,
+        "text-anchor": "bottom",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-ignore-placement": true,
+        "text-justify": "center",
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 1, "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "river"], ["has", "name"]],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": ["Open Sans Italic"],
-        "symbol-placement": "line",
-        "text-size": 12,
-        "symbol-spacing": 1000,
-        "icon-anchor": "center",
-        "text-anchor": "bottom",
-        "visibility": "visible",
-        "icon-allow-overlap": false,
-        "icon-ignore-placement": false,
-        "text-allow-overlap": true,
-        "text-ignore-placement": true,
-        "text-justify": "center"
-      },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5, "text-halo-blur": 1 }
+      "type": "symbol"
     },
     {
-      "id": "All-Waterway-Canal-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "canal"], ["has", "name"]],
+      "id": "All-Waterway-Canal-Names",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 1000,
+        "text-allow-overlap": true,
+        "text-anchor": "bottom",
         "text-field": "{name}",
         "text-font": ["Open Sans Italic"],
-        "text-size": 12,
-        "text-anchor": "bottom",
         "text-ignore-placement": true,
-        "text-allow-overlap": true
+        "text-size": 12
       },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5, "text-halo-blur": 1 }
-    },
-    {
-      "id": "All-Waterway-Drain-Names",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 1, "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "drain"], ["has", "name"]],
+      "id": "All-Waterway-Drain-Names",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 1000,
+        "text-allow-overlap": true,
+        "text-anchor": "bottom",
         "text-field": "{name}",
         "text-font": ["Open Sans Italic"],
-        "text-size": 12,
-        "text-anchor": "bottom",
         "text-ignore-placement": true,
-        "text-allow-overlap": true
+        "text-size": 12
       },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5, "text-halo-blur": 1 }
-    },
-    {
-      "id": "All-Waterway-River-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
       "minzoom": 12,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 1, "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "river"], ["has", "name"]],
+      "id": "All-Waterway-River-Names",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 1000,
+        "text-allow-overlap": true,
+        "text-anchor": "bottom",
         "text-field": "{name}",
         "text-font": ["Open Sans Italic"],
-        "text-size": 12,
-        "text-anchor": "bottom",
         "text-ignore-placement": true,
-        "text-allow-overlap": true
+        "text-size": 12
       },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5, "text-halo-blur": 1 }
-    },
-    {
-      "id": "Waterway-Waterfall-Label",
-      "type": "symbol",
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 1, "text-halo-color": "rgba(239, 239, 239, 0.80)", "text-halo-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
+      "type": "symbol"
+    },
+    {
       "filter": ["any", ["==", "class", "waterfall_edge"], ["==", "class", "waterfall_ln"]],
+      "id": "Waterway-Waterfall-Label",
       "layout": {
         "symbol-placement": "line",
+        "text-allow-overlap": true,
+        "text-anchor": "bottom",
         "text-field": "{name} {height}m",
         "text-font": ["Open Sans Regular"],
-        "text-size": 13,
-        "text-anchor": "bottom",
-        "text-allow-overlap": true,
-        "text-max-width": 3
+        "text-max-width": 3,
+        "text-size": 13
       },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 1.5, "text-halo-blur": 0.5 }
-    },
-    {
-      "id": "Waterway-Waterfall-Pt-Ln",
-      "type": "symbol",
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(239, 239, 239, 1)", "text-halo-width": 1.5 },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 12,
-      "maxzoom": 14,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "waterfall_pt"]],
+      "id": "Waterway-Waterfall-Pt-Ln",
       "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": "rapid_pnt",
+        "icon-size": 1.5,
+        "text-anchor": "bottom",
         "text-field": "",
-        "visibility": "visible",
         "text-font": ["Open Sans Regular"],
         "text-size": {
           "stops": [
@@ -4986,57 +4976,51 @@
             [16, 14]
           ]
         },
-        "icon-allow-overlap": true,
-        "icon-size": 1.5,
-        "icon-image": "rapid_pnt",
-        "text-anchor": "bottom"
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)" }
-    },
-    {
-      "id": "Waterway-Waterfall-Pt",
-      "type": "symbol",
+      "maxzoom": 14,
+      "minzoom": 12,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)" },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 14,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "waterfall_pt"]],
+      "id": "Waterway-Waterfall-Pt",
       "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": "waterfall_pnt",
+        "icon-size": 1.5,
+        "text-anchor": "top",
         "text-field": "{name} {height}m",
-        "visibility": "visible",
         "text-font": ["Open Sans Regular"],
+        "text-max-width": 3,
+        "text-offset": [0, 1],
+        "text-rotate": 0,
         "text-size": {
           "stops": [
             [12, 8],
             [16, 12]
           ]
         },
-        "icon-image": "waterfall_pnt",
-        "icon-allow-overlap": true,
-        "icon-size": 1.5,
-        "text-anchor": "top",
-        "text-offset": [0, 1],
-        "text-max-width": 3,
-        "text-rotate": 0
+        "visibility": "visible"
       },
-      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-color": "rgba(232, 232, 232, 1)", "text-halo-width": 1.5, "text-halo-blur": 0.5 }
+      "minzoom": 14,
+      "paint": { "text-color": "rgba(0, 140, 204, 1)", "text-halo-blur": 0.5, "text-halo-color": "rgba(232, 232, 232, 1)", "text-halo-width": 1.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "symbol"
     },
     {
       "id": "Place-Names-13",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
-      "minzoom": 13,
       "layout": {
+        "icon-rotation-alignment": "auto",
+        "icon-text-fit": "both",
+        "text-allow-overlap": true,
         "text-field": "{name}",
         "text-font": ["Roboto Regular"],
-        "text-max-width": 7,
-        "text-variable-anchor": ["top", "bottom-left"],
-        "text-offset": {
-          "stops": [
-            [4, [0, 1.75]],
-            [6, [0, 1.25]]
-          ]
-        },
+        "text-ignore-placement": false,
         "text-letter-spacing": {
           "stops": [
             [10, 0.08],
@@ -5044,6 +5028,16 @@
             [14, 0]
           ]
         },
+        "text-max-width": 7,
+        "text-offset": {
+          "stops": [
+            [4, [0, 1.75]],
+            [6, [0, 1.25]]
+          ]
+        },
+        "text-optional": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
         "text-size": {
           "stops": [
             [2, 10],
@@ -5054,35 +5048,15 @@
             [14, 16]
           ]
         },
-        "icon-text-fit": "both",
-        "icon-rotation-alignment": "auto",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "text-optional": true,
-        "text-ignore-placement": false,
-        "text-allow-overlap": true,
+        "text-variable-anchor": ["top", "bottom-left"],
         "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "text-halo-blur": 1,
-        "text-halo-width": {
+        "icon-color": {
           "stops": [
-            [4, 1.5],
-            [9, 2]
-          ]
-        },
-        "text-halo-color": "rgba(255, 252, 252, 1)",
-        "text-color": {
-          "stops": [
-            [6, "rgba(35, 34, 34, 1)"],
-            [19, "rgba(111, 111, 111, 1)"]
-          ]
-        },
-        "text-translate-anchor": "viewport",
-        "icon-halo-width": {
-          "stops": [
-            [13, 1],
-            [14, 2]
+            [6, "rgba(53, 53, 53, 1)"],
+            [10, "rgba(53, 53, 53, 1)"]
           ]
         },
         "icon-halo-blur": {
@@ -5091,26 +5065,58 @@
             [14, 0.5]
           ]
         },
-        "icon-opacity": 1,
         "icon-halo-color": "rgba(255, 255, 255, 1)",
-        "icon-color": {
+        "icon-halo-width": {
           "stops": [
-            [6, "rgba(53, 53, 53, 1)"],
-            [10, "rgba(53, 53, 53, 1)"]
+            [13, 1],
+            [14, 2]
           ]
-        }
-      }
+        },
+        "icon-opacity": 1,
+        "text-color": {
+          "stops": [
+            [6, "rgba(35, 34, 34, 1)"],
+            [19, "rgba(111, 111, 111, 1)"]
+          ]
+        },
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255, 252, 252, 1)",
+        "text-halo-width": {
+          "stops": [
+            [4, 1.5],
+            [9, 2]
+          ]
+        },
+        "text-translate-anchor": "viewport"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
     },
     {
       "id": "Place-Names-3-12",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
-      "minzoom": 3,
-      "maxzoom": 13,
       "layout": {
-        "text-font": ["Roboto Regular"],
+        "icon-pitch-alignment": "auto",
         "text-field": "{name}",
+        "text-font": ["Roboto Regular"],
+        "text-ignore-placement": false,
+        "text-letter-spacing": {
+          "stops": [
+            [10, 0.08],
+            [13, 0.04],
+            [14, 0]
+          ]
+        },
+        "text-max-width": 6,
+        "text-offset": {
+          "stops": [
+            [4, [0, 1.75]],
+            [6, [0, 1.25]]
+          ]
+        },
+        "text-optional": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
         "text-size": {
           "stops": [
             [2, 10],
@@ -5121,28 +5127,11 @@
             [14, 17]
           ]
         },
-        "text-letter-spacing": {
-          "stops": [
-            [10, 0.08],
-            [13, 0.04],
-            [14, 0]
-          ]
-        },
-        "text-offset": {
-          "stops": [
-            [4, [0, 1.75]],
-            [6, [0, 1.25]]
-          ]
-        },
-        "text-max-width": 6,
         "text-variable-anchor": ["top", "bottom-left"],
-        "icon-pitch-alignment": "auto",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "text-ignore-placement": false,
-        "text-optional": true,
         "visibility": "visible"
       },
+      "maxzoom": 13,
+      "minzoom": 3,
       "paint": {
         "icon-color": {
           "stops": [
@@ -5150,36 +5139,47 @@
             [10, "rgba(53, 53, 53, 1)"]
           ]
         },
-        "icon-halo-color": "rgba(255, 255, 255, 1)",
-        "icon-opacity": 1,
         "icon-halo-blur": {
           "stops": [
             [13, 1],
             [14, 0.5]
           ]
         },
-        "icon-translate-anchor": "viewport",
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
         "icon-halo-width": {
           "stops": [
             [13, 1],
             [14, 2]
           ]
         },
-        "text-halo-blur": 1,
-        "text-halo-width": {
-          "stops": [
-            [4, 1.5],
-            [9, 2]
-          ]
-        },
-        "text-halo-color": "rgba(255, 252, 252, 1)",
+        "icon-opacity": 1,
+        "icon-translate-anchor": "viewport",
         "text-color": {
           "stops": [
             [6, "rgba(35, 34, 34, 1)"],
             [19, "rgba(111, 111, 111, 1)"]
           ]
+        },
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255, 252, 252, 1)",
+        "text-halo-width": {
+          "stops": [
+            [4, 1.5],
+            [9, 2]
+          ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
     }
-  ]
+  ],
+  "metadata": { "maputnik:renderer": "mbgljs" },
+  "name": "topographic",
+  "sources": {
+    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json" },
+    "LINZ-Texture-Relief": { "maxzoom": 20, "minzoom": 0, "tileSize": 256, "tiles": ["/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp"], "type": "raster" }
+  },
+  "sprite": "/v1/sprites/topographic",
+  "version": 8
 }

--- a/config/style/topolite.json
+++ b/config/style/topolite.json
@@ -1,81 +1,70 @@
 {
-  "id": "st_topolite",
-  "version": 8,
-  "name": "topolite",
-  "metadata": { "maputnik:renderer": "mbgljs" },
-  "sources": {
-    "LINZ Basemaps": { "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json", "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0" },
-    "LINZ-Texture-Relief": { "type": "raster", "tiles": ["/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp"], "tileSize": 256, "minzoom": 0, "maxzoom": 20 }
-  },
-  "sprite": "/v1/sprites/topographic",
   "glyphs": "/v1/fonts/{fontstack}/{range}.pbf",
+  "id": "st_topolite",
   "layers": [
     {
-      "id": "Background",
-      "type": "background",
-      "minzoom": 0,
       "filter": ["all", ["==", "class", "dock"]],
+      "id": "Background",
       "layout": { "visibility": "visible" },
-      "paint": { "background-color": "rgba(184, 220, 242, 1)" }
+      "minzoom": 0,
+      "paint": { "background-color": "rgba(184, 220, 242, 1)" },
+      "type": "background"
     },
     {
+      "filter": ["all", ["==", "class", "sand"]],
       "id": "Landcover-Sand",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 8,
+      "paint": { "fill-color": "rgba(220, 205, 177, 0.3)" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 8,
-      "filter": ["all", ["==", "class", "sand"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(220, 205, 177, 0.3)" }
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
       "id": "Landuse-Mangrove",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 12,
+      "paint": { "fill-color": "rgba(184, 199, 155, 0.3)" },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 12,
-      "filter": ["all", ["==", "wetland_feature", "mangrove"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(184, 199, 155, 0.3)" }
+      "type": "fill"
     },
     {
-      "id": "Coastline2",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "coastline",
-      "minzoom": 0,
       "filter": ["all"],
+      "id": "Coastline2",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "stops": [
             [1, "rgba(234, 233, 229, 1)"],
             [10, "#FCFBF7"]
           ]
         },
-        "fill-antialias": true,
         "fill-translate-anchor": "map"
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "coastline",
+      "type": "fill"
     },
     {
-      "id": "Vegetation-Scatteredscrub",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landcover",
       "filter": ["all", ["==", "class", "grass"], ["==", "natural", "scrub"], ["==", "distribution", "scattered"]],
+      "id": "Vegetation-Scatteredscrub",
       "layout": { "visibility": "visible" },
       "paint": {
-        "fill-color": "rgba(204, 222, 195, 0.4)",
         "fill-antialias": false,
+        "fill-color": "rgba(204, 222, 195, 0.4)",
         "fill-outline-color": "rgba(210, 210, 210, 0.1)"
-      }
-    },
-    {
-      "id": "Vegetation-Scrub",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "grass"], ["==", "natural", "scrub"], ["!has", "distribution"]],
+      "id": "Vegetation-Scrub",
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": "rgba(199, 228, 183, 0.4)",
@@ -86,16 +75,16 @@
             [19, "rgba(255, 255, 255, 0.1)"]
           ]
         }
-      }
-    },
-    {
-      "id": "Vegetation-Exotic",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 0,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "tree", "exotic"], ["==", "landuse", "wood"]],
+      "id": "Vegetation-Exotic",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
         "fill-color": {
           "stops": [
@@ -104,16 +93,16 @@
           ]
         },
         "fill-outline-color": "rgba(210, 210, 210, 0)"
-      }
-    },
-    {
-      "id": "Vegetation-Native",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 0,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "tree", "native"]],
+      "id": "Vegetation-Native",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
         "fill-color": {
           "stops": [
@@ -124,16 +113,16 @@
           ]
         },
         "fill-outline-color": "rgba(210, 210, 210, 0)"
-      }
-    },
-    {
-      "id": "Landcover-Ice",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 0,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "ice"]],
+      "id": "Landcover-Ice",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
         "fill-color": "rgba(255, 255, 255, 0.44)",
         "fill-outline-color": {
@@ -143,43 +132,43 @@
             [11, "rgba(57, 158, 158, 0.5)"]
           ]
         }
-      }
-    },
-    {
-      "id": "Landcover-Orchard",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 10,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "landuse", "orchard"]],
+      "id": "Landcover-Orchard",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "fill-color": "rgba(27, 127, 36, 0.1)",
-        "fill-translate-anchor": "viewport",
-        "fill-outline-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "Landcover-Vineyard",
-      "type": "fill",
+        "fill-outline-color": "rgba(255, 255, 255, 1)",
+        "fill-translate-anchor": "viewport"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 10,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "landuse", "vineyard"]],
+      "id": "Landcover-Vineyard",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
-        "fill-color": "rgba(27, 127, 36, 0.2)",
-        "fill-translate-anchor": "viewport",
         "fill-antialias": false,
-        "fill-outline-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "Landcover-Swamp-Fill",
-      "type": "fill",
+        "fill-color": "rgba(27, 127, 36, 0.2)",
+        "fill-outline-color": "rgba(255, 255, 255, 1)",
+        "fill-translate-anchor": "viewport"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
+      "id": "Landcover-Swamp-Fill",
       "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
@@ -188,438 +177,431 @@
             [14, "rgba(224, 236, 238, 1)"]
           ]
         }
-      }
-    },
-    {
-      "id": "Poi-Mine-Quarry-Poly",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 12,
-      "filter": ["any", ["==", "class", "mine"], ["==", "class", "quarry"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-opacity": 0.5, "fill-color": "rgba(205, 205, 205, 1)" }
-    },
-    {
-      "id": "Landcover-Swamp-Ln",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "minzoom": 10,
-      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
+      "type": "fill"
+    },
+    {
+      "filter": ["any", ["==", "class", "mine"], ["==", "class", "quarry"]],
+      "id": "Poi-Mine-Quarry-Poly",
       "layout": { "visibility": "visible" },
+      "minzoom": 12,
+      "paint": { "fill-color": "rgba(205, 205, 205, 1)", "fill-opacity": 0.5 },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_type", "swamp"]],
+      "id": "Landcover-Swamp-Ln",
+      "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
-        "line-width": 0.5,
-        "line-dasharray": [6, 6, 4, 4],
         "line-color": {
           "stops": [
             [10, "rgba(0, 140, 204, 0.1)"],
             [11, "rgba(0, 140, 204, 0.8)"]
           ]
-        }
-      }
+        },
+        "line-dasharray": [6, 6, 4, 4],
+        "line-width": 0.5
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "line"
     },
     {
-      "id": "Contours-All",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "contours",
-      "minzoom": 9,
-      "maxzoom": 16,
       "filter": ["all", ["!has", "designated"], ["!=", "type", "index"], ["!has", "nat_form"]],
+      "id": "Contours-All",
       "layout": { "visibility": "visible" },
+      "maxzoom": 16,
+      "minzoom": 9,
       "paint": {
+        "line-color": "rgba(232, 184, 77, 0.75)",
         "line-width": {
           "stops": [
             [12, 0.3],
             [16, 0.2]
           ]
-        },
-        "line-color": "rgba(232, 184, 77, 0.75)"
-      }
-    },
-    {
-      "id": "Contours-Designated",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "contours",
-      "minzoom": 9,
-      "maxzoom": 16,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["has", "designated"]],
+      "id": "Contours-Designated",
       "layout": { "visibility": "visible" },
+      "maxzoom": 16,
+      "minzoom": 9,
       "paint": {
-        "line-width": 0.4,
         "line-color": "rgba(232, 184, 77, 0.75)",
-        "line-dasharray": [30, 30]
-      }
-    },
-    {
-      "id": "Contours-Index",
-      "type": "line",
+        "line-dasharray": [30, 30],
+        "line-width": 0.4
+      },
       "source": "LINZ Basemaps",
       "source-layer": "contours",
-      "minzoom": 11,
-      "maxzoom": 16,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "type", "index"]],
+      "id": "Contours-Index",
       "layout": { "visibility": "visible" },
+      "maxzoom": 16,
+      "minzoom": 11,
       "paint": {
-        "line-width": {
-          "stops": [
-            [10, 0.5],
-            [15, 1.2]
-          ]
-        },
         "line-color": {
           "stops": [
             [10, "rgba(232, 184, 77, 0.5)"],
             [15, "rgba(232, 184, 77, 0.5)"]
           ]
+        },
+        "line-width": {
+          "stops": [
+            [10, 0.5],
+            [15, 1.2]
+          ]
         }
-      }
-    },
-    {
-      "id": "Contours-Natural",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "contours",
-      "minzoom": 9,
-      "maxzoom": 16,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["has", "nat_form"]],
+      "id": "Contours-Natural",
       "layout": { "visibility": "visible" },
+      "maxzoom": 16,
+      "minzoom": 9,
       "paint": {
-        "line-width": 0.6,
         "line-color": "rgba(232, 184, 77, 0.5)",
-        "line-dasharray": [30, 10, 10, 10]
-      }
+        "line-dasharray": [30, 10, 10, 10],
+        "line-width": 0.6
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "contours",
+      "type": "line"
     },
     {
-      "id": "Aeroway-Airport",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "aeroway",
-      "minzoom": 10,
       "filter": ["all", ["==", "class", "aerodrome"]],
+      "id": "Aeroway-Airport",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(224, 224, 224, 0.7)" }
+      "minzoom": 10,
+      "paint": { "fill-color": "rgba(224, 224, 224, 0.7)" },
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "runway"], ["==", "surface", "sealed"]],
       "id": "Aeroway-Airstrip-Sealed",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "minzoom": 13,
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "rgba(209, 209, 209, 0.5)"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "aeroway",
-      "minzoom": 13,
-      "filter": ["all", ["==", "class", "runway"], ["==", "surface", "sealed"]],
-      "layout": { "visibility": "visible" },
-      "paint": {
-        "fill-color": "rgba(209, 209, 209, 0.5)",
-        "fill-antialias": false
-      }
+      "type": "fill"
     },
     {
-      "id": "Aeroway-Runway-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "aeroway",
-      "minzoom": 13,
       "filter": ["all", ["==", "class", "runway"], ["==", "surface", "sealed"]],
+      "id": "Aeroway-Runway-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
+        "line-color": "rgba(125, 125, 125, 1)",
         "line-width": {
           "stops": [
             [2, 1],
             [10, 0.7],
             [19, 0.5]
           ]
-        },
-        "line-color": "rgba(125, 125, 125, 1)"
-      }
-    },
-    {
-      "id": "Aeroway-Airstrip-Ln",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "aeroway",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "runway"], ["!has", "surface"]],
+      "id": "Aeroway-Airstrip-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
         "line-color": "rgba(125, 125, 125, 1)",
         "line-dasharray": [5, 5]
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "line"
     },
     {
-      "id": "Water-Polys-Outline",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 11,
       "filter": ["any", ["==", "class", "lake"], ["==", "class", "river"], ["==", "class", "canal"], ["==", "class", "lagoon"]],
+      "id": "Water-Polys-Outline",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
+      "minzoom": 11,
       "paint": {
-        "line-width": {
-          "stops": [
-            [9, 1],
-            [15, 2.5]
-          ]
-        },
-        "line-offset": 0,
         "line-color": {
           "stops": [
             [6, "rgba(184, 220, 242, 1)"],
             [13, "rgba(0, 140, 204, 0.3)"],
             [19, "rgba(0, 140, 204, 1)"]
           ]
+        },
+        "line-offset": 0,
+        "line-width": {
+          "stops": [
+            [9, 1],
+            [15, 2.5]
+          ]
         }
-      }
-    },
-    {
-      "id": "Water-Canal-Poly-Named",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 9,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "canal"], ["has", "name"]],
+      "id": "Water-Canal-Poly-Named",
       "layout": { "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 9,
       "paint": {
+        "fill-antialias": true,
         "fill-color": "rgba(204, 232, 245, 1)",
         "fill-opacity": 1,
-        "fill-translate-anchor": "map",
-        "fill-antialias": true,
         "fill-outline-color": {
           "stops": [
             [6, "rgba(184, 220, 242, 1)"],
             [13, "rgba(0, 140, 204, 0.3)"],
             [19, "rgba(0, 140, 204, 1)"]
           ]
-        }
-      }
-    },
-    {
-      "id": "Water-Lagoon",
-      "type": "fill",
+        },
+        "fill-translate-anchor": "map"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "lagoon"]],
-      "paint": { "fill-color": "rgba(184, 220, 242, 1)", "fill-antialias": true }
-    },
-    {
-      "id": "Water-Lake",
-      "type": "fill",
+      "id": "Water-Lagoon",
+      "paint": { "fill-antialias": true, "fill-color": "rgba(184, 220, 242, 1)" },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 0,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "lake"]],
+      "id": "Water-Lake",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
+        "fill-antialias": true,
         "fill-color": "rgba(184, 220, 242, 1)",
         "fill-opacity": 1,
-        "fill-translate-anchor": "map",
-        "fill-antialias": true
-      }
-    },
-    {
-      "id": "Water-Lake-Named",
-      "type": "fill",
+        "fill-translate-anchor": "map"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "lake"], ["has", "name"]],
+      "id": "Water-Lake-Named",
       "layout": { "visibility": "visible" },
-      "paint": {
-        "fill-color": "rgba(184, 220, 242, 1)",
-        "fill-opacity": 1,
-        "fill-translate-anchor": "map",
-        "fill-antialias": true
-      }
-    },
-    {
-      "id": "Water-River-Poly-Named",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 8,
       "maxzoom": 13,
+      "minzoom": 8,
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "rgba(184, 220, 242, 1)",
+        "fill-opacity": 1,
+        "fill-translate-anchor": "map"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "river"], ["has", "name"]],
+      "id": "Water-River-Poly-Named",
       "layout": { "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
+        "fill-antialias": true,
         "fill-color": "rgba(184, 220, 242, 1)",
         "fill-opacity": 1,
-        "fill-translate-anchor": "map",
-        "fill-antialias": true
-      }
-    },
-    {
-      "id": "Water-Canal-Poly",
-      "type": "fill",
+        "fill-translate-anchor": "map"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 13,
-      "maxzoom": 21,
+      "type": "fill"
+    },
+    {
       "filter": ["any", ["==", "class", "canal"]],
+      "id": "Water-Canal-Poly",
       "layout": { "visibility": "visible" },
-      "paint": {
-        "fill-color": "rgba(184, 220, 242, 1)",
-        "fill-opacity": 1,
-        "fill-translate-anchor": "map",
-        "fill-antialias": true
-      }
-    },
-    {
-      "id": "Water-River-Poly",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 13,
       "maxzoom": 21,
-      "filter": ["any", ["==", "class", "river"]],
-      "layout": { "visibility": "visible" },
+      "minzoom": 13,
       "paint": {
+        "fill-antialias": true,
         "fill-color": "rgba(184, 220, 242, 1)",
         "fill-opacity": 1,
-        "fill-translate-anchor": "map",
-        "fill-antialias": true
-      }
-    },
-    {
-      "id": "Water-Reef",
-      "type": "line",
+        "fill-translate-anchor": "map"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 10,
-      "filter": ["all", ["==", "class", "reef"]],
+      "type": "fill"
+    },
+    {
+      "filter": ["any", ["==", "class", "river"]],
+      "id": "Water-River-Poly",
       "layout": { "visibility": "visible" },
+      "maxzoom": 21,
+      "minzoom": 13,
       "paint": {
+        "fill-antialias": true,
+        "fill-color": "rgba(184, 220, 242, 1)",
+        "fill-opacity": 1,
+        "fill-translate-anchor": "map"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "fill"
+    },
+    {
+      "filter": ["all", ["==", "class", "reef"]],
+      "id": "Water-Reef",
+      "layout": { "visibility": "visible" },
+      "minzoom": 10,
+      "paint": {
+        "line-color": "rgba(0, 140, 204, 1)",
+        "line-dasharray": [12, 2],
         "line-width": {
           "stops": [
             [2, 0.5],
             [10, 1]
           ]
-        },
-        "line-color": "rgba(0, 140, 204, 1)",
-        "line-dasharray": [12, 2]
-      }
-    },
-    {
-      "id": "Waterway-Canal-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 13,
-      "maxzoom": 21,
-      "filter": ["all", ["==", "class", "canal"]],
-      "layout": { "visibility": "visible" },
-      "paint": {
-        "line-opacity": 1,
-        "line-width": {
-          "stops": [
-            [12, 1],
-            [13, 0.75],
-            [18, 0.5]
-          ]
-        },
-        "line-color": {
-          "stops": [
-            [11, "rgba(167, 209, 232, 0.75)"],
-            [13, "rgba(76, 147, 226, 0.75)"],
-            [20, "rgba(0, 140, 204, 0.75)"]
-          ]
         }
-      }
-    },
-    {
-      "id": "Waterway-Drain-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 13,
-      "maxzoom": 21,
-      "filter": ["all", ["==", "class", "drain"]],
-      "layout": { "visibility": "visible" },
-      "paint": {
-        "line-opacity": 1,
-        "line-width": {
-          "stops": [
-            [12, 1],
-            [13, 0.75],
-            [18, 0.5]
-          ]
-        },
-        "line-color": {
-          "stops": [
-            [11, "rgba(167, 209, 232, 0.75)"],
-            [13, "rgba(76, 147, 226, 0.75)"],
-            [20, "rgba(0, 140, 204, 0.75)"]
-          ]
-        }
-      }
-    },
-    {
-      "id": "Water-Dry-Dock-ln",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "dock"]],
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "canal"]],
+      "id": "Waterway-Canal-Ln",
       "layout": { "visibility": "visible" },
+      "maxzoom": 21,
+      "minzoom": 13,
       "paint": {
+        "line-color": {
+          "stops": [
+            [11, "rgba(167, 209, 232, 0.75)"],
+            [13, "rgba(76, 147, 226, 0.75)"],
+            [20, "rgba(0, 140, 204, 0.75)"]
+          ]
+        },
+        "line-opacity": 1,
+        "line-width": {
+          "stops": [
+            [12, 1],
+            [13, 0.75],
+            [18, 0.5]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "drain"]],
+      "id": "Waterway-Drain-Ln",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 21,
+      "minzoom": 13,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [11, "rgba(167, 209, 232, 0.75)"],
+            [13, "rgba(76, 147, 226, 0.75)"],
+            [20, "rgba(0, 140, 204, 0.75)"]
+          ]
+        },
+        "line-opacity": 1,
+        "line-width": {
+          "stops": [
+            [12, 1],
+            [13, 0.75],
+            [18, 0.5]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "dock"]],
+      "id": "Water-Dry-Dock-ln",
+      "layout": { "visibility": "visible" },
+      "minzoom": 12,
+      "paint": {
+        "line-color": "rgba(73, 73, 73, 1)",
         "line-width": {
           "stops": [
             [10, 0.75],
             [14, 1.5],
             [18, 2]
           ]
-        },
-        "line-color": "rgba(73, 73, 73, 1)"
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "line"
     },
     {
-      "id": "Water-River-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 13,
-      "maxzoom": 21,
       "filter": ["all", ["==", "class", "river"]],
+      "id": "Water-River-Ln",
       "layout": { "visibility": "visible" },
+      "maxzoom": 21,
+      "minzoom": 13,
       "paint": {
+        "line-color": {
+          "stops": [
+            [13, "rgba(76, 147, 226, 0.75)"],
+            [20, "rgba(0, 140, 204, 0.75)"]
+          ]
+        },
         "line-opacity": 1,
         "line-width": {
           "stops": [
             [13, 1],
             [18, 0.75]
           ]
-        },
-        "line-color": {
-          "stops": [
-            [13, "rgba(76, 147, 226, 0.75)"],
-            [20, "rgba(0, 140, 204, 0.75)"]
-          ]
         }
-      }
-    },
-    {
-      "id": "Water-River-Ln-Named",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "waterway",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "river"], ["has", "name"]],
+      "id": "Water-River-Ln-Named",
       "layout": { "visibility": "visible" },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
-        "line-opacity": 1,
-        "line-width": {
-          "stops": [
-            [12, 1.5],
-            [13, 1]
-          ]
-        },
         "line-color": {
           "stops": [
             [9, "rgba(125, 198, 215, 0.01)"],
@@ -628,16 +610,25 @@
             [12, "rgba(167, 209, 232, 0.75)"],
             [13, "rgba(76, 147, 226, 0.75)"]
           ]
+        },
+        "line-opacity": 1,
+        "line-width": {
+          "stops": [
+            [12, 1.5],
+            [13, 1]
+          ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "line"
     },
     {
       "id": "texture-relief-combined-test",
-      "type": "raster",
-      "source": "LINZ-Texture-Relief",
       "layout": { "visibility": "visible" },
       "paint": {
         "raster-brightness-min": 0,
+        "raster-contrast": 0,
         "raster-opacity": {
           "stops": [
             [1, 0.35],
@@ -647,47 +638,45 @@
             [16, 0.3]
           ]
         },
-        "raster-resampling": "nearest",
-        "raster-contrast": 0
-      }
+        "raster-resampling": "nearest"
+      },
+      "source": "LINZ-Texture-Relief",
+      "type": "raster"
     },
     {
-      "id": "Waterway-WaterRace",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
       "filter": ["all", ["==", "class", "channel"], ["==", "channel_type", "water_race"]],
+      "id": "Waterway-WaterRace",
       "layout": { "visibility": "visible" },
       "paint": {
-        "line-width": 0.5,
         "line-color": {
           "stops": [
             [13, "rgba(0, 140, 204, 0.3)"],
             [19, "rgba(0, 140, 204, 1)"]
           ]
-        }
-      }
+        },
+        "line-width": 0.5
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "line"
     },
     {
-      "id": "Landuse-Landfill",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "landfill"]],
+      "id": "Landuse-Landfill",
+      "minzoom": 12,
       "paint": {
-        "fill-color": "rgba(143, 104, 55, 0.45)",
-        "fill-antialias": true
-      }
-    },
-    {
-      "id": "Landuse-Pond",
-      "type": "fill",
+        "fill-antialias": true,
+        "fill-color": "rgba(143, 104, 55, 0.45)"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 10,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "wetland"], ["==", "wetland_feature", "pond"]],
+      "id": "Landuse-Pond",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "fill-color": "rgba(184, 220, 242, 1)",
         "fill-outline-color": {
@@ -697,41 +686,41 @@
             [19, "rgba(0, 140, 204, 1)"]
           ]
         }
-      }
-    },
-    {
-      "id": "Landuse-Reservoir-Covered",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 10,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "reservoir"], ["==", "lid_type", "covered"]],
+      "id": "Landuse-Reservoir-Covered",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
         "fill-color": "rgba(148, 148, 148, 1)",
         "fill-outline-color": "rgba(18, 18, 18, 1)"
-      }
-    },
-    {
-      "id": "Landuse-Reservoir-Empty",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 10,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "reservoir"], ["!=", "lid_type", "covered"]],
+      "id": "Landuse-Reservoir-Empty",
+      "minzoom": 10,
       "paint": {
         "fill-color": "rgba(184, 220, 242, 1)",
         "fill-outline-color": "rgba(18, 18, 18, 1)"
-      }
-    },
-    {
-      "id": "Landuse-Residential",
-      "type": "fill",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 8,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "residential"]],
+      "id": "Landuse-Residential",
       "layout": { "visibility": "visible" },
+      "minzoom": 8,
       "paint": {
         "fill-color": {
           "stops": [
@@ -743,25 +732,33 @@
           ]
         },
         "fill-outline-color": "rgba(164, 164, 164, 0.01)"
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "grass"], ["==", "grass_type", "golf_course"]],
       "id": "Landcover-GolfCourse",
-      "type": "fill",
+      "layout": { "visibility": "visible" },
+      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" },
       "source": "LINZ Basemaps",
       "source-layer": "landcover",
-      "filter": ["all", ["==", "class", "grass"], ["==", "grass_type", "golf_course"]],
-      "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" }
+      "type": "fill"
     },
     {
       "id": "Coastline-Ln-2",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "coastline",
-      "minzoom": 0,
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
+        "line-color": {
+          "stops": [
+            [1, "rgba(9, 132, 186, 0.5)"],
+            [6, "rgba(9, 132, 186, 0.5)"],
+            [10, "rgba(27, 152, 193, 0.5)"],
+            [16, "rgba(34, 164, 212, 0.5)"]
+          ]
+        },
         "line-translate-anchor": "map",
         "line-width": {
           "stops": [
@@ -770,43 +767,36 @@
             [15, 1.25],
             [20, 3.5]
           ]
-        },
-        "line-color": {
-          "stops": [
-            [1, "rgba(9, 132, 186, 0.5)"],
-            [6, "rgba(9, 132, 186, 0.5)"],
-            [10, "rgba(27, 152, 193, 0.5)"],
-            [16, "rgba(34, 164, 212, 0.5)"]
-          ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "coastline",
+      "type": "line"
     },
     {
-      "id": "Poi-FishFarm",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
       "filter": ["all", ["==", "class", "fish_farm"]],
+      "id": "Poi-FishFarm",
       "layout": { "visibility": "visible" },
-      "paint": { "fill-color": "rgb(112,172,242)" }
-    },
-    {
-      "id": "Poi-SportsField",
-      "type": "fill",
+      "paint": { "fill-color": "rgb(112,172,242)" },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "sports_field"]],
-      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" }
-    },
-    {
-      "id": "Poi-Storage-Tank-Empty",
-      "type": "fill",
+      "id": "Poi-SportsField",
+      "paint": { "fill-color": "rgba(121, 195, 128, 0.2)" },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 0,
+      "type": "fill"
+    },
+    {
       "filter": ["all", ["==", "class", "storage_tank"], ["!has", "store_item"]],
+      "id": "Poi-Storage-Tank-Empty",
       "layout": { "visibility": "visible" },
+      "minzoom": 0,
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "stops": [
             [6, "rgba(240, 240, 240, 0.85)"],
@@ -819,124 +809,124 @@
             [20, 0.2]
           ]
         },
-        "fill-antialias": true,
         "fill-outline-color": "rgba(67, 67, 67, 1)"
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "fill"
     },
     {
+      "filter": ["all", ["==", "class", "siphon"]],
       "id": "Poi-Siphon",
-      "type": "fill",
+      "minzoom": 12,
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
-      "filter": ["all", ["==", "class", "siphon"]]
+      "type": "fill"
     },
     {
-      "id": "Poi-Tank-Pt-Fill-Empty",
-      "type": "circle",
-      "source": "LINZ Basemaps",
-      "source-layer": "poi",
-      "minzoom": 10,
       "filter": ["all", ["==", "class", "storage_tank_pt"], ["!has", "store_item"]],
+      "id": "Poi-Tank-Pt-Fill-Empty",
       "layout": { "visibility": "visible" },
+      "minzoom": 10,
       "paint": {
+        "circle-color": "rgba(255, 255, 255, 1)",
         "circle-opacity": {
           "stops": [
             [14, 1],
             [20, 0.2]
           ]
         },
+        "circle-pitch-alignment": "map",
         "circle-radius": {
           "stops": [
             [12, 1.5],
             [15, 3.5]
           ]
-        },
-        "circle-color": "rgba(255, 255, 255, 1)",
-        "circle-pitch-alignment": "map"
-      }
-    },
-    {
-      "id": "Poi-Dredge-Tailing",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
-      "minzoom": 12,
+      "type": "circle"
+    },
+    {
       "filter": ["all", ["==", "class", "dredge_tailing"]],
+      "id": "Poi-Dredge-Tailing",
+      "minzoom": 12,
       "paint": {
+        "line-color": "rgba(55, 55, 55, 1)",
         "line-opacity": 0.9,
-        "line-width": 10,
         "line-pattern": "dredge_tailing_pnt",
-        "line-color": "rgba(55, 55, 55, 1)"
-      }
-    },
-    {
-      "id": "Poi-Slipway-Symbol-Dash",
-      "type": "line",
+        "line-width": 10
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "slipway"]],
+      "id": "Poi-Slipway-Symbol-Dash",
       "paint": {
+        "line-color": "rgba(64, 64, 64, 1)",
         "line-width": {
           "stops": [
             [12, 1],
             [16, 4]
           ]
-        },
-        "line-color": "rgba(64, 64, 64, 1)"
-      }
-    },
-    {
-      "id": "Poi-Slipway-Symbol-Line",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "poi",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "slipway"]],
+      "id": "Poi-Slipway-Symbol-Line",
       "layout": { "visibility": "visible" },
       "paint": {
+        "line-color": "rgba(64, 64, 64, 1)",
+        "line-dasharray": [0.15, 0.4],
         "line-width": {
           "stops": [
             [12, 4],
             [16, 18]
           ]
-        },
-        "line-color": "rgba(64, 64, 64, 1)",
-        "line-dasharray": [0.15, 0.4]
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "line"
     },
     {
-      "id": "Parcels-Ln",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "parcel_boundaries",
-      "minzoom": 15,
       "filter": ["none", ["==", "parcel_intent", "Road"], ["==", "parcel_intent", "Hydro"]],
+      "id": "Parcels-Ln",
       "layout": { "visibility": "visible" },
+      "minzoom": 15,
       "paint": {
-        "line-width": {
-          "stops": [
-            [8, 0.2],
-            [16, 0.75],
-            [24, 1.5]
-          ]
-        },
         "line-color": {
           "stops": [
             [8, "rgba(203, 203, 203, 1)"],
             [16, "rgba(204, 204, 204, 1)"],
             [24, "rgba(170, 170, 170, 1)"]
           ]
+        },
+        "line-width": {
+          "stops": [
+            [8, 0.2],
+            [16, 0.75],
+            [24, 1.5]
+          ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "parcel_boundaries",
+      "type": "line"
     },
     {
       "id": "Buildings",
-      "type": "fill",
-      "source": "LINZ Basemaps",
-      "source-layer": "building",
-      "minzoom": 16,
       "layout": { "visibility": "visible" },
+      "minzoom": 16,
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "stops": [
             [15, "#DBDBD9"],
@@ -945,113 +935,119 @@
             [19, "#DBDBD9"]
           ]
         },
-        "fill-opacity": 1,
-        "fill-antialias": true
-      }
+        "fill-opacity": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "building",
+      "type": "fill"
     },
     {
       "id": "Buildings-Outline",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "building",
-      "minzoom": 16,
       "layout": { "visibility": "visible" },
+      "minzoom": 16,
       "paint": {
+        "line-color": "rgba(152, 145, 145,0.6)",
         "line-width": {
           "stops": [
             [17, 0.5],
             [24, 1]
           ]
-        },
-        "line-color": "rgba(152, 145, 145,0.6)"
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "building",
+      "type": "line"
     },
     {
-      "id": "Transport-Bridge-Foot",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 13,
       "filter": ["all", ["==", "brunnel", "bridge"], ["==", "use_1", "foot traffic"]],
+      "id": "Transport-Bridge-Foot",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-color": "rgba(78, 78, 78, 0.3)",
         "line-width": {
           "stops": [
             [10, 0.5],
             [15, 4],
             [19, 6]
           ]
-        },
-        "line-color": "rgba(78, 78, 78, 0.3)"
-      }
-    },
-    {
-      "id": "Transport-FootTracks-Shadow",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
+      "id": "Transport-FootTracks-Shadow",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-color": "rgba(231, 231, 231, 0.4)",
         "line-width": {
           "stops": [
             [13, 1.5],
             [15, 2.5],
             [19, 5]
           ]
-        },
-        "line-color": "rgba(231, 231, 231, 0.4)"
-      }
-    },
-    {
-      "id": "Transport-VehicleTracks-Shadow",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "track"], ["==", "track_use", "vehicle"]],
+      "id": "Transport-VehicleTracks-Shadow",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-blur": 0.75,
+        "line-color": "rgba(231, 231, 231, 0.4)",
+        "line-dasharray": [8],
         "line-width": {
+          "base": 1,
           "stops": [
             [13, 2],
             [15, 3],
             [19, 5]
-          ],
-          "base": 1
-        },
-        "line-blur": 0.75,
-        "line-dasharray": [8],
-        "line-color": "rgba(231, 231, 231, 0.4)"
-      }
-    },
-    {
-      "id": "Transport-1Casing",
-      "type": "line",
+          ]
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
-      "maxzoom": 18,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"]],
+      "id": "Transport-1Casing",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "maxzoom": 18,
+      "minzoom": 11,
       "paint": {
+        "line-color": {
+          "stops": [
+            [10, "rgba(78, 78, 78, .1)"],
+            [17, "rgba(78, 78, 78, .1)"],
+            [18, "rgba(96, 96, 96, .1)"]
+          ]
+        },
         "line-width": {
           "stops": [
             [10, 1.5],
@@ -1062,30 +1058,30 @@
             [19, 40],
             [22, 200]
           ]
-        },
-        "line-color": {
-          "stops": [
-            [10, "rgba(78, 78, 78, .1)"],
-            [17, "rgba(78, 78, 78, .1)"],
-            [18, "rgba(96, 96, 96, .1)"]
-          ]
         }
-      }
-    },
-    {
-      "id": "Transport-2Casing",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
-      "maxzoom": 18,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["in", "lane_count", 2, 3, 4, 5, 6, 7, 8], ["!=", "class", "motorway"]],
+      "id": "Transport-2Casing",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "maxzoom": 18,
+      "minzoom": 11,
       "paint": {
+        "line-color": {
+          "stops": [
+            [10, "rgba(78, 78, 78, 0.1)"],
+            [17, "rgba(78, 78, 78, 0.1)"],
+            [18, "rgba(96, 96, 96, 0.1)"]
+          ]
+        },
         "line-width": {
           "stops": [
             [11, 3.5],
@@ -1096,29 +1092,24 @@
             [19, 50],
             [22, 200]
           ]
-        },
-        "line-color": {
-          "stops": [
-            [10, "rgba(78, 78, 78, 0.1)"],
-            [17, "rgba(78, 78, 78, 0.1)"],
-            [18, "rgba(96, 96, 96, 0.1)"]
-          ]
         }
-      }
-    },
-    {
-      "id": "Transport-1UnMetalled",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "unmetalled"], ["==", "lane_count", 1]],
+      "id": "Transport-1UnMetalled",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 11,
       "paint": {
+        "line-color": "rgba(255, 254, 252, 1)",
+        "line-gap-width": 0,
         "line-translate-anchor": "map",
         "line-width": {
           "stops": [
@@ -1130,81 +1121,24 @@
             [19, 35],
             [22, 180]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(255, 254, 252, 1)"
-      }
-    },
-    {
-      "id": "Transport-1Metalled-White",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "metalled"], ["==", "lane_count", 1]],
+      "id": "Transport-1Metalled-White",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
-      "paint": {
-        "line-translate-anchor": "map",
-        "line-width": {
-          "stops": [
-            [10, 0.5],
-            [11, 1],
-            [13, 2],
-            [15, 3],
-            [18, 8],
-            [19, 35],
-            [22, 180]
-          ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(255, 254, 252, 1)"
-      }
-    },
-    {
-      "id": "Transport-1-UnderCons",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
       "minzoom": 10,
-      "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"], ["==", "status", "under construction"]],
-      "layout": {
-        "visibility": "visible",
-        "line-cap": "butt",
-        "line-join": "bevel"
-      },
       "paint": {
-        "line-width": {
-          "stops": [
-            [10, 0.5],
-            [11, 1],
-            [13, 2],
-            [15, 3],
-            [18, 8],
-            [19, 35],
-            [22, 180]
-          ]
-        },
-        "line-color": "rgba(96, 96, 96, 0.1)",
-        "line-dasharray": [1, 5]
-      }
-    },
-    {
-      "id": "Transport-1Sealed",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 11,
-      "filter": ["all", ["==", "surface", "sealed"], ["==", "lane_count", 1], ["!=", "class", "motorway"]],
-      "layout": {
-        "visibility": "visible",
-        "line-cap": "round",
-        "line-join": "bevel"
-      },
-      "paint": {
+        "line-color": "rgba(255, 254, 252, 1)",
+        "line-gap-width": 0,
         "line-translate-anchor": "map",
         "line-width": {
           "stops": [
@@ -1216,30 +1150,87 @@
             [19, 35],
             [22, 180]
           ]
-        },
-        "line-gap-width": 0,
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"], ["==", "status", "under construction"]],
+      "id": "Transport-1-UnderCons",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 10,
+      "paint": {
+        "line-color": "rgba(96, 96, 96, 0.1)",
+        "line-dasharray": [1, 5],
+        "line-width": {
+          "stops": [
+            [10, 0.5],
+            [11, 1],
+            [13, 2],
+            [15, 3],
+            [18, 8],
+            [19, 35],
+            [22, 180]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "sealed"], ["==", "lane_count", 1], ["!=", "class", "motorway"]],
+      "id": "Transport-1Sealed",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 11,
+      "paint": {
         "line-color": {
           "stops": [
             [10, "#fff"],
             [17, "#fff"],
             [19, "#fff"]
           ]
+        },
+        "line-gap-width": 0,
+        "line-translate-anchor": "map",
+        "line-width": {
+          "stops": [
+            [10, 0.5],
+            [11, 1],
+            [13, 2],
+            [15, 3],
+            [18, 8],
+            [19, 35],
+            [22, 180]
+          ]
         }
-      }
-    },
-    {
-      "id": "Transport-2UnMetalled",
-      "type": "line",
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "unmetalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7], ["!=", "staus", "under construction"]],
+      "id": "Transport-2UnMetalled",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
+      "minzoom": 10,
       "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-gap-width": 0,
         "line-translate-anchor": "map",
         "line-width": {
           "stops": [
@@ -1251,24 +1242,24 @@
             [19, 55],
             [22, 380]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "Transport-2Metalled-White",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "metalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
+      "id": "Transport-2Metalled-White",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
+      "minzoom": 10,
       "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-gap-width": 0,
         "line-translate-anchor": "map",
         "line-width": {
           "stops": [
@@ -1280,24 +1271,25 @@
             [19, 55],
             [22, 380]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "Transport-2UnderContruction",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "status", "under construction"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
+      "id": "Transport-2UnderContruction",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 10,
       "paint": {
+        "line-color": "rgba(96, 96, 96, 0.1)",
+        "line-dasharray": [1, 5],
+        "line-gap-width": 0,
         "line-translate-anchor": "map",
         "line-width": {
           "stops": [
@@ -1309,25 +1301,24 @@
             [19, 55],
             [22, 380]
           ]
-        },
-        "line-gap-width": 0,
-        "line-dasharray": [1, 5],
-        "line-color": "rgba(96, 96, 96, 0.1)"
-      }
-    },
-    {
-      "id": "Transport-2+Sealed",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 10,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "surface", "sealed"], ["in", "lane_count", 2, 3, 4, 5, 6, 7], ["!=", "class", "motorway"]],
+      "id": "Transport-2+Sealed",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
+      "minzoom": 10,
       "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-gap-width": 0,
         "line-translate-anchor": "map",
         "line-width": {
           "stops": [
@@ -1340,95 +1331,94 @@
             [19, 55],
             [22, 380]
           ]
-        },
-        "line-gap-width": 0,
-        "line-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "Transport-Railway-Siding",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rail"], ["has", "rway_use"]],
+      "id": "Transport-Railway-Siding",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
-      "paint": { "line-width": 1, "line-color": "rgba(67, 61, 61, 0.65)" }
-    },
-    {
-      "id": "Transport-Railway-Single",
-      "type": "line",
+      "minzoom": 11,
+      "paint": { "line-color": "rgba(67, 61, 61, 0.65)", "line-width": 1 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rail"], ["==", "track_type", "single"], ["!has", "rway_use"]],
+      "id": "Transport-Railway-Single",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
-      "paint": { "line-width": 2, "line-color": "rgba(67, 61, 61, 0.65)" }
-    },
-    {
-      "id": "Transport-Railway-Multiple",
-      "type": "line",
+      "minzoom": 11,
+      "paint": { "line-color": "rgba(67, 61, 61, 0.65)", "line-width": 2 },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rail"], ["==", "track_type", "multiple"]],
+      "id": "Transport-Railway-Multiple",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
+      "minzoom": 11,
       "paint": {
+        "line-color": "rgba(67, 61, 61, 0.65)",
         "line-width": {
           "stops": [
             [11, 2.5],
             [19, 4],
             [20, 4]
           ]
-        },
-        "line-color": "rgba(67, 61, 61, 0.65)"
-      }
-    },
-    {
-      "id": "Transport-Railway-High",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
-      "maxzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "rail"]],
+      "id": "Transport-Railway-High",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "butt",
         "line-join": "round",
-        "line-cap": "butt"
+        "visibility": "visible"
       },
+      "maxzoom": 11,
+      "minzoom": 8,
       "paint": {
-        "line-width": 2,
         "line-color": {
           "stops": [
             [8, "rgba(158, 153, 153, 1)"],
             [10, "rgba(96, 90, 90, 0.95)"]
           ]
-        }
-      }
-    },
-    {
-      "id": "Transport-Roads-9-Casing",
-      "type": "line",
+        },
+        "line-width": 2
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 0,
-      "maxzoom": 9,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"]],
+      "id": "Transport-Roads-9-Casing",
       "layout": { "visibility": "visible" },
+      "maxzoom": 9,
+      "minzoom": 0,
       "paint": {
+        "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
           "stops": [
             [1, 0],
@@ -1436,24 +1426,24 @@
             [7, 1],
             [8, 3.5]
           ]
-        },
-        "line-color": "rgba(120, 120, 120, 1)"
-      }
-    },
-    {
-      "id": "Transport-Roads-9",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 0,
-      "maxzoom": 9,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"]],
+      "id": "Transport-Roads-9",
       "layout": {
-        "visibility": "visible",
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
+      "maxzoom": 9,
+      "minzoom": 0,
       "paint": {
+        "line-color": "rgba(210, 162, 84, 1)",
         "line-width": {
           "stops": [
             [1, 0.1],
@@ -1461,24 +1451,24 @@
             [7, 1.4],
             [8, 2.5]
           ]
-        },
-        "line-color": "rgba(210, 162, 84, 1)"
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
+      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 1]],
       "id": "Transport-1HWY-Casing",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 8,
-      "maxzoom": 13,
-      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 1]],
       "layout": {
-        "visibility": "none",
+        "line-cap": "butt",
         "line-join": "round",
-        "line-cap": "butt"
+        "visibility": "none"
       },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
+        "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
           "stops": [
             [8, 1.5],
@@ -1490,24 +1480,24 @@
             [19, 50],
             [22, 220]
           ]
-        },
-        "line-color": "rgba(120, 120, 120, 1)"
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
+      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
       "id": "Transport-2HWY-Casing",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 8,
-      "maxzoom": 13,
-      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
       "layout": {
-        "visibility": "none",
+        "line-cap": "butt",
         "line-join": "round",
-        "line-cap": "butt"
+        "visibility": "none"
       },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
+        "line-color": "rgba(120, 120, 120, 0.8)",
         "line-width": {
           "stops": [
             [8, 3.25],
@@ -1519,24 +1509,24 @@
             [19, 70],
             [22, 450]
           ]
-        },
-        "line-color": "rgba(120, 120, 120, 0.8)"
-      }
-    },
-    {
-      "id": "Transport-HWY-Casing",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
-      "maxzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
+      "id": "Transport-HWY-Casing",
       "layout": {
-        "visibility": "none",
+        "line-cap": "butt",
         "line-join": "round",
-        "line-cap": "butt"
+        "visibility": "none"
       },
+      "maxzoom": 13,
+      "minzoom": 8,
       "paint": {
+        "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
           "stops": [
             [8, 3.5],
@@ -1548,23 +1538,23 @@
             [19, 80],
             [22, 470]
           ]
-        },
-        "line-color": "rgba(120, 120, 120, 1)"
-      }
-    },
-    {
-      "id": "Transport-2HWY-Casing-14",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
+      "id": "Transport-2HWY-Casing-14",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
           "stops": [
             [8, 3.25],
@@ -1576,23 +1566,23 @@
             [19, 70],
             [22, 450]
           ]
-        },
-        "line-color": "rgba(120, 120, 120, 1)"
-      }
-    },
-    {
-      "id": "Transport-1HWY-Casing-14",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 1]],
+      "id": "Transport-1HWY-Casing-14",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "butt",
         "line-join": "round",
-        "line-cap": "butt"
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
           "stops": [
             [8, 1.5],
@@ -1604,23 +1594,23 @@
             [19, 50],
             [22, 220]
           ]
-        },
-        "line-color": "rgba(120, 120, 120, 1)"
-      }
-    },
-    {
-      "id": "Transport-HWY-Casing-14",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
+      "id": "Transport-HWY-Casing-14",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "butt",
         "line-join": "round",
-        "line-cap": "butt"
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
+        "line-color": "rgba(120, 120, 120, 1)",
         "line-width": {
           "stops": [
             [8, 3.5],
@@ -1632,23 +1622,24 @@
             [19, 80],
             [22, 470]
           ]
-        },
-        "line-color": "rgba(120, 120, 120, 1)"
-      }
-    },
-    {
-      "id": "Transport-2HWY",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
+      "id": "Transport-2HWY",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "round",
         "line-join": "round",
-        "line-cap": "round"
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
+        "line-blur": 0,
+        "line-color": "rgba(240, 164, 82, 1)",
         "line-width": {
           "stops": [
             [8, 1.35],
@@ -1660,24 +1651,23 @@
             [19, 60],
             [22, 420]
           ]
-        },
-        "line-blur": 0,
-        "line-color": "rgba(240, 164, 82, 1)"
-      }
-    },
-    {
-      "id": "Transport-1HWY",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["==", "lane_count", 1]],
+      "id": "Transport-1HWY",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "butt",
         "line-join": "round",
-        "line-cap": "butt"
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
+        "line-color": "rgba(240, 164, 82, 1)",
         "line-width": {
           "stops": [
             [8, 0.75],
@@ -1689,23 +1679,23 @@
             [19, 40],
             [22, 200]
           ]
-        },
-        "line-color": "rgba(240, 164, 82, 1)"
-      }
-    },
-    {
-      "id": "Transport-HWY",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 8,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
+      "id": "Transport-HWY",
       "layout": {
-        "visibility": "visible",
+        "line-cap": "butt",
         "line-join": "round",
-        "line-cap": "butt"
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
+        "line-color": "rgba(240, 164, 82, 1)",
         "line-width": {
           "stops": [
             [8, 1.5],
@@ -1717,23 +1707,23 @@
             [19, 70],
             [22, 440]
           ]
-        },
-        "line-color": "rgba(240, 164, 82, 1)"
-      }
-    },
-    {
-      "id": "Transport-Bridge-VT-Casing",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "brunnel", "bridge"], ["in", "use_1", "train", "vehicle"]],
+      "id": "Transport-Bridge-VT-Casing",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 11,
       "paint": {
+        "line-color": "rgba(168, 168, 168, 1)",
         "line-width": {
           "stops": [
             [12, 6],
@@ -1742,23 +1732,23 @@
             [19, 75],
             [22, 450]
           ]
-        },
-        "line-color": "rgba(168, 168, 168, 1)"
-      }
-    },
-    {
-      "id": "Transport-Bridge-VT",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 11,
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "brunnel", "bridge"], ["in", "use_1", "train", "vehicle"]],
+      "id": "Transport-Bridge-VT",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 11,
       "paint": {
+        "line-color": "rgba(220, 220, 220, 1)",
         "line-width": {
           "stops": [
             [12, 5],
@@ -1767,66 +1757,69 @@
             [19, 66],
             [22, 400]
           ]
-        },
-        "line-color": "rgba(220, 220, 220, 1)"
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
-      "id": "Landuse-Boom",
-      "type": "line",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "boom"]],
+      "id": "Landuse-Boom",
+      "minzoom": 12,
       "paint": {
+        "line-color": "rgba(73, 73, 73, 1)",
         "line-width": {
           "stops": [
             [10, 1.5],
             [13, 2],
             [15, 4]
           ]
-        },
-        "line-color": "rgba(73, 73, 73, 1)"
-      }
-    },
-    {
-      "id": "Landuse-Dam",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "class", "dam_ln"]],
+      "id": "Landuse-Dam",
       "paint": {
+        "line-color": "rgba(211, 211, 211, 1)",
         "line-width": {
           "stops": [
             [10, 4],
             [15, 8.5],
             [19, 14.5]
           ]
-        },
-        "line-color": "rgba(211, 211, 211, 1)"
-      }
-    },
-    {
-      "id": "Landuse-MarineFarm-Ln",
-      "type": "line",
+        }
+      },
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "filter": ["all", ["==", "class", "marine_farm_ln"]],
-      "paint": { "line-width": 3, "line-color": "rgba(25, 114, 242, 0.45)" }
+      "type": "line"
     },
     {
-      "id": "Transport-Tunnel-VT",
-      "type": "line",
+      "filter": ["all", ["==", "class", "marine_farm_ln"]],
+      "id": "Landuse-MarineFarm-Ln",
+      "paint": { "line-color": "rgba(25, 114, 242, 0.45)", "line-width": 3 },
       "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 10,
+      "source-layer": "landuse",
+      "type": "line"
+    },
+    {
       "filter": ["all", ["==", "brunnel", "tunnel"]],
+      "id": "Transport-Tunnel-VT",
       "layout": {
-        "visibility": "visible",
         "line-cap": "butt",
-        "line-join": "bevel"
+        "line-join": "bevel",
+        "visibility": "visible"
       },
+      "minzoom": 10,
       "paint": {
+        "line-blur": 0,
+        "line-color": "rgba(90, 89, 86, 0.6)",
+        "line-dasharray": [4, 2.5],
+        "line-gap-width": 8,
         "line-opacity": 1,
         "line-width": {
           "stops": [
@@ -1834,20 +1827,15 @@
             [15, 1],
             [19, 4]
           ]
-        },
-        "line-blur": 0,
-        "line-gap-width": 8,
-        "line-dasharray": [4, 2.5],
-        "line-color": "rgba(90, 89, 86, 0.6)"
-      }
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
     },
     {
-      "id": "Landuse-GravelPit-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "landuse",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "gravel_pit"]],
+      "id": "Landuse-GravelPit-Label",
       "layout": {
         "icon-size": 0.8,
         "text-field": "",
@@ -1858,128 +1846,65 @@
             [15, 10]
           ]
         }
-      }
-    },
-    {
-      "id": "Landuse-MarineFarm-Label",
-      "type": "symbol",
+      },
+      "minzoom": 12,
       "source": "LINZ Basemaps",
       "source-layer": "landuse",
-      "minzoom": 15,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "marine_farm"]],
+      "id": "Landuse-MarineFarm-Label",
       "layout": {
         "text-field": "{species}",
         "text-font": ["Roboto Bold Italic"]
       },
+      "minzoom": 15,
       "paint": {
-        "text-halo-width": 1.5,
         "text-color": "rgba(232, 232, 232, 1)",
-        "text-halo-color": "rgba(25, 114, 242, 0.45)"
-      }
+        "text-halo-color": "rgba(25, 114, 242, 0.45)",
+        "text-halo-width": 1.5
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
     },
     {
-      "id": "Waterway-Rapid-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 13,
       "filter": ["all", ["==", "class", "stream"], ["==", "stream_feature", "rapid_cl"], ["has", "name"]],
+      "id": "Waterway-Rapid-Names",
       "layout": {
-        "symbol-spacing": 750,
-        "visibility": "visible",
-        "text-field": "{name}",
         "icon-anchor": "center",
-        "text-size": 12,
-        "text-anchor": "bottom",
         "symbol-placement": "line",
-        "text-font": ["Open Sans Italic"]
+        "symbol-spacing": 750,
+        "text-anchor": "bottom",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-size": 12,
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "text-halo-blur": 1,
         "text-color": "rgba(0, 140, 204, 1)",
+        "text-halo-blur": 1,
         "text-halo-color": "rgba(239, 239, 239, 0.80)",
         "text-halo-width": 1.5
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "symbol"
     },
     {
-      "id": "All-Highway-Labels-standard",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 8,
       "filter": ["all", ["has", "hway_num"], ["!in", "hway_num", "6,94", "2,50", "1,3", "12,15", "14,15", "6,96", "25A", "20A", "20B", "29A", "30A", "74A", "67A"], ["!=", "lane_count", 1]],
+      "id": "All-Highway-Labels-standard",
       "layout": {
-        "icon-rotation-alignment": "viewport",
-        "icon-pitch-alignment": "viewport",
-        "visibility": "visible",
-        "text-field": "{hway_num}",
-        "text-size": {
-          "stops": [
-            [8, 9],
-            [11, 10],
-            [15, 14]
-          ]
-        },
-        "icon-text-fit": "none",
-        "icon-size": {
-          "stops": [
-            [8, 1.2],
-            [12, 1.5],
-            [15, 1.7]
-          ]
-        },
-        "symbol-placement": "line",
+        "icon-anchor": "center",
         "icon-image": "highway_pnt_standard",
-        "text-font": ["Open Sans Bold"],
-        "icon-padding": 2,
-        "symbol-spacing": {
-          "stops": [
-            [6, 500],
-            [13, 400]
-          ]
-        },
-        "text-pitch-alignment": "viewport",
-        "text-justify": "center",
-        "icon-text-fit-padding": [1, 4, 3, 3],
-        "icon-anchor": "center",
-        "text-rotation-alignment": "viewport",
-        "icon-offset": [0, 1],
-        "text-keep-upright": true,
         "icon-keep-upright": false,
-        "icon-rotate": 0
-      },
-      "paint": {
-        "text-translate-anchor": "map",
-        "icon-translate-anchor": "map",
-        "text-color": "rgba(255, 255, 255, 1)",
-        "icon-opacity": {
-          "stops": [
-            [6, 0.9],
-            [14, 1]
-          ]
-        }
-      }
-    },
-    {
-      "id": "All-Highway-Labels-three",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "transportation",
-      "minzoom": 8,
-      "filter": ["all", ["in", "hway_num", "25A", "20A", "20B", "29A", "30A", "74A", "67A"]],
-      "layout": {
-        "icon-rotation-alignment": "viewport",
+        "icon-offset": [0, 1],
+        "icon-padding": 2,
         "icon-pitch-alignment": "viewport",
-        "visibility": "visible",
-        "text-field": "{hway_num}",
-        "text-size": {
-          "stops": [
-            [8, 9],
-            [11, 10],
-            [15, 14]
-          ]
-        },
-        "icon-text-fit": "none",
+        "icon-rotate": 0,
+        "icon-rotation-alignment": "viewport",
         "icon-size": {
           "stops": [
             [8, 1.2],
@@ -1987,52 +1912,118 @@
             [15, 1.7]
           ]
         },
+        "icon-text-fit": "none",
+        "icon-text-fit-padding": [1, 4, 3, 3],
         "symbol-placement": "line",
-        "icon-image": "highway_pnt_wide",
-        "text-font": ["Open Sans Bold"],
-        "icon-padding": 2,
         "symbol-spacing": {
           "stops": [
             [6, 500],
             [13, 400]
           ]
         },
-        "text-pitch-alignment": "viewport",
+        "text-field": "{hway_num}",
+        "text-font": ["Open Sans Bold"],
         "text-justify": "center",
-        "icon-text-fit-padding": [1, 4, 3, 3],
-        "icon-anchor": "center",
-        "text-rotation-alignment": "viewport",
-        "icon-offset": [0, 1],
         "text-keep-upright": true,
-        "icon-keep-upright": false,
-        "icon-rotate": 0
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [8, 9],
+            [11, 10],
+            [15, 14]
+          ]
+        },
+        "visibility": "visible"
       },
+      "minzoom": 8,
       "paint": {
-        "text-translate-anchor": "map",
-        "icon-translate-anchor": "map",
-        "text-color": "rgba(255, 255, 255, 1)",
         "icon-opacity": {
           "stops": [
             [6, 0.9],
             [14, 1]
           ]
-        }
-      }
-    },
-    {
-      "id": "All-Road-Labels",
-      "type": "symbol",
+        },
+        "icon-translate-anchor": "map",
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-translate-anchor": "map"
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 13,
-      "filter": ["all", ["has", "name"]],
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["in", "hway_num", "25A", "20A", "20B", "29A", "30A", "74A", "67A"]],
+      "id": "All-Highway-Labels-three",
       "layout": {
-        "symbol-spacing": 250,
-        "text-transform": "none",
-        "icon-pitch-alignment": "auto",
-        "visibility": "visible",
+        "icon-anchor": "center",
+        "icon-image": "highway_pnt_wide",
+        "icon-keep-upright": false,
+        "icon-offset": [0, 1],
+        "icon-padding": 2,
+        "icon-pitch-alignment": "viewport",
+        "icon-rotate": 0,
+        "icon-rotation-alignment": "viewport",
+        "icon-size": {
+          "stops": [
+            [8, 1.2],
+            [12, 1.5],
+            [15, 1.7]
+          ]
+        },
+        "icon-text-fit": "none",
+        "icon-text-fit-padding": [1, 4, 3, 3],
+        "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [6, 500],
+            [13, 400]
+          ]
+        },
+        "text-field": "{hway_num}",
+        "text-font": ["Open Sans Bold"],
         "text-justify": "center",
+        "text-keep-upright": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [8, 9],
+            [11, 10],
+            [15, 14]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "icon-opacity": {
+          "stops": [
+            [6, 0.9],
+            [14, 1]
+          ]
+        },
+        "icon-translate-anchor": "map",
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-translate-anchor": "map"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "name"]],
+      "id": "All-Road-Labels",
+      "layout": {
+        "icon-ignore-placement": false,
+        "icon-pitch-alignment": "auto",
+        "icon-text-fit": "both",
+        "symbol-placement": "line",
+        "symbol-spacing": 250,
+        "text-anchor": "center",
         "text-field": "{name}",
+        "text-font": ["Open Sans Regular"],
+        "text-justify": "center",
         "text-size": {
           "stops": [
             [13, 8],
@@ -2042,30 +2033,28 @@
             [22, 60]
           ]
         },
-        "text-anchor": "center",
-        "icon-text-fit": "both",
-        "symbol-placement": "line",
-        "icon-ignore-placement": false,
-        "text-font": ["Open Sans Regular"]
+        "text-transform": "none",
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "text-halo-width": 2.5,
-        "text-opacity": 0.9,
+        "text-color": "rgba(51, 51, 51, 1)",
         "text-halo-color": "rgba(243, 243, 242, 0.9)",
-        "text-color": "rgba(51, 51, 51, 1)"
-      }
-    },
-    {
-      "id": "Transport-Tunnel-Label",
-      "type": "symbol",
+        "text-halo-width": 2.5,
+        "text-opacity": 0.9
+      },
       "source": "LINZ Basemaps",
       "source-layer": "transportation",
-      "minzoom": 15,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "brunnel", "tunnel"]],
+      "id": "Transport-Tunnel-Label",
       "layout": {
+        "symbol-placement": "line",
         "symbol-spacing": 180,
-        "visibility": "visible",
         "text-field": "{brunnel}",
+        "text-font": ["Roboto Black"],
         "text-offset": {
           "stops": [
             [15, [0, -1.25]],
@@ -2076,175 +2065,175 @@
           ]
         },
         "text-size": 10,
-        "symbol-placement": "line",
-        "text-font": ["Roboto Black"]
+        "visibility": "visible"
       },
+      "minzoom": 15,
       "paint": {
-        "text-halo-width": 2,
         "text-color": "rgba(80, 75, 75, 1)",
-        "text-halo-color": "rgba(230, 230, 230, 0.5)"
-      }
+        "text-halo-color": "rgba(230, 230, 230, 0.5)",
+        "text-halo-width": 2
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
     },
     {
       "id": "Airport-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "aerodrome_label",
-      "minzoom": 12,
       "layout": {
-        "icon-rotation-alignment": "viewport",
-        "icon-pitch-alignment": "viewport",
-        "visibility": "visible",
-        "text-field": "{name}",
-        "text-size": 10,
-        "text-anchor": "top",
-        "text-allow-overlap": false,
-        "icon-text-fit": "none",
-        "icon-size": 1.2,
+        "icon-anchor": "bottom",
         "icon-ignore-placement": false,
         "icon-image": "airport_airport_pnt_fill",
-        "text-font": ["Open Sans Bold Italic"],
+        "icon-offset": [0, 0],
+        "icon-pitch-alignment": "viewport",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1.2,
+        "icon-text-fit": "none",
         "symbol-spacing": 250,
-        "text-pitch-alignment": "auto",
+        "text-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Bold Italic"],
         "text-justify": "center",
         "text-max-width": 5,
-        "icon-anchor": "bottom",
+        "text-padding": 2,
+        "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
-        "icon-offset": [0, 0],
-        "text-padding": 2
-      },
-      "paint": {
-        "text-halo-blur": 0.5,
-        "text-color": "rgba(129, 123, 123, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 1,
-        "icon-opacity": 0.8
-      }
-    },
-    {
-      "id": "Aeroway-Airstrip-Label",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "aeroway",
-      "minzoom": 15,
-      "filter": ["all", ["==", "class", "runway"], ["!has", "surface"]],
-      "layout": {
-        "text-justify": "left",
-        "text-field": "airstrip",
-        "text-font": ["Roboto Light"],
         "text-size": 10,
-        "text-anchor": "left",
         "visibility": "visible"
       },
+      "minzoom": 12,
       "paint": {
-        "text-halo-width": 1.5,
+        "icon-opacity": 0.8,
+        "text-color": "rgba(129, 123, 123, 1)",
         "text-halo-blur": 0.5,
-        "text-halo-color": "rgba(246, 246, 246, 1)"
-      }
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "aerodrome_label",
+      "type": "symbol"
     },
     {
-      "id": "All-Reef-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "water",
-      "minzoom": 13,
-      "filter": ["all", ["==", "class", "reef"], ["has", "name"]],
+      "filter": ["all", ["==", "class", "runway"], ["!has", "surface"]],
+      "id": "Aeroway-Airstrip-Label",
       "layout": {
-        "visibility": "visible",
-        "text-max-width": 4,
+        "text-anchor": "left",
+        "text-field": "airstrip",
+        "text-font": ["Roboto Light"],
+        "text-justify": "left",
+        "text-size": 10,
+        "visibility": "visible"
+      },
+      "minzoom": 15,
+      "paint": {
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(246, 246, 246, 1)",
+        "text-halo-width": 1.5
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "reef"], ["has", "name"]],
+      "id": "All-Reef-Names",
+      "layout": {
+        "text-anchor": "center",
         "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-max-width": 4,
         "text-offset": [0, 1],
         "text-size": 12,
-        "text-anchor": "center",
-        "text-font": ["Open Sans Italic"]
+        "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "text-halo-width": 2,
         "text-color": "rgba(0, 140, 204, 1)",
-        "text-halo-color": "rgba(239, 239, 239, 1)"
-      }
-    },
-    {
-      "id": "All-Lake-Names",
-      "type": "symbol",
+        "text-halo-color": "rgba(239, 239, 239, 1)",
+        "text-halo-width": 2
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 11,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "lake"], ["has", "name"]],
+      "id": "All-Lake-Names",
       "layout": {
-        "visibility": "visible",
-        "text-max-width": 4,
         "text-field": "{name}",
         "text-font": ["Open Sans Italic"],
-        "text-size": 12
+        "text-max-width": 4,
+        "text-size": 12,
+        "visibility": "visible"
       },
+      "minzoom": 11,
       "paint": {
-        "text-halo-width": 2,
         "text-color": "rgba(0, 140, 204, 1)",
-        "text-halo-color": "rgba(239, 239, 239, 1)"
-      }
-    },
-    {
-      "id": "All-River-Names",
-      "type": "symbol",
+        "text-halo-color": "rgba(239, 239, 239, 1)",
+        "text-halo-width": 2
+      },
       "source": "LINZ Basemaps",
       "source-layer": "water",
-      "minzoom": 12,
+      "type": "symbol"
+    },
+    {
       "filter": ["all", ["==", "class", "river"], ["has", "name"]],
+      "id": "All-River-Names",
       "layout": {
         "icon-allow-overlap": false,
-        "visibility": "visible",
-        "text-field": "{name}",
-        "text-size": 12,
-        "text-anchor": "bottom",
-        "text-allow-overlap": true,
-        "symbol-placement": "line",
-        "icon-ignore-placement": false,
-        "text-font": ["Open Sans Italic"],
-        "symbol-spacing": 1000,
-        "text-justify": "center",
         "icon-anchor": "center",
-        "text-ignore-placement": true
+        "icon-ignore-placement": false,
+        "symbol-placement": "line",
+        "symbol-spacing": 1000,
+        "text-allow-overlap": true,
+        "text-anchor": "bottom",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Italic"],
+        "text-ignore-placement": true,
+        "text-justify": "center",
+        "text-size": 12,
+        "visibility": "visible"
       },
+      "minzoom": 12,
       "paint": {
-        "text-halo-blur": 1,
         "text-color": "rgba(0, 140, 204, 1)",
+        "text-halo-blur": 1,
         "text-halo-color": "rgba(239, 239, 239, 0.80)",
         "text-halo-width": 1.5
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "water",
+      "type": "symbol"
     },
     {
-      "id": "All-Waterway-River-Names",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "waterway",
-      "minzoom": 12,
       "filter": ["all", ["==", "class", "river"], ["has", "name"]],
+      "id": "All-Waterway-River-Names",
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 1000,
+        "text-allow-overlap": true,
+        "text-anchor": "bottom",
         "text-field": "{name}",
         "text-font": ["Open Sans Italic"],
-        "text-size": 12,
-        "text-anchor": "bottom",
         "text-ignore-placement": true,
-        "text-allow-overlap": true
+        "text-size": 12
       },
+      "minzoom": 12,
       "paint": {
         "text-color": "rgba(0, 140, 204, 1)",
+        "text-halo-blur": 1,
         "text-halo-color": "rgba(239, 239, 239, 0.80)",
-        "text-halo-width": 1.5,
-        "text-halo-blur": 1
-      }
+        "text-halo-width": 1.5
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "waterway",
+      "type": "symbol"
     },
     {
       "id": "Housenumber",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "housenumber",
-      "minzoom": 17,
       "layout": {
         "text-allow-overlap": false,
+        "text-anchor": "bottom",
         "text-field": "{housenumber}",
         "text-font": ["Open Sans Regular"],
         "text-size": {
@@ -2252,34 +2241,29 @@
             [17, 9],
             [19, 10]
           ]
-        },
-        "text-anchor": "bottom"
+        }
       },
+      "minzoom": 17,
       "paint": {
         "icon-color": "rgba(0, 0, 0, 0.6)",
-        "text-halo-blur": 20,
         "text-color": "rgba(85, 85, 85, 1)",
+        "text-halo-blur": 20,
         "text-halo-color": "rgba(255, 255, 255, 0.8)",
         "text-halo-width": 0.5
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "housenumber",
+      "type": "symbol"
     },
     {
       "id": "Place-Names-13",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
-      "minzoom": 13,
       "layout": {
+        "icon-rotation-alignment": "auto",
+        "icon-text-fit": "both",
+        "text-allow-overlap": true,
         "text-field": "{name}",
         "text-font": ["Roboto Regular"],
-        "text-max-width": 7,
-        "text-variable-anchor": ["top", "bottom-left"],
-        "text-offset": {
-          "stops": [
-            [4, [0, 1.75]],
-            [6, [0, 1.25]]
-          ]
-        },
+        "text-ignore-placement": false,
         "text-letter-spacing": {
           "stops": [
             [10, 0.08],
@@ -2287,6 +2271,16 @@
             [14, 0]
           ]
         },
+        "text-max-width": 7,
+        "text-offset": {
+          "stops": [
+            [4, [0, 1.75]],
+            [6, [0, 1.25]]
+          ]
+        },
+        "text-optional": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
         "text-size": {
           "stops": [
             [2, 10],
@@ -2297,35 +2291,15 @@
             [14, 16]
           ]
         },
-        "icon-text-fit": "both",
-        "icon-rotation-alignment": "auto",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "text-optional": true,
-        "text-ignore-placement": false,
-        "text-allow-overlap": true,
+        "text-variable-anchor": ["top", "bottom-left"],
         "visibility": "visible"
       },
+      "minzoom": 13,
       "paint": {
-        "text-halo-blur": 1,
-        "text-halo-width": {
+        "icon-color": {
           "stops": [
-            [4, 1.5],
-            [9, 2]
-          ]
-        },
-        "text-halo-color": "rgba(255, 252, 252, 1)",
-        "text-color": {
-          "stops": [
-            [6, "rgba(35, 34, 34, 1)"],
-            [19, "rgba(111, 111, 111, 1)"]
-          ]
-        },
-        "text-translate-anchor": "viewport",
-        "icon-halo-width": {
-          "stops": [
-            [13, 1],
-            [14, 2]
+            [6, "rgba(53, 53, 53, 1)"],
+            [10, "rgba(53, 53, 53, 1)"]
           ]
         },
         "icon-halo-blur": {
@@ -2334,26 +2308,58 @@
             [14, 0.5]
           ]
         },
-        "icon-opacity": 1,
         "icon-halo-color": "rgba(255, 255, 255, 1)",
-        "icon-color": {
+        "icon-halo-width": {
           "stops": [
-            [6, "rgba(53, 53, 53, 1)"],
-            [10, "rgba(53, 53, 53, 1)"]
+            [13, 1],
+            [14, 2]
           ]
-        }
-      }
+        },
+        "icon-opacity": 1,
+        "text-color": {
+          "stops": [
+            [6, "rgba(35, 34, 34, 1)"],
+            [19, "rgba(111, 111, 111, 1)"]
+          ]
+        },
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255, 252, 252, 1)",
+        "text-halo-width": {
+          "stops": [
+            [4, 1.5],
+            [9, 2]
+          ]
+        },
+        "text-translate-anchor": "viewport"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
     },
     {
       "id": "Place-Names-3-12",
-      "type": "symbol",
-      "source": "LINZ Basemaps",
-      "source-layer": "place",
-      "minzoom": 3,
-      "maxzoom": 13,
       "layout": {
-        "text-font": ["Roboto Regular"],
+        "icon-pitch-alignment": "auto",
         "text-field": "{name}",
+        "text-font": ["Roboto Regular"],
+        "text-ignore-placement": false,
+        "text-letter-spacing": {
+          "stops": [
+            [10, 0.08],
+            [13, 0.04],
+            [14, 0]
+          ]
+        },
+        "text-max-width": 6,
+        "text-offset": {
+          "stops": [
+            [4, [0, 1.75]],
+            [6, [0, 1.25]]
+          ]
+        },
+        "text-optional": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
         "text-size": {
           "stops": [
             [2, 10],
@@ -2364,28 +2370,11 @@
             [14, 17]
           ]
         },
-        "text-letter-spacing": {
-          "stops": [
-            [10, 0.08],
-            [13, 0.04],
-            [14, 0]
-          ]
-        },
-        "text-offset": {
-          "stops": [
-            [4, [0, 1.75]],
-            [6, [0, 1.25]]
-          ]
-        },
-        "text-max-width": 6,
         "text-variable-anchor": ["top", "bottom-left"],
-        "icon-pitch-alignment": "auto",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "text-ignore-placement": false,
-        "text-optional": true,
         "visibility": "visible"
       },
+      "maxzoom": 13,
+      "minzoom": 3,
       "paint": {
         "icon-color": {
           "stops": [
@@ -2393,36 +2382,47 @@
             [10, "rgba(53, 53, 53, 1)"]
           ]
         },
-        "icon-halo-color": "rgba(255, 255, 255, 1)",
-        "icon-opacity": 1,
         "icon-halo-blur": {
           "stops": [
             [13, 1],
             [14, 0.5]
           ]
         },
-        "icon-translate-anchor": "viewport",
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
         "icon-halo-width": {
           "stops": [
             [13, 1],
             [14, 2]
           ]
         },
-        "text-halo-blur": 1,
-        "text-halo-width": {
-          "stops": [
-            [4, 1.5],
-            [9, 2]
-          ]
-        },
-        "text-halo-color": "rgba(255, 252, 252, 1)",
+        "icon-opacity": 1,
+        "icon-translate-anchor": "viewport",
         "text-color": {
           "stops": [
             [6, "rgba(35, 34, 34, 1)"],
             [19, "rgba(111, 111, 111, 1)"]
           ]
+        },
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255, 252, 252, 1)",
+        "text-halo-width": {
+          "stops": [
+            [4, 1.5],
+            [9, 2]
+          ]
         }
-      }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
     }
-  ]
+  ],
+  "metadata": { "maputnik:renderer": "mbgljs" },
+  "name": "topolite",
+  "sources": {
+    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json" },
+    "LINZ-Texture-Relief": { "maxzoom": 20, "minzoom": 0, "tileSize": 256, "tiles": ["/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp"], "type": "raster" }
+  },
+  "sprite": "/v1/sprites/topographic",
+  "version": 8
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@linzjs/style": "^3.15.0"
+        "@linzjs/style": "^3.15.0",
+        "eslint-plugin-prettier": "^5.0.1",
+        "prettier-plugin-sort-json": "^3.1.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -111,6 +113,42 @@
         "linz-style-install": "linz-style-install"
       }
     },
+    "node_modules/@linzjs/style/node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@linzjs/style/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -142,6 +180,32 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -407,6 +471,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
@@ -425,6 +510,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/callsites": {
@@ -504,6 +604,52 @@
       "version": "0.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -605,20 +751,29 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
+      "integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
       },
       "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
@@ -740,6 +895,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -751,9 +929,10 @@
       "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -853,6 +1032,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "dev": true,
@@ -934,6 +1125,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "dev": true,
@@ -979,6 +1179,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -998,6 +1213,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "dev": true,
@@ -1012,6 +1245,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -1082,6 +1354,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "dev": true,
@@ -1100,6 +1378,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -1128,12 +1418,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -1223,6 +1573,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "dev": true,
@@ -1243,14 +1599,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -1265,6 +1623,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-sort-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-json/-/prettier-plugin-sort-json-3.1.0.tgz",
+      "integrity": "sha512-eIDEUjwzekiVd+oKrpd0aoACBTp5zOW71wDTNy+qQ5C9Q8oqt9n9wCm4F+SeRZbXfgblh/WYIguJynImlBXrvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/punycode": {
@@ -1325,6 +1695,110 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/run-applescript/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/run-applescript/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/run-applescript/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/run-applescript/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -1380,6 +1854,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "dev": true,
@@ -1397,6 +1877,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -1421,10 +1913,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/synckit/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1488,6 +2014,15 @@
       },
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint config/**/*.json --quiet --fix --report-unused-disable-directives"
   },
   "devDependencies": {
-    "@linzjs/style": "^3.15.0"
+    "@linzjs/style": "^3.15.0",
+    "eslint-plugin-prettier": "^5.0.1",
+    "prettier-plugin-sort-json": "^3.1.0"
   }
 }


### PR DESCRIPTION
#### Motivation
Style config might have different order in layers when export from maputinik, this makes use hard to review the changes.

#### Modification

We using prettier json sort plughin to sort all the keys in the style config json files. 

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
