### PR TITLE
feat(aerial): remove old canterbury datasets from aerial config

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -533,22 +533,6 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/selwyn_urban_2018-2019_0-075m_RGB/01F6P1Q9FCCZ9EH7HE7X2SK2Q1",
-      "3857": "s3://linz-basemaps/3857/selwyn_urban_2018-2019_0-075m_RGB/01ESPVY6HBS1SH79ZH24RW7ZSQ",
-      "name": "selwyn-urban-2018-2019-0.075m",
-      "minZoom": 14,
-      "title": "Selwyn 0.075m Urban Aerial Photos (2018-2019)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/selwyn_urban_2019_0-075m_RGB/01FMJQBZ1H9F9KBFK8VH5THM2K",
-      "3857": "s3://linz-basemaps/3857/selwyn_urban_2019_0-075m_RGB/01FMJQANZJNCWB6SZAYG7P11ZT",
-      "name": "selwyn-urban-2019-0.075m",
-      "minZoom": 14,
-      "title": "Selwyn 0.075m Urban Aerial Photos (2019)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/selwyn_2022-2023_0.075m/01HFART1HWA37AQDR2X88AS7AZ",
       "3857": "s3://linz-basemaps/3857/selwyn_2022-2023_0.075m/01HFART8HS45C7T38K6G5K3XF1",
       "name": "selwyn-2022-2023-0.075m",
@@ -653,35 +637,11 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/mackenzie_urban_2020_0-075m_RGB/01FPV7GGNZ008JBH25F35KXC71",
-      "3857": "s3://linz-basemaps/3857/mackenzie_urban_2020_0-075m_RGB/01FPV7C0KD6R4FD8TTE3S43ETF",
-      "name": "mackenzie-urban-2020-0.075m",
-      "minZoom": 14,
-      "title": "MacKenzie 0.075m Urban Aerial Photos (2020)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/timaru_urban_2020_0-075m_RGB/01FPV7FD7SX1JKW7TK25ESMYN1",
-      "3857": "s3://linz-basemaps/3857/timaru_urban_2020_0-075m_RGB/01FPV7DVA9TW7XQCR64SSB12DA",
-      "name": "timaru-urban-2020-0.075m",
-      "minZoom": 14,
-      "title": "Timaru 0.075m Urban Aerial Photos (2020)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/waimakariri_2023_0.1m/01H4Q66MSD5ATAS9QX25FZ385V",
       "3857": "s3://linz-basemaps/3857/waimakariri_2023_0.1m/01H4Q681F7MWQY303BM8TKAT6K",
       "name": "waimakariri-2023-0.1m",
       "minZoom": 14,
       "title": "Waimakariri 0.1m Urban Aerial Photos (2023)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2020-2021_0-075m_RGB/01FPXB0T4ZCASWGX1X1GVEHDQZ",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2020-2021_0-075m_RGB/01FPXB36CCAK3FC6FWCMK1D156",
-      "name": "christchurch-urban-2020-2021-0.075m",
-      "minZoom": 13,
-      "title": "Christchurch 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos"
     },
     {

--- a/config/tileset/individual/christchurch-urban-2020-2021-0.075m.json
+++ b/config/tileset/individual/christchurch-urban-2020-2021-0.075m.json
@@ -1,0 +1,18 @@
+{
+  "type": "raster",
+  "id": "ts_christchurch-urban-2020-2021-0.075m",
+  "title": "Christchurch 0.075m Urban Aerial Photos (2020-2021)",
+  "background": "#00000000",
+  "category": "Urban Aerial Photos",
+  "layers": [
+    {
+      "2193": "s3://linz-basemaps/2193/christchurch_urban_2020-2021_0-075m_RGB/01FPXB0T4ZCASWGX1X1GVEHDQZ",
+      "3857": "s3://linz-basemaps/3857/christchurch_urban_2020-2021_0-075m_RGB/01FPXB36CCAK3FC6FWCMK1D156",
+      "name": "christchurch-urban-2020-2021-0.075m",
+      "title": "Christchurch 0.075m Urban Aerial Photos (2020-2021)",
+      "category": "Urban Aerial Photos",
+      "minZoom": 0,
+      "maxZoom": 32
+    }
+  ]
+}

--- a/config/tileset/individual/mackenzie-urban-2020-0.075m.json
+++ b/config/tileset/individual/mackenzie-urban-2020-0.075m.json
@@ -1,0 +1,18 @@
+{
+  "type": "raster",
+  "id": "ts_mackenzie-urban-2020-0.075m",
+  "title": "MacKenzie 0.075m Urban Aerial Photos (2020)",
+  "background": "#00000000",
+  "category": "Urban Aerial Photos",
+  "layers": [
+    {
+      "2193": "s3://linz-basemaps/2193/mackenzie_urban_2020_0-075m_RGB/01FPV7GGNZ008JBH25F35KXC71",
+      "3857": "s3://linz-basemaps/3857/mackenzie_urban_2020_0-075m_RGB/01FPV7C0KD6R4FD8TTE3S43ETF",
+      "name": "mackenzie-urban-2020-0.075m",
+      "title": "MacKenzie 0.075m Urban Aerial Photos (2020)",
+      "category": "Urban Aerial Photos",
+      "minZoom": 0,
+      "maxZoom": 32
+    }
+  ]
+}

--- a/config/tileset/individual/selwyn-urban-2018-2019-0.075m.json
+++ b/config/tileset/individual/selwyn-urban-2018-2019-0.075m.json
@@ -1,0 +1,18 @@
+{
+  "type": "raster",
+  "id": "ts_selwyn-urban-2018-2019-0.075m",
+  "title": "Selwyn 0.075m Urban Aerial Photos (2018-2019)",
+  "background": "#00000000",
+  "category": "Urban Aerial Photos",
+  "layers": [
+    {
+      "2193": "s3://linz-basemaps/2193/selwyn_urban_2018-2019_0-075m_RGB/01F6P1Q9FCCZ9EH7HE7X2SK2Q1",
+      "3857": "s3://linz-basemaps/3857/selwyn_urban_2018-2019_0-075m_RGB/01ESPVY6HBS1SH79ZH24RW7ZSQ",
+      "name": "selwyn-urban-2018-2019-0.075m",
+      "title": "Selwyn 0.075m Urban Aerial Photos (2018-2019)",
+      "category": "Urban Aerial Photos",
+      "minZoom": 0,
+      "maxZoom": 32
+    }
+  ]
+}

--- a/config/tileset/individual/selwyn-urban-2019-0.075m.json
+++ b/config/tileset/individual/selwyn-urban-2019-0.075m.json
@@ -1,0 +1,18 @@
+{
+  "type": "raster",
+  "id": "ts_selwyn-urban-2019-0.075m",
+  "title": "Selwyn 0.075m Urban Aerial Photos (2019)",
+  "background": "#00000000",
+  "category": "Urban Aerial Photos",
+  "layers": [
+    {
+      "2193": "s3://linz-basemaps/2193/selwyn_urban_2019_0-075m_RGB/01FMJQBZ1H9F9KBFK8VH5THM2K",
+      "3857": "s3://linz-basemaps/3857/selwyn_urban_2019_0-075m_RGB/01FMJQANZJNCWB6SZAYG7P11ZT",
+      "name": "selwyn-urban-2019-0.075m",
+      "title": "Selwyn 0.075m Urban Aerial Photos (2019)",
+      "category": "Urban Aerial Photos",
+      "minZoom": 0,
+      "maxZoom": 32
+    }
+  ]
+}

--- a/config/tileset/individual/timaru-urban-2020-0.075m.json
+++ b/config/tileset/individual/timaru-urban-2020-0.075m.json
@@ -1,0 +1,18 @@
+{
+  "type": "raster",
+  "id": "ts_timaru-urban-2020-0.075m",
+  "title": "Timaru 0.075m Urban Aerial Photos (2020)",
+  "background": "#00000000",
+  "category": "Urban Aerial Photos",
+  "layers": [
+    {
+      "2193": "s3://linz-basemaps/2193/timaru_urban_2020_0-075m_RGB/01FPV7FD7SX1JKW7TK25ESMYN1",
+      "3857": "s3://linz-basemaps/3857/timaru_urban_2020_0-075m_RGB/01FPV7DVA9TW7XQCR64SSB12DA",
+      "name": "timaru-urban-2020-0.075m",
+      "title": "Timaru 0.075m Urban Aerial Photos (2020)",
+      "category": "Urban Aerial Photos",
+      "minZoom": 0,
+      "maxZoom": 32
+    }
+  ]
+}


### PR DESCRIPTION
#### Motivation

2018-2020 Canterbury urbans are larger in footprint than 2022-2023 urbans but only slightly, and the additional area makes the Aerial Imagery basemap look untidy and confusing.

#### Modification

Remove 5 older Canterbury urban aerial imagery datasets, placing them in as individual tilesets.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
