### PR TITLE
fix: move Waikato urbans above new Waikato rural

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -445,14 +445,6 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/thames-coromandel_2021_0.1m/01HAK2FBK5CBCCM2S6XHCWK9VP",
-      "3857": "s3://linz-basemaps/3857/thames-coromandel_2021_0.1m/01HAK2FBGQ7MH75YWFSDT41QR3/",
-      "name": "thames-coromandel-2021-0.1m",
-      "minZoom": 14,
-      "title": "Thames-Coromandel 0.1m Urban Aerial Photos (2021)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/auckland_urban_2017_0-075m/01F66DXCRR1CFTFQTE5R3525EJ",
       "3857": "s3://linz-basemaps/3857/auckland_urban_2017_0-075m/01ED81HZRR86YBB8A0ZQRABP96",
       "name": "auckland-urban-2017-0.075m",
@@ -826,6 +818,14 @@
       "name": "waikato-urban-2021-0.1m",
       "minZoom": 14,
       "title": "Waikato District 0.1m Urban Aerial Photos (2021)",
+      "category": "Urban Aerial Photos"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/thames-coromandel_2021_0.1m/01HAK2FBK5CBCCM2S6XHCWK9VP",
+      "3857": "s3://linz-basemaps/3857/thames-coromandel_2021_0.1m/01HAK2FBGQ7MH75YWFSDT41QR3/",
+      "name": "thames-coromandel-2021-0.1m",
+      "minZoom": 14,
+      "title": "Thames-Coromandel 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {

--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -653,43 +653,11 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/ōtorohanga_urban_2021_0-1m_RGB/01FYWKAJ86W9P7RWM1VB62KD0H",
-      "3857": "s3://linz-basemaps/3857/ōtorohanga_urban_2021_0-1m_RGB/01FYWKATAEK2ZTJQ2PX44Y0XNT",
-      "name": "ōtorohanga-urban-2021-0.1m",
-      "minZoom": 14,
-      "title": "Ōtorohanga 0.1m Urban Aerial Photos (2021)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/waipa_urban_2021_0-1m_RGB/01G28WB9GKP01A8DPYWG9CBMN1",
-      "3857": "s3://linz-basemaps/3857/waipa_urban_2021_0-1m_RGB/01G28WC5349Y0J3CGWGTZ796DD",
-      "name": "waipa-urban-2021-0.1m",
-      "minZoom": 14,
-      "title": "Waipa 0.1m Urban Aerial Photos (2021)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/waikato_urban_2021_0-1m_RGB/01G75YF8RQTNWDSTJ9618EGGSH",
-      "3857": "s3://linz-basemaps/3857/waikato_urban_2021_0-1m_RGB/01G75YFYNRYPFF9H8P4CR4HDAJ",
-      "name": "waikato-urban-2021-0.1m",
-      "minZoom": 14,
-      "title": "Waikato District 0.1m Urban Aerial Photos (2021)",
-      "category": "Urban Aerial Photos"
-    },
-    {
       "2193": "s3://linz-basemaps/2193/nelson_urban_2022_0-075m_RGB/01G87CWVWSG7KWE3DHC6R18BCX",
       "3857": "s3://linz-basemaps/3857/nelson_urban_2022_0-075m_RGB/01G87CXGF81D5CVT22B038BCM1",
       "name": "nelson-urban-2022-0.075m",
       "minZoom": 14,
       "title": "Nelson 0.075m Urban Aerial Photos (2022)",
-      "category": "Urban Aerial Photos"
-    },
-    {
-      "2193": "s3://linz-basemaps/2193/hamilton_2023_0.05m/01H6YT6HDGMQ0DA04Q4YKTN6KS",
-      "3857": "s3://linz-basemaps/3857/hamilton_2023_0.05m/01H6YT8M3R6BN6V2869HA33NQ1",
-      "name": "hamilton-2023-0.05m",
-      "minZoom": 14,
-      "title": "Hamilton 0.05m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
     {
@@ -835,6 +803,38 @@
       "minZoom": 13,
       "title": "Auckland 0.075m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/ōtorohanga_urban_2021_0-1m_RGB/01FYWKAJ86W9P7RWM1VB62KD0H",
+      "3857": "s3://linz-basemaps/3857/ōtorohanga_urban_2021_0-1m_RGB/01FYWKATAEK2ZTJQ2PX44Y0XNT",
+      "name": "ōtorohanga-urban-2021-0.1m",
+      "minZoom": 14,
+      "title": "Ōtorohanga 0.1m Urban Aerial Photos (2021)",
+      "category": "Urban Aerial Photos"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/waipa_urban_2021_0-1m_RGB/01G28WB9GKP01A8DPYWG9CBMN1",
+      "3857": "s3://linz-basemaps/3857/waipa_urban_2021_0-1m_RGB/01G28WC5349Y0J3CGWGTZ796DD",
+      "name": "waipa-urban-2021-0.1m",
+      "minZoom": 14,
+      "title": "Waipa 0.1m Urban Aerial Photos (2021)",
+      "category": "Urban Aerial Photos"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/waikato_urban_2021_0-1m_RGB/01G75YF8RQTNWDSTJ9618EGGSH",
+      "3857": "s3://linz-basemaps/3857/waikato_urban_2021_0-1m_RGB/01G75YFYNRYPFF9H8P4CR4HDAJ",
+      "name": "waikato-urban-2021-0.1m",
+      "minZoom": 14,
+      "title": "Waikato District 0.1m Urban Aerial Photos (2021)",
+      "category": "Urban Aerial Photos"
+    },
+    {
+      "2193": "s3://linz-basemaps/2193/hamilton_2023_0.05m/01H6YT6HDGMQ0DA04Q4YKTN6KS",
+      "3857": "s3://linz-basemaps/3857/hamilton_2023_0.05m/01H6YT8M3R6BN6V2869HA33NQ1",
+      "name": "hamilton-2023-0.05m",
+      "minZoom": 14,
+      "title": "Hamilton 0.05m Urban Aerial Photos (2023)",
+      "category": "Urban Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/whanganui_2022_0.075m/01GZMXEKG8QRB3W2TS4EXEGVR7",


### PR DESCRIPTION
In attempting to place the new Waikato Rural aerial imagery appropriately between Auckland Rural imagery, Waikato Urbans were accidentally ordered below the new rural imagery. This PR attempts to fix this and place Waikato Urbans back on top.