### PR TITLE
fix: lock basemaps cli to last known good version

### DIFF
--- a/scripts/bmc.sh
+++ b/scripts/bmc.sh
@@ -5,5 +5,5 @@ docker run \
   -v ${PWD}:${PWD} \
   -p 5000:5000 \
   -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_REGION -e AWS_DEFAULT_REGION \
-  ghcr.io/linz/basemaps/cli:latest \
+  ghcr.io/linz/basemaps/cli:v7.0.0-10-g82970b53 \
   "$@"


### PR DESCRIPTION
#### Motivation

Basemaps' master branch can be a little broken, use a locked version to prevent using a broken build

#### Modification

locks the basemaps cli to the last known good version until a new release is made.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
