### PR TITLE
build: Upgrade the basemaps cli to version v7.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,16 +59,9 @@ jobs:
           mask-aws-account-id: true
           role-to-assume: ${{ secrets.AWS_ROLE_SCREENSHOT }}
 
-      - name: Cache Configs
-        id: cache-configs
-        uses: actions/cache@v4
-        with:
-          path: cache-config
-          key: ${{ runner.os }}-configs
-
       - name: Bundle Config File
         run: |
-          ./scripts/bmc.sh bundle --config $PWD/config --output $PWD/config-staging.json --assets ${ASSETS_LOCATION_STAGING} --cache cache-config
+          ./scripts/bmc.sh bundle --config $PWD/config --output $PWD/config-staging.json --assets ${ASSETS_LOCATION_STAGING} --cache s3://linz-basemaps-staging/basemaps-config/cache/
           CONFIG_HASH_STAGING=$(cat config-staging.json | jq .hash -r)
           echo "CONFIG_LOCATION_STAGING=s3://linz-basemaps-staging/config/config-${CONFIG_HASH_STAGING}.json.gz" >> $GITHUB_ENV
 
@@ -176,7 +169,7 @@ jobs:
 
           # aws s3 cp assets-current.tar.co ${ASSETS_LOCATION_PROD}
 
-          ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache cache-config
+          ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache s3://linz-basemaps-staging/basemaps-config/cache/
 
           CONFIG_HASH_PROD=$(cat config-prod.json | jq .hash -r)
           echo "CONFIG_LOCATION_PROD=s3://linz-basemaps/config/config-${CONFIG_HASH_PROD}.json.gz" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,16 @@ jobs:
           mask-aws-account-id: true
           role-to-assume: ${{ secrets.AWS_ROLE_SCREENSHOT }}
 
+      - name: Cache Configs
+        id: cache-configs
+        uses: actions/cache@v4
+        with:
+          path: cache/config
+          key: ${{ runner.os }}-configs
+
       - name: Bundle Config File
         run: |
-          ./scripts/bmc.sh bundle --config $PWD/config --output $PWD/config-staging.json --assets ${ASSETS_LOCATION_STAGING} --cache s3://linz-basemaps-scratch/basemaps-config/cache/
+          ./scripts/bmc.sh bundle --config $PWD/config --output $PWD/config-staging.json --assets ${ASSETS_LOCATION_STAGING} --cache cache/config
           CONFIG_HASH_STAGING=$(cat config-staging.json | jq .hash -r)
           echo "CONFIG_LOCATION_STAGING=s3://linz-basemaps-staging/config/config-${CONFIG_HASH_STAGING}.json.gz" >> $GITHUB_ENV
 
@@ -169,7 +176,7 @@ jobs:
 
           # aws s3 cp assets-current.tar.co ${ASSETS_LOCATION_PROD}
 
-          ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache s3://linz-basemaps-scratch/basemaps-config/cache/
+          ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache cache/config
 
           CONFIG_HASH_PROD=$(cat config-prod.json | jq .hash -r)
           echo "CONFIG_LOCATION_PROD=s3://linz-basemaps/config/config-${CONFIG_HASH_PROD}.json.gz" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Bundle Config File
         run: |
-          ./scripts/bmc.sh bundle --config $PWD/config --output $PWD/config-staging.json --assets ${ASSETS_LOCATION_STAGING}
+          ./scripts/bmc.sh bundle --config $PWD/config --output $PWD/config-staging.json --assets ${ASSETS_LOCATION_STAGING} --cache s3://linz-basemaps-scratch/basemaps-config/cache/
           CONFIG_HASH_STAGING=$(cat config-staging.json | jq .hash -r)
           echo "CONFIG_LOCATION_STAGING=s3://linz-basemaps-staging/config/config-${CONFIG_HASH_STAGING}.json.gz" >> $GITHUB_ENV
 
@@ -169,7 +169,7 @@ jobs:
 
           # aws s3 cp assets-current.tar.co ${ASSETS_LOCATION_PROD}
 
-          ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD}
+          ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache s3://linz-basemaps-scratch/basemaps-config/cache/
 
           CONFIG_HASH_PROD=$(cat config-prod.json | jq .hash -r)
           echo "CONFIG_LOCATION_PROD=s3://linz-basemaps/config/config-${CONFIG_HASH_PROD}.json.gz" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,12 +63,12 @@ jobs:
         id: cache-configs
         uses: actions/cache@v4
         with:
-          path: cache/config
+          path: cache-config
           key: ${{ runner.os }}-configs
 
       - name: Bundle Config File
         run: |
-          ./scripts/bmc.sh bundle --config $PWD/config --output $PWD/config-staging.json --assets ${ASSETS_LOCATION_STAGING} --cache cache/config
+          ./scripts/bmc.sh bundle --config $PWD/config --output $PWD/config-staging.json --assets ${ASSETS_LOCATION_STAGING} --cache cache-config
           CONFIG_HASH_STAGING=$(cat config-staging.json | jq .hash -r)
           echo "CONFIG_LOCATION_STAGING=s3://linz-basemaps-staging/config/config-${CONFIG_HASH_STAGING}.json.gz" >> $GITHUB_ENV
 
@@ -176,7 +176,7 @@ jobs:
 
           # aws s3 cp assets-current.tar.co ${ASSETS_LOCATION_PROD}
 
-          ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache cache/config
+          ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache cache-config
 
           CONFIG_HASH_PROD=$(cat config-prod.json | jq .hash -r)
           echo "CONFIG_LOCATION_PROD=s3://linz-basemaps/config/config-${CONFIG_HASH_PROD}.json.gz" >> $GITHUB_ENV

--- a/scripts/bmc.sh
+++ b/scripts/bmc.sh
@@ -5,5 +5,5 @@ docker run \
   -v ${PWD}:${PWD} \
   -p 5000:5000 \
   -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_REGION -e AWS_DEFAULT_REGION \
-  ghcr.io/linz/basemaps/cli:v7.1.1-3-g5d6b8671 \
+  ghcr.io/linz/basemaps/cli:v7.2.0 \
   "$@"

--- a/scripts/bmc.sh
+++ b/scripts/bmc.sh
@@ -5,5 +5,5 @@ docker run \
   -v ${PWD}:${PWD} \
   -p 5000:5000 \
   -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_REGION -e AWS_DEFAULT_REGION \
-  ghcr.io/linz/basemaps/cli:v7.0.0-10-g82970b53 \
+  ghcr.io/linz/basemaps/cli:v7.1.1-3-g5d6b8671 \
   "$@"


### PR DESCRIPTION
#### Motivation

Upgrade the cli version for the ci cd.

#### Modification

The new config cli will be able to bundle the elevation config and individual vector tilesets. And it also add the cache to the `linz-basemaps-scrach` bucket for bundling performance.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
