### PR TITLE
feat(raster): Add trailing slashes for all the imagery urls

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -6,16 +6,16 @@
   "background": "dce9edff",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gebco_2020_Nztm2000Quad_305-75m/01F1BFJN8R8P7BXN3XTHC5MT5G",
-      "3857": "s3://linz-basemaps/3857/gebco_2020_305-75m/01EDMTM3P563P06TWYQAZRA9F6",
+      "2193": "s3://linz-basemaps/2193/gebco_2020_Nztm2000Quad_305-75m/01F1BFJN8R8P7BXN3XTHC5MT5G/",
+      "3857": "s3://linz-basemaps/3857/gebco_2020_305-75m/01EDMTM3P563P06TWYQAZRA9F6/",
       "name": "gebco-2020-305.75m",
       "maxZoom": 15,
       "title": "GEBCO Gridded Bathymetry (2020)",
       "category": "Bathymetry"
     },
     {
-      "2193": "s3://linz-basemaps/2193/chatham-islands_digital-globe_2014-2019_0-5m/01F66EEHWXVMK4B7E13AVZ8NE7",
-      "3857": "s3://linz-basemaps/3857/chatham-islands_digital-globe_2014-2019_0-5m/01ED84CATGQ1THNG7QEEEZBEBT",
+      "2193": "s3://linz-basemaps/2193/chatham-islands_digital-globe_2014-2019_0-5m/01F66EEHWXVMK4B7E13AVZ8NE7/",
+      "3857": "s3://linz-basemaps/3857/chatham-islands_digital-globe_2014-2019_0-5m/01ED84CATGQ1THNG7QEEEZBEBT/",
       "name": "chatham-islands-digital-globe-2014-2019-0.5m",
       "title": "Chatham Islands 0.5m Satellite Imagery (2014-2019)",
       "category": "Satellite Imagery"
@@ -28,480 +28,480 @@
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8BB9EBP892F3JQSSSHQG",
-      "3857": "s3://linz-basemaps/3857/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8NX9DE6ZA3Y5VK1QAHNK",
+      "2193": "s3://linz-basemaps/2193/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8BB9EBP892F3JQSSSHQG/",
+      "3857": "s3://linz-basemaps/3857/auckland-islands_satellite_2014-2021_0-5m_RGB/01FZYE8NX9DE6ZA3Y5VK1QAHNK/",
       "name": "auckland-islands-satellite-2014-2021-0.5m",
       "minZoom": 2,
       "title": "Auckland Islands 0.5m Satellite Imagery (2014-2021)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5MYGMYCH5WPDCP1DMYHZ8",
-      "3857": "s3://linz-basemaps/3857/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5N4E6Q4P2TV3MP94BKTMB",
+      "2193": "s3://linz-basemaps/2193/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5MYGMYCH5WPDCP1DMYHZ8/",
+      "3857": "s3://linz-basemaps/3857/antipodes-islands_satellite_2019-2020_0-5m_RGB/01FZY5N4E6Q4P2TV3MP94BKTMB/",
       "name": "antipodes-islands-satellite-2019-2020-0.5m",
       "minZoom": 5,
       "title": "Antipodes Islands 0.5m Satellite Imagery (2019-2020)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bounty-islands_satellite_2020_0-5m_RGB/01FZYK75PS5DM0BKGZ885RZ94D",
-      "3857": "s3://linz-basemaps/3857/bounty-islands_satellite_2020_0-5m_RGB/01FZYK7C7Y9GHSPRKM4B4C5RSY",
+      "2193": "s3://linz-basemaps/2193/bounty-islands_satellite_2020_0-5m_RGB/01FZYK75PS5DM0BKGZ885RZ94D/",
+      "3857": "s3://linz-basemaps/3857/bounty-islands_satellite_2020_0-5m_RGB/01FZYK7C7Y9GHSPRKM4B4C5RSY/",
       "name": "bounty-islands-satellite-2020-0.5m",
       "minZoom": 5,
       "title": "Bounty Islands 0.5m Satellite Imagery (2020)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E8Y3HSN66NDDKP89H2VTT",
-      "3857": "s3://linz-basemaps/3857/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E9728953QMD6NY7BVDGSN",
+      "2193": "s3://linz-basemaps/2193/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E8Y3HSN66NDDKP89H2VTT/",
+      "3857": "s3://linz-basemaps/3857/campbell-island-motu-ihupuku_satellite_2015-2020_0-5m_RGB/01G00E9728953QMD6NY7BVDGSN/",
       "name": "campbell-island-motu-ihupuku-satellite-2015-2020-0.5m",
       "minZoom": 2,
       "title": "Campbell Island/Motu Ihupuku 0.5m Satellite Imagery (2015-2020)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/kermadec-islands_satellite_2020-2021_0-5m_RGB/01G00S1WQ72T0PCN9T7QNE81V0",
-      "3857": "s3://linz-basemaps/3857/kermadec-islands_satellite_2020-2021_0-5m_RGB/01G00S25RMGY8FEHWFRYNPFDFJ",
+      "2193": "s3://linz-basemaps/2193/kermadec-islands_satellite_2020-2021_0-5m_RGB/01G00S1WQ72T0PCN9T7QNE81V0/",
+      "3857": "s3://linz-basemaps/3857/kermadec-islands_satellite_2020-2021_0-5m_RGB/01G00S25RMGY8FEHWFRYNPFDFJ/",
       "name": "kermadec-islands-satellite-2020-2021-0.5m",
       "minZoom": 5,
       "title": "Kermadec Islands 0.5m Satellite Imagery (2020-2021)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XY0TVJJ4QVJ7988TCKGWS",
-      "3857": "s3://linz-basemaps/3857/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XYQ8YKAZC7P5QJ4BPCX22",
+      "2193": "s3://linz-basemaps/2193/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XY0TVJJ4QVJ7988TCKGWS/",
+      "3857": "s3://linz-basemaps/3857/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XYQ8YKAZC7P5QJ4BPCX22/",
       "name": "nz-nearshore-islands-satellite-2010-2021-0.5m",
       "minZoom": 13,
       "title": "New Zealand Nearshore Islands 0.5m Satellite Imagery (2010-2021)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01G011MVHNRWAMSQSPBKXVAEC3",
-      "3857": "s3://linz-basemaps/3857/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01G011N3MVQVYP0Q1025R45219",
+      "2193": "s3://linz-basemaps/2193/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01G011MVHNRWAMSQSPBKXVAEC3/",
+      "3857": "s3://linz-basemaps/3857/snares-islands-tini-heke_satellite_2019-2020_0-5m_RGB/01G011N3MVQVYP0Q1025R45219/",
       "name": "snares-islands-tini-heke-satellite-2019-2020-0.5m",
       "minZoom": 5,
       "title": "Snares Islands/Tini Heke 0.5m Satellite Imagery (2019-2020)",
       "category": "Satellite Imagery"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2004-2005_1m_RGB/01F6P1TQVSC7QRF1R3JAT893ZS",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2004-2005_1m_RGB/01EE962ZB3Z6Y7GVZ28XCWJ9JB",
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2004-2005_1m_RGB/01F6P1TQVSC7QRF1R3JAT893ZS/",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2004-2005_1m_RGB/01EE962ZB3Z6Y7GVZ28XCWJ9JB/",
       "name": "tasman-rural-2004-2005-1m",
       "minZoom": 13,
       "title": "Tasman 1m Rural Aerial Photos (2004-2005)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_rural_2005-2011_0-75m_RGBA/01F6P1S7DSP4N5DCBGCTZCMJ27",
-      "3857": "s3://linz-basemaps/3857/southland_rural_2005-2011_0-75m_RGBA/01ED835ZSP0MQ3W55QEMVZKNR1",
+      "2193": "s3://linz-basemaps/2193/southland_rural_2005-2011_0-75m_RGBA/01F6P1S7DSP4N5DCBGCTZCMJ27/",
+      "3857": "s3://linz-basemaps/3857/southland_rural_2005-2011_0-75m_RGBA/01ED835ZSP0MQ3W55QEMVZKNR1/",
       "name": "southland-rural-2005-2011-0.75m",
       "minZoom": 13,
       "title": "Southland 0.75m Rural Aerial Photos (2005-2011)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_rural_2010-2012_0-50m_RGBA/01F66DT3ZBYZZM6R0AF9Q2989R",
-      "3857": "s3://linz-basemaps/3857/auckland_rural_2010-2012_0-50m_RGBA/01ED81BNAX2ESPMV59YPC3AQ2C",
+      "2193": "s3://linz-basemaps/2193/auckland_rural_2010-2012_0-50m_RGBA/01F66DT3ZBYZZM6R0AF9Q2989R/",
+      "3857": "s3://linz-basemaps/3857/auckland_rural_2010-2012_0-50m_RGBA/01ED81BNAX2ESPMV59YPC3AQ2C/",
       "name": "auckland-rural-2010-2012-0.5m",
       "minZoom": 13,
       "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_rural_2012-2013_0-40m_RGBA/01F66E9294YKPYAJP7SXTVY2EM",
-      "3857": "s3://linz-basemaps/3857/canterbury_rural_2012-2013_0-40m_RGBA/01ED81XK539QM497AYHM1X70JQ",
+      "2193": "s3://linz-basemaps/2193/canterbury_rural_2012-2013_0-40m_RGBA/01F66E9294YKPYAJP7SXTVY2EM/",
+      "3857": "s3://linz-basemaps/3857/canterbury_rural_2012-2013_0-40m_RGBA/01ED81XK539QM497AYHM1X70JQ/",
       "name": "canterbury-rural-2012-2013-0.4m",
       "minZoom": 13,
       "title": "Canterbury 0.4m Rural Aerial Photos (2012-2013)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_rural_2013-2014_0-40m_RGBA/01F66E9VVX07WFC1C5Y05S4JXM",
-      "3857": "s3://linz-basemaps/3857/canterbury_rural_2013-2014_0-40m_RGBA/01ED81YFYF0D76RZRH9FHF7JDN",
+      "2193": "s3://linz-basemaps/2193/canterbury_rural_2013-2014_0-40m_RGBA/01F66E9VVX07WFC1C5Y05S4JXM/",
+      "3857": "s3://linz-basemaps/3857/canterbury_rural_2013-2014_0-40m_RGBA/01ED81YFYF0D76RZRH9FHF7JDN/",
       "name": "canterbury-rural-2013-2014-0.4m",
       "minZoom": 13,
       "title": "Canterbury 0.4m Rural Aerial Photos (2013-2014)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland-central-otago_rural_2013-2014_0-40m_RGBA/01F6P1R136F2BHRHRJ961SC7CH",
-      "3857": "s3://linz-basemaps/3857/southland-central-otago_rural_2013-2014_0-40m_RGBA/01ED83886J46GSSZP6GKCCYGH1",
+      "2193": "s3://linz-basemaps/2193/southland-central-otago_rural_2013-2014_0-40m_RGBA/01F6P1R136F2BHRHRJ961SC7CH/",
+      "3857": "s3://linz-basemaps/3857/southland-central-otago_rural_2013-2014_0-40m_RGBA/01ED83886J46GSSZP6GKCCYGH1/",
       "name": "southland-central-otago-rural-2013-2014-0.4m",
       "minZoom": 13,
       "title": "Southland & Central Otago 0.4m Rural Aerial Photos (2013-2014)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_rural_2014-2015_0-30m_RGBA/01F66EATPYCJF8R9WZRRE481ZP",
-      "3857": "s3://linz-basemaps/3857/canterbury_rural_2014-2015_0-30m_RGBA/01ED81ZMNH3PM5Q3E2MWRFD22B",
+      "2193": "s3://linz-basemaps/2193/canterbury_rural_2014-2015_0-30m_RGBA/01F66EATPYCJF8R9WZRRE481ZP/",
+      "3857": "s3://linz-basemaps/3857/canterbury_rural_2014-2015_0-30m_RGBA/01ED81ZMNH3PM5Q3E2MWRFD22B/",
       "name": "canterbury-rural-2014-2015-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2014-2015)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_rural_2014-16_0-4m/01F6P1JB8GFYFC08W3AK9KFGJW",
-      "3857": "s3://linz-basemaps/3857/northland_rural_2014-16_0-4m/01ED82WK4A955T96RV5NWEN3R6",
+      "2193": "s3://linz-basemaps/2193/northland_rural_2014-16_0-4m/01F6P1JB8GFYFC08W3AK9KFGJW/",
+      "3857": "s3://linz-basemaps/3857/northland_rural_2014-16_0-4m/01ED82WK4A955T96RV5NWEN3R6/",
       "name": "northland-rural-2014-2016-0.4m",
       "minZoom": 13,
       "title": "Northland 0.4m Rural Aerial Photos (2014-2016)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_rural_2015-2016_0-30m_RGBA/01F66EBN9BYJA29NMW96ZJM7ZJ",
-      "3857": "s3://linz-basemaps/3857/canterbury_rural_2015-2016_0-30m_RGBA/01ED82104D376HEF1ZMW8PRX5N",
+      "2193": "s3://linz-basemaps/2193/canterbury_rural_2015-2016_0-30m_RGBA/01F66EBN9BYJA29NMW96ZJM7ZJ/",
+      "3857": "s3://linz-basemaps/3857/canterbury_rural_2015-2016_0-30m_RGBA/01ED82104D376HEF1ZMW8PRX5N/",
       "name": "canterbury-rural-2015-2016-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland-central-otago_rural_2015-2017_0-40m_RGB/01F6P1RQRT6N94DDKGRCSYKM6R",
-      "3857": "s3://linz-basemaps/3857/southland-central-otago_rural_2015-2017_0-40m_RGB/01ED83A271YNKAW0KRH17RPMMV",
+      "2193": "s3://linz-basemaps/2193/southland-central-otago_rural_2015-2017_0-40m_RGB/01F6P1RQRT6N94DDKGRCSYKM6R/",
+      "3857": "s3://linz-basemaps/3857/southland-central-otago_rural_2015-2017_0-40m_RGB/01ED83A271YNKAW0KRH17RPMMV/",
       "name": "southland-central-otago-rural-2015-2017-0.4m",
       "minZoom": 13,
       "title": "Southland & Central Otago 0.4m Rural Aerial Photos (2015-2017)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_2023_0.25m/01H9S5K5N9BHQEPC9EW207TQ94",
-      "3857": "s3://linz-basemaps/3857/southland_2023_0.25m/01H9S5K5N7Q3WX9F3XB4VHHNQP",
+      "2193": "s3://linz-basemaps/2193/southland_2023_0.25m/01H9S5K5N9BHQEPC9EW207TQ94/",
+      "3857": "s3://linz-basemaps/3857/southland_2023_0.25m/01H9S5K5N7Q3WX9F3XB4VHHNQP/",
       "name": "southland-2023-0.25m",
       "minZoom": 13,
       "title": "Southland 0.25m Rural Aerial Photos (2023)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_rural_2015-16_0-3m/01F6P21PNQC7D67W5SHQF806Z3",
-      "3857": "s3://linz-basemaps/3857/west-coast_rural_2015-16_0-3m/01ED83TT0ZHKXTPFXEGFJHP2M5",
+      "2193": "s3://linz-basemaps/2193/west-coast_rural_2015-16_0-3m/01F6P21PNQC7D67W5SHQF806Z3/",
+      "3857": "s3://linz-basemaps/3857/west-coast_rural_2015-16_0-3m/01ED83TT0ZHKXTPFXEGFJHP2M5/",
       "name": "west-coast-rural-2015-2016-0.3m",
       "minZoom": 13,
       "title": "West Coast 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_rural_2016-18_0-3m/01F66ECJGT5PGYPVK9MW7TYHPZ",
-      "3857": "s3://linz-basemaps/3857/canterbury_rural_2016-18_0-3m/01ED8225A94WY3GQ4CNZ9E1PZN",
+      "2193": "s3://linz-basemaps/2193/canterbury_rural_2016-18_0-3m/01F66ECJGT5PGYPVK9MW7TYHPZ/",
+      "3857": "s3://linz-basemaps/3857/canterbury_rural_2016-18_0-3m/01ED8225A94WY3GQ4CNZ9E1PZN/",
       "name": "canterbury-rural-2016-2018-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2017-2018)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/kaikoura-post-earthquake_rural_2016-17_0-3m/01F6P1AGSRJG1VKND6PD8BXH2Q",
-      "3857": "s3://linz-basemaps/3857/kaikoura-post-earthquake_rural_2016-17_0-3m/01ED82F0376F6FJFMTV4JAVJ53",
+      "2193": "s3://linz-basemaps/2193/kaikoura-post-earthquake_rural_2016-17_0-3m/01F6P1AGSRJG1VKND6PD8BXH2Q/",
+      "3857": "s3://linz-basemaps/3857/kaikoura-post-earthquake_rural_2016-17_0-3m/01ED82F0376F6FJFMTV4JAVJ53/",
       "name": "kaikoura-post-earthquake-rural-2016-2017-0.3m",
       "minZoom": 13,
       "title": "Kaikōura Earthquake 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Event"
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_rural_2021_0-3m_RGB/01FB82NZY0ASDQBKT28DSXS8XC",
-      "3857": "s3://linz-basemaps/3857/wellington_rural_2021_0-3m_RGB/01FB82QKPWEHV0FWN7KBXM6NDM",
+      "2193": "s3://linz-basemaps/2193/wellington_rural_2021_0-3m_RGB/01FB82NZY0ASDQBKT28DSXS8XC/",
+      "3857": "s3://linz-basemaps/3857/wellington_rural_2021_0-3m_RGB/01FB82QKPWEHV0FWN7KBXM6NDM/",
       "name": "wellington-rural-2021-0.3m",
       "minZoom": 13,
       "title": "Wellington 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_rural_2016-17_0-3m/01F6P220GYWC836YQ4RRZGSV73",
-      "3857": "s3://linz-basemaps/3857/west-coast_rural_2016-17_0-3m/01ED83VT2T06B1FVXF9P6CCV8C",
+      "2193": "s3://linz-basemaps/2193/west-coast_rural_2016-17_0-3m/01F6P220GYWC836YQ4RRZGSV73/",
+      "3857": "s3://linz-basemaps/3857/west-coast_rural_2016-17_0-3m/01ED83VT2T06B1FVXF9P6CCV8C/",
       "name": "west-coast-rural-2016-2017-0.3m",
       "minZoom": 13,
       "title": "West Coast 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_rural_2017-2019_0-3m_RGB/01F6P15VGNRA3N06S2NEY9PFAX",
-      "3857": "s3://linz-basemaps/3857/gisborne_rural_2017-2019_0-3m_RGB/01EZWZGMW2Q53VNC65X2X4VFRZ",
+      "2193": "s3://linz-basemaps/2193/gisborne_rural_2017-2019_0-3m_RGB/01F6P15VGNRA3N06S2NEY9PFAX/",
+      "3857": "s3://linz-basemaps/3857/gisborne_rural_2017-2019_0-3m_RGB/01EZWZGMW2Q53VNC65X2X4VFRZ/",
       "name": "gisborne-rural-2017-2019-0.3m",
       "minZoom": 13,
       "title": "Gisborne 0.3m Rural Aerial Photos (2017-2019)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_rural_2017-18_0-3m/01F6P1E05SRRSMA94E11F1EAFJ",
-      "3857": "s3://linz-basemaps/3857/marlborough_rural_2017-18_0-3m/01EDAMZ587FYSZ9NY8TP40VASS",
+      "2193": "s3://linz-basemaps/2193/marlborough_rural_2017-18_0-3m/01F6P1E05SRRSMA94E11F1EAFJ/",
+      "3857": "s3://linz-basemaps/3857/marlborough_rural_2017-18_0-3m/01EDAMZ587FYSZ9NY8TP40VASS/",
       "name": "marlborough-rural-2017-2018-0.3m",
       "minZoom": 13,
       "title": "Marlborough 0.3m Rural Aerial Photos (2017-2018)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_rural_2017-2019_0-30m_RGB/01F6P1N3TA18Y2GYJ5B4YGGZYC",
-      "3857": "s3://linz-basemaps/3857/otago_rural_2017-2019_0-30m_RGB/01ED831MKK85M1QNCNZV0AYPYC",
+      "2193": "s3://linz-basemaps/2193/otago_rural_2017-2019_0-30m_RGB/01F6P1N3TA18Y2GYJ5B4YGGZYC/",
+      "3857": "s3://linz-basemaps/3857/otago_rural_2017-2019_0-30m_RGB/01ED831MKK85M1QNCNZV0AYPYC/",
       "name": "otago-rural-2017-2019-0.3m",
       "minZoom": 13,
       "title": "Otago 0.3m Rural Aerial Photos (2017-2019)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_rural_2017-19_0-3m/01F6P1YQNFECBE6S3TESNSPA2X",
-      "3857": "s3://linz-basemaps/3857/waikato_rural_2017-19_0-3m/01EDAN2JJVFCS9WZWMB9105XFH",
+      "2193": "s3://linz-basemaps/2193/waikato_rural_2017-19_0-3m/01F6P1YQNFECBE6S3TESNSPA2X/",
+      "3857": "s3://linz-basemaps/3857/waikato_rural_2017-19_0-3m/01EDAN2JJVFCS9WZWMB9105XFH/",
       "name": "waikato-rural-2017-2019-0.3m",
       "minZoom": 13,
       "title": "Waikato 0.3m Rural Aerial Photos (2016-2019)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/nelson_rural_2018-19_0-3m/01F6P1FJNXVVTS7HC3VS3FHEYX",
-      "3857": "s3://linz-basemaps/3857/nelson_rural_2018-19_0-3m/01ED82T5HM0H275QJPMDQN0JFJ",
+      "2193": "s3://linz-basemaps/2193/nelson_rural_2018-19_0-3m/01F6P1FJNXVVTS7HC3VS3FHEYX/",
+      "3857": "s3://linz-basemaps/3857/nelson_rural_2018-19_0-3m/01ED82T5HM0H275QJPMDQN0JFJ/",
       "name": "nelson-rural-2018-2019-0.3m",
       "minZoom": 13,
       "title": "Nelson 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2018-19_0-3m/01F6P1VDEYFR0XB5XJMN9X6V1C",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2018-19_0-3m/01ED83DSMR8N1FQFVXM8JASBV2",
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2018-19_0-3m/01F6P1VDEYFR0XB5XJMN9X6V1C/",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2018-19_0-3m/01ED83DSMR8N1FQFVXM8JASBV2/",
       "name": "tasman-rural-2018-2019-0.3m",
       "minZoom": 13,
       "title": "Tasman 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2016-17_0-3m/01F66E3G0Z8DNKWXG5M55QNW9G",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2016-17_0-3m/01F66E3G0Z8DNKWXG5M55QNW9G/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW/",
       "name": "bay-of-plenty-rural-2016-2017-0.3m",
       "title": "Bay of Plenty 0.3m Rural Aerial Photos (2016-2017)",
       "minZoom": 13,
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2021_0-2m/01H3E4XFK8N1JYJCM8BHDQAJPQ",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2021_0-2m/01H3E4ZG0MJ0SABSSBW2MJXVNS",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2021_0-2m/01H3E4XFK8N1JYJCM8BHDQAJPQ/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2021_0-2m/01H3E4ZG0MJ0SABSSBW2MJXVNS/",
       "name": "bay-of-plenty-rural-2021-0.2m",
       "minZoom": 13,
       "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2020_0-3m_RGB/01FBGB1QN859XRGNNWT6ZBHEN8",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2020_0-3m_RGB/01FBGB0T73562VAZBEBHZ7E84T",
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2020_0-3m_RGB/01FBGB1QN859XRGNNWT6ZBHEN8/",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2020_0-3m_RGB/01FBGB0T73562VAZBEBHZ7E84T/",
       "name": "tasman-rural-2020-0.3m",
       "minZoom": 13,
       "title": "Tasman 0.3m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_2022-2023_0.25m/01H4Q84VRY1WFXERB721NJZPED",
-      "3857": "s3://linz-basemaps/3857/tasman_2022-2023_0.25m/01H4Q85QE0ZF7E13DSGGZRR04V",
+      "2193": "s3://linz-basemaps/2193/tasman_2022-2023_0.25m/01H4Q84VRY1WFXERB721NJZPED/",
+      "3857": "s3://linz-basemaps/3857/tasman_2022-2023_0.25m/01H4Q85QE0ZF7E13DSGGZRR04V/",
       "name": "tasman-2022-2023-0.25m",
       "minZoom": 13,
       "title": "Tasman 0.25m Rural Aerial Photos (2022-2023)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_rural_2019_0-3m_RGB/01FJJFP25MYHH34JEV0XM9Z8Q8",
-      "3857": "s3://linz-basemaps/3857/canterbury_rural_2019_0-3m_RGB/01FJJFN1H62SA0836CKX2BYE5F",
+      "2193": "s3://linz-basemaps/2193/canterbury_rural_2019_0-3m_RGB/01FJJFP25MYHH34JEV0XM9Z8Q8/",
+      "3857": "s3://linz-basemaps/3857/canterbury_rural_2019_0-3m_RGB/01FJJFN1H62SA0836CKX2BYE5F/",
       "name": "canterbury-rural-2019-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_rural_2020_0-3m_RGB/01FHRTDFP4DDQD4X1G63SDF0AX",
-      "3857": "s3://linz-basemaps/3857/canterbury_rural_2020_0-3m_RGB/01FHRTF5GHTZD5SEXP3MS7E911",
+      "2193": "s3://linz-basemaps/2193/canterbury_rural_2020_0-3m_RGB/01FHRTDFP4DDQD4X1G63SDF0AX/",
+      "3857": "s3://linz-basemaps/3857/canterbury_rural_2020_0-3m_RGB/01FHRTF5GHTZD5SEXP3MS7E911/",
       "name": "canterbury-rural-2020-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_rural_2020-2021_0-2m_RGB/01FHV1ZNDNT9256J13H89BRKWT",
-      "3857": "s3://linz-basemaps/3857/canterbury_rural_2020-2021_0-2m_RGB/01FHV1VPTBM52WH81ZT7XAX93W",
+      "2193": "s3://linz-basemaps/2193/canterbury_rural_2020-2021_0-2m_RGB/01FHV1ZNDNT9256J13H89BRKWT/",
+      "3857": "s3://linz-basemaps/3857/canterbury_rural_2020-2021_0-2m_RGB/01FHV1VPTBM52WH81ZT7XAX93W/",
       "name": "canterbury-rural-2020-2021-0.2m",
       "minZoom": 13,
       "title": "Canterbury 0.2m Rural Aerial Photos (2020-2021)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_rural_2019-2021_0-3m_RGB/01FKP9RXGA4EXSFWBGKHKVTPMT",
-      "3857": "s3://linz-basemaps/3857/otago_rural_2019-2021_0-3m_RGB/01FKP9PAF9VNHC4FYGQRGHF593",
+      "2193": "s3://linz-basemaps/2193/otago_rural_2019-2021_0-3m_RGB/01FKP9RXGA4EXSFWBGKHKVTPMT/",
+      "3857": "s3://linz-basemaps/3857/otago_rural_2019-2021_0-3m_RGB/01FKP9PAF9VNHC4FYGQRGHF593/",
       "name": "otago-rural-2019-2021-0.3m",
       "minZoom": 13,
       "title": "Otago 0.3m Rural Aerial Photos (2019-2021)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury-waitaki_rural_2021_0-3m_RGB/01FQ07ZVQYC3M57D8N84WFM4F5",
-      "3857": "s3://linz-basemaps/3857/canterbury-waitaki_rural_2021_0-3m_RGB/01FQ07XS8GHPFS913PGY5P9010",
+      "2193": "s3://linz-basemaps/2193/canterbury-waitaki_rural_2021_0-3m_RGB/01FQ07ZVQYC3M57D8N84WFM4F5/",
+      "3857": "s3://linz-basemaps/3857/canterbury-waitaki_rural_2021_0-3m_RGB/01FQ07XS8GHPFS913PGY5P9010/",
       "name": "canterbury-waitaki-rural-2021-0.3m",
       "minZoom": 13,
       "title": "Canterbury - Waitaki 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury-mackenzie_rural_2021_0-3m_RGB/01FQ081YGQNSSB120WPZ3N70W0",
-      "3857": "s3://linz-basemaps/3857/canterbury-mackenzie_rural_2021_0-3m_RGB/01FQ080VWM2VAMT9G2BYPWZTKB",
+      "2193": "s3://linz-basemaps/2193/canterbury-mackenzie_rural_2021_0-3m_RGB/01FQ081YGQNSSB120WPZ3N70W0/",
+      "3857": "s3://linz-basemaps/3857/canterbury-mackenzie_rural_2021_0-3m_RGB/01FQ080VWM2VAMT9G2BYPWZTKB/",
       "name": "canterbury-mackenzie-rural-2021-0.3m",
       "minZoom": 13,
       "title": "Canterbury - Mackenzie 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2022_0-3m_RGB/01G75YD43EBA980HFWVF6ZFV6B",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2022_0-3m_RGB/01G75YDG4KFEZ5BAGTPHMEAPP7",
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2022_0-3m_RGB/01G75YD43EBA980HFWVF6ZFV6B/",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2022_0-3m_RGB/01G75YDG4KFEZ5BAGTPHMEAPP7/",
       "name": "tasman-rural-2022-0.3m",
       "minZoom": 13,
       "title": "Tasman 0.3m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ84DPHCND4PG6BD0W999A",
-      "3857": "s3://linz-basemaps/3857/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ9988GKX5JF0F0EW2R9Q3",
+      "2193": "s3://linz-basemaps/2193/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ84DPHCND4PG6BD0W999A/",
+      "3857": "s3://linz-basemaps/3857/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ9988GKX5JF0F0EW2R9Q3/",
       "name": "marlborough-rural-2021-2022-0.25m",
       "minZoom": 13,
       "title": "Marlborough 0.25m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_2023_0.25m/01H6WRJWDK9VNKK6HE2PZ63AKG",
-      "3857": "s3://linz-basemaps/3857/marlborough_2023_0.25m/01H6WRKSPQD92366HB8WT35BQK",
+      "2193": "s3://linz-basemaps/2193/marlborough_2023_0.25m/01H6WRJWDK9VNKK6HE2PZ63AKG/",
+      "3857": "s3://linz-basemaps/3857/marlborough_2023_0.25m/01H6WRKSPQD92366HB8WT35BQK/",
       "name": "marlborough-2023-0.25m",
       "minZoom": 13,
       "title": "Marlborough 0.25m Rural Aerial Photos (2023) - Draft",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH2Y0Q4PENH4T22PGJB521",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH42RKHGCSHRB3EMZVZD91",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH2Y0Q4PENH4T22PGJB521/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH42RKHGCSHRB3EMZVZD91/",
       "name": "hawkes-bay-rural-2021-2022-0.3m",
       "minZoom": 13,
       "title": "Hawke's Bay 0.3m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_rural_2021-2022_0.25m_RGB/01GDKFTY5BPAHMSKKVC336J9Y2",
-      "3857": "s3://linz-basemaps/3857/taranaki_rural_2021-2022_0.25m_RGB/01GDKFVY7VZ7CVYGYG02FXSEMJ",
+      "2193": "s3://linz-basemaps/2193/taranaki_rural_2021-2022_0.25m_RGB/01GDKFTY5BPAHMSKKVC336J9Y2/",
+      "3857": "s3://linz-basemaps/3857/taranaki_rural_2021-2022_0.25m_RGB/01GDKFVY7VZ7CVYGYG02FXSEMJ/",
       "name": "taranaki-rural-2021-2022-0.25m",
       "minZoom": 13,
       "title": "Taranaki 0.25m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2021-2022_0.3m/01GVCD2Y9RTQ57TWG4MPTHJ84R",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2021-2022_0.3m/01GVCDBNDH2Z9JEHDHJSD1EJ79",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2021-2022_0.3m/01GVCD2Y9RTQ57TWG4MPTHJ84R/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2021-2022_0.3m/01GVCDBNDH2Z9JEHDHJSD1EJ79/",
       "name": "manawatu-whanganui-rural-2021-2022-0.3m",
       "minZoom": 13,
       "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_2021-2022_0.2m/01GHW1Y474AHB191P8SRKENK7Y",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_2021-2022_0.2m/01GHW1ZWNS4N0GP9TAM09WHPBC",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_2021-2022_0.2m/01GHW1Y474AHB191P8SRKENK7Y/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_2021-2022_0.2m/01GHW1ZWNS4N0GP9TAM09WHPBC/",
       "name": "bay-of-plenty-2021-2022-0.2m",
       "minZoom": 13,
       "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_2022_0.3m/01GPEXMRQCA525WF8B0XBV5575",
-      "3857": "s3://linz-basemaps/3857/canterbury_2022_0.3m/01GPEXPBHG2XJZK0JPGKNAVD6A",
+      "2193": "s3://linz-basemaps/2193/canterbury_2022_0.3m/01GPEXMRQCA525WF8B0XBV5575/",
+      "3857": "s3://linz-basemaps/3857/canterbury_2022_0.3m/01GPEXPBHG2XJZK0JPGKNAVD6A/",
       "name": "canterbury-2022-0.3m",
       "minZoom": 13,
       "title": "Canterbury 0.3m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_rural_2021-2023_0.2m/01H2S2ADDFREPQC2797VEN5RAE",
-      "3857": "s3://linz-basemaps/3857/gisborne_rural_2021-2023_0.2m/01H2S2CJTQKXXY2NHZ88D4TP2X",
+      "2193": "s3://linz-basemaps/2193/gisborne_rural_2021-2023_0.2m/01H2S2ADDFREPQC2797VEN5RAE/",
+      "3857": "s3://linz-basemaps/3857/gisborne_rural_2021-2023_0.2m/01H2S2CJTQKXXY2NHZ88D4TP2X/",
       "name": "gisborne-rural-2021-2023-0.2m",
       "minZoom": 13,
       "title": "Gisborne 0.2m Rural Aerial Photos (2021-2023)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne-cyclone-gabrielle_2023_0.2m/01HB78D84QQPQKZH8V22C754GB",
-      "3857": "s3://linz-basemaps/3857/gisborne-cyclone-gabrielle_2023_0.2m/01HB78D862TBKEF4ZQTK6BFS51",
+      "2193": "s3://linz-basemaps/2193/gisborne-cyclone-gabrielle_2023_0.2m/01HB78D84QQPQKZH8V22C754GB/",
+      "3857": "s3://linz-basemaps/3857/gisborne-cyclone-gabrielle_2023_0.2m/01HB78D862TBKEF4ZQTK6BFS51/",
       "name": "gisborne-cyclone-gabrielle-2023-0.2m",
       "title": "Cyclone Gabrielle Gisborne 0.2m Aerial Photos (20 February 2023 - 17 May 2023)",
       "minZoom": 13,
       "category": "Event"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_2023_0.3m/01HFASC66T0ARNZK91N4XNM42Z",
-      "3857": "s3://linz-basemaps/3857/canterbury_2023_0.3m/01HFART8DDXKKGVM10S859K4WQ",
+      "2193": "s3://linz-basemaps/2193/canterbury_2023_0.3m/01HFASC66T0ARNZK91N4XNM42Z/",
+      "3857": "s3://linz-basemaps/3857/canterbury_2023_0.3m/01HFART8DDXKKGVM10S859K4WQ/",
       "name": "canterbury-2023-0.3m",
       "title": "Canterbury 0.3m Rural Aerial Photos (2023)",
       "category": "Rural Aerial Photos",
       "minZoom": 13
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_urban_2014-2015_0-10m_RGBA/01F6P1K57WYSAZVCTP35DVKG4B",
-      "3857": "s3://linz-basemaps/3857/northland_urban_2014-2015_0-10m_RGBA/01ED82YEHRRNR3YQC55TJY37E6",
+      "2193": "s3://linz-basemaps/2193/northland_urban_2014-2015_0-10m_RGBA/01F6P1K57WYSAZVCTP35DVKG4B/",
+      "3857": "s3://linz-basemaps/3857/northland_urban_2014-2015_0-10m_RGBA/01ED82YEHRRNR3YQC55TJY37E6/",
       "name": "northland-urban-2014-2015-0.1m",
       "minZoom": 14,
       "title": "Northland 0.1m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_urban_2017_0-075m/01F66DXCRR1CFTFQTE5R3525EJ",
-      "3857": "s3://linz-basemaps/3857/auckland_urban_2017_0-075m/01ED81HZRR86YBB8A0ZQRABP96",
+      "2193": "s3://linz-basemaps/2193/auckland_urban_2017_0-075m/01F66DXCRR1CFTFQTE5R3525EJ/",
+      "3857": "s3://linz-basemaps/3857/auckland_urban_2017_0-075m/01ED81HZRR86YBB8A0ZQRABP96/",
       "name": "auckland-urban-2017-0.075m",
       "minZoom": 14,
       "title": "Auckland 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/kapiti-coast_urban_2021_0-075m_RGB/01FC1XYXHBADGNDYM36SH8D1XY",
-      "3857": "s3://linz-basemaps/3857/kapiti-coast_urban_2021_0-075m_RGB/01FC1Y20KQZQDJESGSR97G9SSW",
+      "2193": "s3://linz-basemaps/2193/kapiti-coast_urban_2021_0-075m_RGB/01FC1XYXHBADGNDYM36SH8D1XY/",
+      "3857": "s3://linz-basemaps/3857/kapiti-coast_urban_2021_0-075m_RGB/01FC1Y20KQZQDJESGSR97G9SSW/",
       "name": "kapiti-coast-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Kapiti Coast 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_2023_0.075m/01HKX50M6A5XHFFB5K2YCWE9Q1",
-      "3857": "s3://linz-basemaps/3857/marlborough_2023_0.075m/01HKX50M6BTZBAN5DXDMZG6HF6",
+      "2193": "s3://linz-basemaps/2193/marlborough_2023_0.075m/01HKX50M6A5XHFFB5K2YCWE9Q1/",
+      "3857": "s3://linz-basemaps/3857/marlborough_2023_0.075m/01HKX50M6BTZBAN5DXDMZG6HF6/",
       "name": "marlborough-2023-0.075m",
       "title": "Marlborough 0.075m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos",
       "minZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/dunedin_urban_2018-19_0-1m/01F6P12VGV6BJR4AWJR29V6JQM",
-      "3857": "s3://linz-basemaps/3857/dunedin_urban_2018-19_0-1m/01ED826QV4Q60TNS6VM8HE36BV",
+      "2193": "s3://linz-basemaps/2193/dunedin_urban_2018-19_0-1m/01F6P12VGV6BJR4AWJR29V6JQM/",
+      "3857": "s3://linz-basemaps/3857/dunedin_urban_2018-19_0-1m/01ED826QV4Q60TNS6VM8HE36BV/",
       "name": "dunedin-urban-2018-2019-0.1m",
       "minZoom": 14,
       "title": "Dunedin 0.1m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hurunui_urban_2018-2019_0-075m_RGB/01F6P19APSPMW8GM4XZYQTCGES",
-      "3857": "s3://linz-basemaps/3857/hurunui_urban_2018-2019_0-075m_RGB/01ESPMPK1H0CH2G5K839WN1BT9",
+      "2193": "s3://linz-basemaps/2193/hurunui_urban_2018-2019_0-075m_RGB/01F6P19APSPMW8GM4XZYQTCGES/",
+      "3857": "s3://linz-basemaps/3857/hurunui_urban_2018-2019_0-075m_RGB/01ESPMPK1H0CH2G5K839WN1BT9/",
       "name": "hurunui-urban-2018-2019-0.075m",
       "minZoom": 14,
       "title": "Hurunui 0.075m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_urban_2018_0-1m/01F6P1NRHYW2SVKHBMRZ0NXYQA",
-      "3857": "s3://linz-basemaps/3857/otago_urban_2018_0-1m/01ED832ZRP7TDQEX5WMVHCP3VM",
+      "2193": "s3://linz-basemaps/2193/otago_urban_2018_0-1m/01F6P1NRHYW2SVKHBMRZ0NXYQA/",
+      "3857": "s3://linz-basemaps/3857/otago_urban_2018_0-1m/01ED832ZRP7TDQEX5WMVHCP3VM/",
       "name": "otago-urban-2018-0.1m",
       "minZoom": 14,
       "title": "Otago 0.1m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/selwyn_2022-2023_0.075m/01HFART1HWA37AQDR2X88AS7AZ",
-      "3857": "s3://linz-basemaps/3857/selwyn_2022-2023_0.075m/01HFART8HS45C7T38K6G5K3XF1",
+      "2193": "s3://linz-basemaps/2193/selwyn_2022-2023_0.075m/01HFART1HWA37AQDR2X88AS7AZ/",
+      "3857": "s3://linz-basemaps/3857/selwyn_2022-2023_0.075m/01HFART8HS45C7T38K6G5K3XF1/",
       "name": "selwyn-2022-2023-0.075m",
       "title": "Selwyn 0.075m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos",
       "minZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu_2022-2023_0.1m/01H4Q66MQ16RH0A8VMSTEDG6W4",
-      "3857": "s3://linz-basemaps/3857/manawatu_2022-2023_0.1m/01H4Q67HMMFNPJ9GEA6XYS1XDG",
+      "2193": "s3://linz-basemaps/2193/manawatu_2022-2023_0.1m/01H4Q66MQ16RH0A8VMSTEDG6W4/",
+      "3857": "s3://linz-basemaps/3857/manawatu_2022-2023_0.1m/01H4Q67HMMFNPJ9GEA6XYS1XDG/",
       "name": "manawatu-2022-2023-0.1m",
       "minZoom": 14,
       "title": "Manawatu 0.1m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington-city_urban_2021_0-075m_RGB/01GBRRFSNR0V1N50WP0H1E7SDP",
-      "3857": "s3://linz-basemaps/3857/wellington-city_urban_2021_0-075m_RGB/01GBRRG6Z6Q8SJNECE7K49M88R",
+      "2193": "s3://linz-basemaps/2193/wellington-city_urban_2021_0-075m_RGB/01GBRRFSNR0V1N50WP0H1E7SDP/",
+      "3857": "s3://linz-basemaps/3857/wellington-city_urban_2021_0-075m_RGB/01GBRRG6Z6Q8SJNECE7K49M88R/",
       "name": "wellington-city-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Wellington City 0.075m Urban Aerial Photos (2021)",
@@ -516,232 +516,232 @@
       "minZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/carterton_urban_2021_0-075m_RGB/01FC534VYVGP4WMS19M8SV1E6S",
-      "3857": "s3://linz-basemaps/3857/carterton_urban_2021_0-075m_RGB/01FC53660FJRP02Z4GZAQPZJV6",
+      "2193": "s3://linz-basemaps/2193/carterton_urban_2021_0-075m_RGB/01FC534VYVGP4WMS19M8SV1E6S/",
+      "3857": "s3://linz-basemaps/3857/carterton_urban_2021_0-075m_RGB/01FC53660FJRP02Z4GZAQPZJV6/",
       "name": "carterton-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Carterton 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/south-wairarapa_urban_2021_0-075m/01FCVP124PSVRSW7JCEC4KS2K1",
-      "3857": "s3://linz-basemaps/3857/south-wairarapa_urban_2021_0-075m/01FCVP30VG02HSFH1VVRM97RXP",
+      "2193": "s3://linz-basemaps/2193/south-wairarapa_urban_2021_0-075m/01FCVP124PSVRSW7JCEC4KS2K1/",
+      "3857": "s3://linz-basemaps/3857/south-wairarapa_urban_2021_0-075m/01FCVP30VG02HSFH1VVRM97RXP/",
       "name": "south-wairarapa-urban-2021-0.075m",
       "minZoom": 14,
       "title": "South Wairarapa 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/masterton_urban_2021_0-075m_RGB/01FCYQ2P6RB18BWV5B8WTDGX4R",
-      "3857": "s3://linz-basemaps/3857/masterton_urban_2021_0-075m_RGB/01FCYQ5JV710MS355E84P574DV",
+      "2193": "s3://linz-basemaps/2193/masterton_urban_2021_0-075m_RGB/01FCYQ2P6RB18BWV5B8WTDGX4R/",
+      "3857": "s3://linz-basemaps/3857/masterton_urban_2021_0-075m_RGB/01FCYQ5JV710MS355E84P574DV/",
       "name": "masterton-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Masterton 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hutt-city_urban_2021_0-075m_RGB/01FFGK6PT74ZGK3VFX3PY50S0S",
-      "3857": "s3://linz-basemaps/3857/hutt-city_urban_2021_0-075m_RGB/01FFGK7ZHHJ4SCYWMET8J4K3J1",
+      "2193": "s3://linz-basemaps/2193/hutt-city_urban_2021_0-075m_RGB/01FFGK6PT74ZGK3VFX3PY50S0S/",
+      "3857": "s3://linz-basemaps/3857/hutt-city_urban_2021_0-075m_RGB/01FFGK7ZHHJ4SCYWMET8J4K3J1/",
       "name": "hutt-city-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Hutt City 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/upper-hutt_urban_2021_0-075m_RGB/01FFH545V69N2SC5K4PSH7VZCV",
-      "3857": "s3://linz-basemaps/3857/upper-hutt_urban_2021_0-075m_RGB/01FFH51T317TVK35J75ZRZV0PN",
+      "2193": "s3://linz-basemaps/2193/upper-hutt_urban_2021_0-075m_RGB/01FFH545V69N2SC5K4PSH7VZCV/",
+      "3857": "s3://linz-basemaps/3857/upper-hutt_urban_2021_0-075m_RGB/01FFH51T317TVK35J75ZRZV0PN/",
       "name": "upper-hutt-urban-2021-0.075m",
       "minZoom": 14,
       "title": "Upper Hutt 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/rangitikei_urban_2021_0-125m_RGB/01FGT7KFSVPEX2RPW5PKN3XCAE",
-      "3857": "s3://linz-basemaps/3857/rangitikei_urban_2021_0-125m_RGB/01FGT7MAMPX1EPKW678BP3YWGQ",
+      "2193": "s3://linz-basemaps/2193/rangitikei_urban_2021_0-125m_RGB/01FGT7KFSVPEX2RPW5PKN3XCAE/",
+      "3857": "s3://linz-basemaps/3857/rangitikei_urban_2021_0-125m_RGB/01FGT7MAMPX1EPKW678BP3YWGQ/",
       "name": "rangitikei-urban-2021-0.125m",
       "minZoom": 14,
       "title": "Rangitīkei 0.125m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_urban_2016_0-1m_RGB/01FH4G3JZ5NSF7MTXB5291SRN9",
-      "3857": "s3://linz-basemaps/3857/northland_urban_2016_0-1m_RGB/01FH4G1K9A0YHZVCDE5B0J501A",
+      "2193": "s3://linz-basemaps/2193/northland_urban_2016_0-1m_RGB/01FH4G3JZ5NSF7MTXB5291SRN9/",
+      "3857": "s3://linz-basemaps/3857/northland_urban_2016_0-1m_RGB/01FH4G1K9A0YHZVCDE5B0J501A/",
       "name": "northland-urban-2016-0.1m",
       "minZoom": 14,
       "title": "Northland 0.1m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FVDF75ZM3KHXDYJES57AG",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FX6SQBKE27MWG6K3E86CM",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FVDF75ZM3KHXDYJES57AG/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FX6SQBKE27MWG6K3E86CM/",
       "name": "bay-of-plenty-urban-2020-0.1m",
       "minZoom": 13,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_2023_0.1m/01H7BSV0VASQPKX47EQD4JWYDM",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_2023_0.1m/01H7BSWXXHTC8581TSPJS1QTM1",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_2023_0.1m/01H7BSV0VASQPKX47EQD4JWYDM/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_2023_0.1m/01H7BSWXXHTC8581TSPJS1QTM1/",
       "name": "bay-of-plenty-2023-0.1m",
       "minZoom": 13,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waimakariri_2023_0.1m/01H4Q66MSD5ATAS9QX25FZ385V",
-      "3857": "s3://linz-basemaps/3857/waimakariri_2023_0.1m/01H4Q681F7MWQY303BM8TKAT6K",
+      "2193": "s3://linz-basemaps/2193/waimakariri_2023_0.1m/01H4Q66MSD5ATAS9QX25FZ385V/",
+      "3857": "s3://linz-basemaps/3857/waimakariri_2023_0.1m/01H4Q681F7MWQY303BM8TKAT6K/",
       "name": "waimakariri-2023-0.1m",
       "minZoom": 14,
       "title": "Waimakariri 0.1m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/christchurch_2023_0.075m/01HFART7KYYR9XX5RNHPMNRBJH",
-      "3857": "s3://linz-basemaps/3857/christchurch_2023_0.075m/01HFART7QPK7Y2TC7PY4XHHNNJ",
+      "2193": "s3://linz-basemaps/2193/christchurch_2023_0.075m/01HFART7KYYR9XX5RNHPMNRBJH/",
+      "3857": "s3://linz-basemaps/3857/christchurch_2023_0.075m/01HFART7QPK7Y2TC7PY4XHHNNJ/",
       "name": "christchurch-2023-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos",
       "minZoom": 13
     },
     {
-      "2193": "s3://linz-basemaps/2193/waitaki_urban_2020-2021_0-075m_RGB/01FSWMVSKCNWK9H4J3JP6RAQ0S",
-      "3857": "s3://linz-basemaps/3857/waitaki_urban_2020-2021_0-075m_RGB/01FSWMXCT9AF67HW8BQKV9WM0K",
+      "2193": "s3://linz-basemaps/2193/waitaki_urban_2020-2021_0-075m_RGB/01FSWMVSKCNWK9H4J3JP6RAQ0S/",
+      "3857": "s3://linz-basemaps/3857/waitaki_urban_2020-2021_0-075m_RGB/01FSWMXCT9AF67HW8BQKV9WM0K/",
       "name": "waitaki-urban-2020-2021-0.075m",
       "minZoom": 14,
       "title": "Waitaki 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/nelson_urban_2022_0-075m_RGB/01G87CWVWSG7KWE3DHC6R18BCX",
-      "3857": "s3://linz-basemaps/3857/nelson_urban_2022_0-075m_RGB/01G87CXGF81D5CVT22B038BCM1",
+      "2193": "s3://linz-basemaps/2193/nelson_urban_2022_0-075m_RGB/01G87CWVWSG7KWE3DHC6R18BCX/",
+      "3857": "s3://linz-basemaps/3857/nelson_urban_2022_0-075m_RGB/01G87CXGF81D5CVT22B038BCM1/",
       "name": "nelson-urban-2022-0.075m",
       "minZoom": 14,
       "title": "Nelson 0.075m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546/",
       "name": "hawkes-bay-urban-2022-0.1m",
       "minZoom": 14,
       "title": "Hawke's Bay 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94/",
       "name": "hawkes-bay-urban-2022-0.05m",
       "minZoom": 14,
       "title": "Hawke's Bay 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.1m_RGB/01GDM79KSKKCZ4FQCX5S2Q4BDQ",
-      "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.1m_RGB/01GDM7ACWGP9QZP7V3MF4MPKH8",
+      "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.1m_RGB/01GDM79KSKKCZ4FQCX5S2Q4BDQ/",
+      "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.1m_RGB/01GDM7ACWGP9QZP7V3MF4MPKH8/",
       "name": "taranaki-urban-2022-0.1m",
       "minZoom": 14,
       "title": "Taranaki 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_2022-2023_0.1m/01H4Q85VREX8HE76AY26NY2K8G",
-      "3857": "s3://linz-basemaps/3857/taranaki_2022-2023_0.1m/01H4Q867YPZYQ66124QQD5W9KA",
+      "2193": "s3://linz-basemaps/2193/taranaki_2022-2023_0.1m/01H4Q85VREX8HE76AY26NY2K8G/",
+      "3857": "s3://linz-basemaps/3857/taranaki_2022-2023_0.1m/01H4Q867YPZYQ66124QQD5W9KA/",
       "name": "taranaki-2022-2023-0.1m",
       "minZoom": 14,
       "title": "Taranaki 0.1m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.05m_RGB/01GDM781KPM27STN22MDPWC57Y",
-      "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.05m_RGB/01GDM7896HY2KQG4K3ESSZMPH6",
+      "2193": "s3://linz-basemaps/2193/taranaki_urban_2022_0.05m_RGB/01GDM781KPM27STN22MDPWC57Y/",
+      "3857": "s3://linz-basemaps/3857/taranaki_urban_2022_0.05m_RGB/01GDM7896HY2KQG4K3ESSZMPH6/",
       "name": "taranaki-urban-2022-0.05m",
       "minZoom": 14,
       "title": "Taranaki 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_2022-2023_0.05m/01H4Q85E2DHHDYDSEQGB80WA6F",
-      "3857": "s3://linz-basemaps/3857/taranaki_2022-2023_0.05m/01H4Q85VW9QY89WFKEQFZDRW56",
+      "2193": "s3://linz-basemaps/2193/taranaki_2022-2023_0.05m/01H4Q85E2DHHDYDSEQGB80WA6F/",
+      "3857": "s3://linz-basemaps/3857/taranaki_2022-2023_0.05m/01H4Q85VW9QY89WFKEQFZDRW56/",
       "name": "taranaki-2022-2023-0.05m",
       "minZoom": 14,
       "title": "Taranaki 0.05m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/invercargill_2022_0.1m/01GG8G03K4N284BJ7Q0DFTRW6P",
-      "3857": "s3://linz-basemaps/3857/invercargill_2022_0.1m/01GG8G0NQDH4F6XPCMQS312DRK",
+      "2193": "s3://linz-basemaps/2193/invercargill_2022_0.1m/01GG8G03K4N284BJ7Q0DFTRW6P/",
+      "3857": "s3://linz-basemaps/3857/invercargill_2022_0.1m/01GG8G0NQDH4F6XPCMQS312DRK/",
       "name": "invercargill-urban-2022-0.1m",
       "minZoom": 14,
       "title": "Invercargill 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/ashburton_urban_2021-2022_0.075m/01GM796A98A5WRYAKBJXRN57Z4",
-      "3857": "s3://linz-basemaps/3857/ashburton_urban_2021-2022_0.075m/01GM79743023G6STTDG08J4GV8",
+      "2193": "s3://linz-basemaps/2193/ashburton_urban_2021-2022_0.075m/01GM796A98A5WRYAKBJXRN57Z4/",
+      "3857": "s3://linz-basemaps/3857/ashburton_urban_2021-2022_0.075m/01GM79743023G6STTDG08J4GV8/",
       "name": "ashburton-urban-2021-2022-0.075m",
       "minZoom": 14,
       "title": "Ashburton 0.075m Urban Aerial Photos (2021-2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/invercargill_2022_0.05m/01GJ3WD5DCSRF0QN7JKN82GPCF",
-      "3857": "s3://linz-basemaps/3857/invercargill_2022_0.05m/01GJ3WDN7PTMGZ14AH56GPX39G",
+      "2193": "s3://linz-basemaps/2193/invercargill_2022_0.05m/01GJ3WD5DCSRF0QN7JKN82GPCF/",
+      "3857": "s3://linz-basemaps/3857/invercargill_2022_0.05m/01GJ3WDN7PTMGZ14AH56GPX39G/",
       "name": "invercargill-2022-0.05m",
       "minZoom": 14,
       "title": "Invercargill 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_2023_0.1m/01H795QH5JXYH5AYFKE7DG9H82",
-      "3857": "s3://linz-basemaps/3857/southland_2023_0.1m/01H795RNWP5JPF23FGWJFTNPC9",
+      "2193": "s3://linz-basemaps/2193/southland_2023_0.1m/01H795QH5JXYH5AYFKE7DG9H82/",
+      "3857": "s3://linz-basemaps/3857/southland_2023_0.1m/01H795RNWP5JPF23FGWJFTNPC9/",
       "name": "southland-2023-0.1m",
       "minZoom": 14,
       "title": "Southland 0.1m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waimate_2021_0.075m/01GKSQ99D3KZ2NN9H7MWSABMNM",
-      "3857": "s3://linz-basemaps/3857/waimate_2021_0.075m/01GKSQ9HMFNF4Z55QXCJ2Y2X0X",
+      "2193": "s3://linz-basemaps/2193/waimate_2021_0.075m/01GKSQ99D3KZ2NN9H7MWSABMNM/",
+      "3857": "s3://linz-basemaps/3857/waimate_2021_0.075m/01GKSQ9HMFNF4Z55QXCJ2Y2X0X/",
       "name": "waimate-2021-0.075m",
       "minZoom": 14,
       "title": "Waimate 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMPDNDV54KMKAS2RQH4A3WNE",
-      "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMPDP0B72W5VKH15PRD5DGYC",
+      "2193": "s3://linz-basemaps/2193/palmerston_north_2022_0.125m/01GMPDNDV54KMKAS2RQH4A3WNE/",
+      "3857": "s3://linz-basemaps/3857/palmerston_north_2022_0.125m/01GMPDP0B72W5VKH15PRD5DGYC/",
       "name": "palmerston-north-2022-0.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2022)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/queenstown-lakes_2022-2023_0.1m/01GTFDQVAACPYQXCPBVH51RBYK",
-      "3857": "s3://linz-basemaps/3857/queenstown-lakes_2022-2023_0.1m/01GTFDR0FZYRAMMGZN24RR5XY4",
+      "2193": "s3://linz-basemaps/2193/queenstown-lakes_2022-2023_0.1m/01GTFDQVAACPYQXCPBVH51RBYK/",
+      "3857": "s3://linz-basemaps/3857/queenstown-lakes_2022-2023_0.1m/01GTFDR0FZYRAMMGZN24RR5XY4/",
       "name": "queenstown-lakes-2022-2023-0.1m",
       "title": "Queenstown Lakes 0.1m Urban Aerial Photos (2022-2023)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taupo_2019_0.1m/01H4EY7Y0YNZWDBQPPH5DN90E1",
-      "3857": "s3://linz-basemaps/3857/taupo_2019_0.1m/01H4EY825250VGCTG7ZJ0BPAY4",
+      "2193": "s3://linz-basemaps/2193/taupo_2019_0.1m/01H4EY7Y0YNZWDBQPPH5DN90E1/",
+      "3857": "s3://linz-basemaps/3857/taupo_2019_0.1m/01H4EY825250VGCTG7ZJ0BPAY4/",
       "name": "taupo-2019-0.1m",
       "title": "Taupō 0.1m Urban Aerial Photos (2019)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taupo_2021_0.15m/01GX7WPF56PRH3N4NHV06BBF73",
-      "3857": "s3://linz-basemaps/3857/taupo_2021_0.15m/01GX7WPPSD1RZK0JCSYTYW3DJ2",
+      "2193": "s3://linz-basemaps/2193/taupo_2021_0.15m/01GX7WPF56PRH3N4NHV06BBF73/",
+      "3857": "s3://linz-basemaps/3857/taupo_2021_0.15m/01GX7WPPSD1RZK0JCSYTYW3DJ2/",
       "name": "taupo-2021-0.15m",
       "title": "Taupō 0.15m Urban Aerial Photos (2021)",
       "minZoom": 14,
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E",
-      "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8",
+      "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E/",
+      "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8/",
       "name": "auckland-rural-2020-0.075m",
       "minZoom": 13,
       "title": "Auckland 0.075m Rural Aerial Photos (2020)",
@@ -756,39 +756,39 @@
       "minZoom": 13
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_rural_2022_0-075m_RGB/01G6HJ9S4PGK6MTVEZWWHV56QN",
-      "3857": "s3://linz-basemaps/3857/auckland_rural_2022_0-075m_RGB/01G6HJBFJRBKJ7FQPHVRACKMNQ",
+      "2193": "s3://linz-basemaps/2193/auckland_rural_2022_0-075m_RGB/01G6HJ9S4PGK6MTVEZWWHV56QN/",
+      "3857": "s3://linz-basemaps/3857/auckland_rural_2022_0-075m_RGB/01G6HJBFJRBKJ7FQPHVRACKMNQ/",
       "name": "auckland-rural-2022-0.075m",
       "minZoom": 13,
       "title": "Auckland 0.075m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/ōtorohanga_urban_2021_0-1m_RGB/01FYWKAJ86W9P7RWM1VB62KD0H",
-      "3857": "s3://linz-basemaps/3857/ōtorohanga_urban_2021_0-1m_RGB/01FYWKATAEK2ZTJQ2PX44Y0XNT",
+      "2193": "s3://linz-basemaps/2193/ōtorohanga_urban_2021_0-1m_RGB/01FYWKAJ86W9P7RWM1VB62KD0H/",
+      "3857": "s3://linz-basemaps/3857/ōtorohanga_urban_2021_0-1m_RGB/01FYWKATAEK2ZTJQ2PX44Y0XNT/",
       "name": "ōtorohanga-urban-2021-0.1m",
       "minZoom": 14,
       "title": "Ōtorohanga 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waipa_urban_2021_0-1m_RGB/01G28WB9GKP01A8DPYWG9CBMN1",
-      "3857": "s3://linz-basemaps/3857/waipa_urban_2021_0-1m_RGB/01G28WC5349Y0J3CGWGTZ796DD",
+      "2193": "s3://linz-basemaps/2193/waipa_urban_2021_0-1m_RGB/01G28WB9GKP01A8DPYWG9CBMN1/",
+      "3857": "s3://linz-basemaps/3857/waipa_urban_2021_0-1m_RGB/01G28WC5349Y0J3CGWGTZ796DD/",
       "name": "waipa-urban-2021-0.1m",
       "minZoom": 14,
       "title": "Waipa 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_urban_2021_0-1m_RGB/01G75YF8RQTNWDSTJ9618EGGSH",
-      "3857": "s3://linz-basemaps/3857/waikato_urban_2021_0-1m_RGB/01G75YFYNRYPFF9H8P4CR4HDAJ",
+      "2193": "s3://linz-basemaps/2193/waikato_urban_2021_0-1m_RGB/01G75YF8RQTNWDSTJ9618EGGSH/",
+      "3857": "s3://linz-basemaps/3857/waikato_urban_2021_0-1m_RGB/01G75YFYNRYPFF9H8P4CR4HDAJ/",
       "name": "waikato-urban-2021-0.1m",
       "minZoom": 14,
       "title": "Waikato District 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/thames-coromandel_2021_0.1m/01HAK2FBK5CBCCM2S6XHCWK9VP",
+      "2193": "s3://linz-basemaps/2193/thames-coromandel_2021_0.1m/01HAK2FBK5CBCCM2S6XHCWK9VP/",
       "3857": "s3://linz-basemaps/3857/thames-coromandel_2021_0.1m/01HAK2FBGQ7MH75YWFSDT41QR3/",
       "name": "thames-coromandel-2021-0.1m",
       "minZoom": 14,
@@ -796,40 +796,40 @@
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hamilton_2023_0.05m/01H6YT6HDGMQ0DA04Q4YKTN6KS",
-      "3857": "s3://linz-basemaps/3857/hamilton_2023_0.05m/01H6YT8M3R6BN6V2869HA33NQ1",
+      "2193": "s3://linz-basemaps/2193/hamilton_2023_0.05m/01H6YT6HDGMQ0DA04Q4YKTN6KS/",
+      "3857": "s3://linz-basemaps/3857/hamilton_2023_0.05m/01H6YT8M3R6BN6V2869HA33NQ1/",
       "name": "hamilton-2023-0.05m",
       "minZoom": 14,
       "title": "Hamilton 0.05m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/whanganui_2022_0.075m/01GZMXEKG8QRB3W2TS4EXEGVR7",
-      "3857": "s3://linz-basemaps/3857/whanganui_2022_0.075m/01GZMXF18WABTRJ2B3TZ20JPJZ",
+      "2193": "s3://linz-basemaps/2193/whanganui_2022_0.075m/01GZMXEKG8QRB3W2TS4EXEGVR7/",
+      "3857": "s3://linz-basemaps/3857/whanganui_2022_0.075m/01GZMXF18WABTRJ2B3TZ20JPJZ/",
       "name": "whanganui-2022-0.075m",
       "minZoom": 14,
       "title": "Whanganui 0.075m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/taupo_2023_0.075m/01H0RX2PWKENR1D1S7E6GYNH1E",
-      "3857": "s3://linz-basemaps/3857/taupo_2023_0.075m/01H0RX3235SBMQJ5T3DF8FQTJN",
+      "2193": "s3://linz-basemaps/2193/taupo_2023_0.075m/01H0RX2PWKENR1D1S7E6GYNH1E/",
+      "3857": "s3://linz-basemaps/3857/taupo_2023_0.075m/01H0RX3235SBMQJ5T3DF8FQTJN/",
       "name": "taupo-2023-0.075m",
       "minZoom": 14,
       "title": "Taupō 0.075m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/queenstown_2021_0.1m/01HBW70P7CTXRZ45HGECZM14YS",
-      "3857": "s3://linz-basemaps/3857/queenstown_2021_0.1m/01HBW70P7CX6TVTNMY0ZJBPMZX",
+      "2193": "s3://linz-basemaps/2193/queenstown_2021_0.1m/01HBW70P7CTXRZ45HGECZM14YS/",
+      "3857": "s3://linz-basemaps/3857/queenstown_2021_0.1m/01HBW70P7CX6TVTNMY0ZJBPMZX/",
       "name": "queenstown-2021-0.1m",
       "minZoom": 14,
       "title": "Queenstown 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos"
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_2023_0.3m/01HFASC66T0ARNZK91N4XNM42Z",
-      "3857": "s3://linz-basemaps/3857/canterbury_2023_0.3m/01HFART8DDXKKGVM10S859K4WQ",
+      "2193": "s3://linz-basemaps/2193/canterbury_2023_0.3m/01HFASC66T0ARNZK91N4XNM42Z/",
+      "3857": "s3://linz-basemaps/3857/canterbury_2023_0.3m/01HFART8DDXKKGVM10S859K4WQ/",
       "name": "canterbury-2023-0.3m",
       "title": "Canterbury 0.3m Rural Aerial Photos (2023)",
       "category": "Rural Aerial Photos",
@@ -837,32 +837,32 @@
       "maxZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/mackenzie_2023_0.075m/01HFAS3KHGJ416HZ83RAD06806",
-      "3857": "s3://linz-basemaps/3857/mackenzie_2023_0.075m/01HFASC646P7KCY8Z34H65WWJA",
+      "2193": "s3://linz-basemaps/2193/mackenzie_2023_0.075m/01HFAS3KHGJ416HZ83RAD06806/",
+      "3857": "s3://linz-basemaps/3857/mackenzie_2023_0.075m/01HFASC646P7KCY8Z34H65WWJA/",
       "name": "mackenzie-2023-0.075m",
       "title": "Mackenzie 0.075m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos",
       "minZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/hurunui_2023_0.075m/01HFAS0PCEY0WBGCPXPHDQ29AE",
-      "3857": "s3://linz-basemaps/3857/hurunui_2023_0.075m/01HFAS0PCJPDPBXD5MQFCG13KX",
+      "2193": "s3://linz-basemaps/2193/hurunui_2023_0.075m/01HFAS0PCEY0WBGCPXPHDQ29AE/",
+      "3857": "s3://linz-basemaps/3857/hurunui_2023_0.075m/01HFAS0PCJPDPBXD5MQFCG13KX/",
       "name": "hurunui-2023-0.075m",
       "title": "Hurunui 0.075m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos",
       "minZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/ashburton_2023_0.1m/01HFAN2WCXEEF68TH48D33685N",
-      "3857": "s3://linz-basemaps/3857/ashburton_2023_0.1m/01HFAN2WCSQP52SHRAM47WYQEG",
+      "2193": "s3://linz-basemaps/2193/ashburton_2023_0.1m/01HFAN2WCXEEF68TH48D33685N/",
+      "3857": "s3://linz-basemaps/3857/ashburton_2023_0.1m/01HFAN2WCSQP52SHRAM47WYQEG/",
       "name": "ashburton-2023-0.1m",
       "title": "Ashburton 0.1m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos",
       "minZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/timaru_2022-2023_0.1m/01HFASBR6S6H0PKSGJYDF5EN3Z",
-      "3857": "s3://linz-basemaps/3857/timaru_2022-2023_0.1m/01HFART8EK8PX5B5HYFRXR0G92",
+      "2193": "s3://linz-basemaps/2193/timaru_2022-2023_0.1m/01HFASBR6S6H0PKSGJYDF5EN3Z/",
+      "3857": "s3://linz-basemaps/3857/timaru_2022-2023_0.1m/01HFART8EK8PX5B5HYFRXR0G92/",
       "name": "timaru-2022-2023-0.1m",
       "title": "Timaru 0.075m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos",
@@ -885,8 +885,8 @@
       "minZoom": 14
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_2023_0.075m/01HQS79210XRB25W757BG4E46D",
-      "3857": "s3://linz-basemaps/3857/gisborne_2023_0.075m/01HQS7921XXZ4ZWAHHT721QEZ0",
+      "2193": "s3://linz-basemaps/2193/gisborne_2023_0.075m/01HQS79210XRB25W757BG4E46D/",
+      "3857": "s3://linz-basemaps/3857/gisborne_2023_0.075m/01HQS7921XXZ4ZWAHHT721QEZ0/",
       "name": "gisborne-2023-0.075m",
       "title": "Gisborne 0.075m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos",
@@ -917,14 +917,14 @@
       "minZoom": 14
     },
     {
-      "3857": "s3://linz-basemaps/3857/geographx_nz_dem_2012_8-0m/01FM8DEN1XG1QGNT229A4T3KZ6",
+      "3857": "s3://linz-basemaps/3857/geographx_nz_dem_2012_8-0m/01FM8DEN1XG1QGNT229A4T3KZ6/",
       "name": "geographx-nz-dem-2012-8m",
       "maxZoom": 14,
       "title": "New Zealand 8m DEM Hillshade (2012)",
       "category": "Elevation"
     },
     {
-      "3857": "s3://linz-basemaps/3857/geographx_nz_texture_shade_2012_8-0m/01FMK5CJHR30YG9A0JDNVXYCKN",
+      "3857": "s3://linz-basemaps/3857/geographx_nz_texture_shade_2012_8-0m/01FMK5CJHR30YG9A0JDNVXYCKN/",
       "name": "geographx-nz-texture-shade-2012-8m",
       "maxZoom": 14,
       "title": "New Zealand 8m DEM Texture Shade (2012)",

--- a/config/tileset/auckland/imagery/auckland-2015-2016-0.075m.json
+++ b/config/tileset/auckland/imagery/auckland-2015-2016-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/auckland_2015-2016_0.075m/01GYDZV2MH0QVT8XXDMNMYK0DP",
-      "3857": "s3://linz-basemaps/3857/auckland_2015-2016_0.075m/01GYDZYBK72ED9ACTRSZNKS7GP",
+      "2193": "s3://linz-basemaps/2193/auckland_2015-2016_0.075m/01GYDZV2MH0QVT8XXDMNMYK0DP/",
+      "3857": "s3://linz-basemaps/3857/auckland_2015-2016_0.075m/01GYDZYBK72ED9ACTRSZNKS7GP/",
       "name": "auckland-2015-2016-0.075m",
       "title": "Auckland 0.075m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/auckland/imagery/auckland-coast-2022-2023-0.05m.json
+++ b/config/tileset/auckland/imagery/auckland-coast-2022-2023-0.05m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/auckland-coast_2022-2023_0.05m/01HKR511V54V4XXW3GZ3WWK8MC",
-      "3857": "s3://linz-basemaps/3857/auckland-coast_2022-2023_0.05m/01HKR511V7765A8KNMCFMJHV6S",
+      "2193": "s3://linz-basemaps/2193/auckland-coast_2022-2023_0.05m/01HKR511V54V4XXW3GZ3WWK8MC/",
+      "3857": "s3://linz-basemaps/3857/auckland-coast_2022-2023_0.05m/01HKR511V7765A8KNMCFMJHV6S/",
       "name": "auckland-coast-2022-2023-0.05m",
       "title": "Auckland Coast 0.05m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/auckland/imagery/auckland-sn5600-1979-0.375m.json
+++ b/config/tileset/auckland/imagery/auckland-sn5600-1979-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/auckland_sn5600_1979_0.375m/01H8J7E74WKJYFY8FCST5F90N0",
-      "3857": "s3://linz-basemaps/3857/auckland_sn5600_1979_0.375m/01H8J7E747XFQYM268Y71E0EK1",
+      "2193": "s3://linz-basemaps/2193/auckland_sn5600_1979_0.375m/01H8J7E74WKJYFY8FCST5F90N0/",
+      "3857": "s3://linz-basemaps/3857/auckland_sn5600_1979_0.375m/01H8J7E747XFQYM268Y71E0EK1/",
       "name": "auckland-sn5600-1979-0.375m",
       "title": "Auckland 0.375m SN5600 (1979)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/auckland/imagery/auckland-sn9211-1992-0.4m.json
+++ b/config/tileset/auckland/imagery/auckland-sn9211-1992-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/auckland_sn9211_1992_0.4m/01H8J8R1ES1F2Y7X460FEVK1TN",
-      "3857": "s3://linz-basemaps/3857/auckland_sn9211_1992_0.4m/01H8J8R16Y4MG3M3PQZSCZ3C60",
+      "2193": "s3://linz-basemaps/2193/auckland_sn9211_1992_0.4m/01H8J8R1ES1F2Y7X460FEVK1TN/",
+      "3857": "s3://linz-basemaps/3857/auckland_sn9211_1992_0.4m/01H8J8R16Y4MG3M3PQZSCZ3C60/",
       "name": "auckland-sn9211-1992-0.4m",
       "title": "Auckland 0.4m SN9211 (1992)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/auckland/imagery/auckland-snc50347-2003-2004-0.75m.json
+++ b/config/tileset/auckland/imagery/auckland-snc50347-2003-2004-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/auckland_snc50347_2003-2004_0.75m/01H8J8R2RMBRQH6V66M8Q82K7R",
-      "3857": "s3://linz-basemaps/3857/auckland_snc50347_2003-2004_0.75m/01H8J8R3YN3C1XHZ2BMBW0VZ74",
+      "2193": "s3://linz-basemaps/2193/auckland_snc50347_2003-2004_0.75m/01H8J8R2RMBRQH6V66M8Q82K7R/",
+      "3857": "s3://linz-basemaps/3857/auckland_snc50347_2003-2004_0.75m/01H8J8R3YN3C1XHZ2BMBW0VZ74/",
       "name": "auckland-snc50347-2003-2004-0.75m",
       "title": "Auckland 0.75m SNC50347 (2003-2004)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/auckland/imagery/auckland-waikato-sn8772-1987-1988-0.375m.json
+++ b/config/tileset/auckland/imagery/auckland-waikato-sn8772-1987-1988-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/auckland_waikato_sn8772_1987-1988_0.375m/01H8J8R64E4FPBHR3NR913XPDJ",
-      "3857": "s3://linz-basemaps/3857/auckland_waikato_sn8772_1987-1988_0.375m/01H8J8R67E85JMKT8V72CB4CYB",
+      "2193": "s3://linz-basemaps/2193/auckland_waikato_sn8772_1987-1988_0.375m/01H8J8R64E4FPBHR3NR913XPDJ/",
+      "3857": "s3://linz-basemaps/3857/auckland_waikato_sn8772_1987-1988_0.375m/01H8J8R67E85JMKT8V72CB4CYB/",
       "name": "auckland-waikato-sn8772-1987-1988-0.375m",
       "title": "Auckland / Waikato 0.375m SN8772 (1987-1988)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-gisborne-sn5975-1981-0.375m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-gisborne-sn5975-1981-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_gisborne_sn5975_1981_0.375m/01H8J8R5EMEX2T3HGHCWM5A2SN",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_gisborne_sn5975_1981_0.375m/01H8J8R6VBQMBS4MZFZ4K046SN",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_gisborne_sn5975_1981_0.375m/01H8J8R5EMEX2T3HGHCWM5A2SN/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_gisborne_sn5975_1981_0.375m/01H8J8R6VBQMBS4MZFZ4K046SN/",
       "name": "bay-of-plenty-gisborne-sn5975-1981-0.375m",
       "title": "Bay of Plenty / Gisborne 0.375m SN5975 (1981)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-gisborne-sn8564-1985-0.375m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-gisborne-sn8564-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_gisborne_sn8564_1985_0.375m/01H8J8R807NE0G76Y8QNFR7X98",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_gisborne_sn8564_1985_0.375m/01H8J8R7T8Z03959Z4VZRFGZPV",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_gisborne_sn8564_1985_0.375m/01H8J8R807NE0G76Y8QNFR7X98/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_gisborne_sn8564_1985_0.375m/01H8J8R7T8Z03959Z4VZRFGZPV/",
       "name": "bay-of-plenty-gisborne-sn8564-1985-0.375m",
       "title": "Bay of Plenty / Gisborne 0.375m SN8564 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-hawkes-bay-sn8419-1984-0.75m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-hawkes-bay-sn8419-1984-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/01H8J8R980P2CG305088NFPW8P",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/01H8J8RANGZD43A4B7KWC9DG4Z",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/01H8J8R980P2CG305088NFPW8P/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/01H8J8RANGZD43A4B7KWC9DG4Z/",
       "name": "bay-of-plenty-hawkes-bay-sn8419-1984-0.75m",
       "title": "Bay of Plenty / Hawkes Bay 0.75m SN8419 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2011-2012-0.25m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2011-2012-0.25m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2011-2012_0-25m_RGBA/01F66E1BB777Z4GN4PAW44FGFA",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2011-2012_0-25m_RGBA/01EDMTQXYCBANNYTKD4VK6C2GK",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2011-2012_0-25m_RGBA/01F66E1BB777Z4GN4PAW44FGFA/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2011-2012_0-25m_RGBA/01EDMTQXYCBANNYTKD4VK6C2GK/",
       "name": "bay-of-plenty-rural-2011-2012-0.25m",
       "title": "Bay of Plenty 0.25m Rural Aerial Photos (2011-2012)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2015-2017-0.25m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2015-2017-0.25m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2015-17_0-25m/01F66E2MGVQY9F4WXRYDRWRGPE",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2015-17_0-25m/01ED81P0KGVWJP2XHDKJJRYNQM",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2015-17_0-25m/01F66E2MGVQY9F4WXRYDRWRGPE/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2015-17_0-25m/01ED81P0KGVWJP2XHDKJJRYNQM/",
       "name": "bay-of-plenty-rural-2015-2017-0.25m",
       "title": "Bay of Plenty 0.25m Rural Aerial Photos (2015-2017)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2016-2017-0.3m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2016-2017-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2016-17_0-3m/01F66E3G0Z8DNKWXG5M55QNW9G",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2016-17_0-3m/01F66E3G0Z8DNKWXG5M55QNW9G/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW/",
       "name": "bay-of-plenty-rural-2016-2017-0.3m",
       "title": "Bay of Plenty 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2019-0.3m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2019-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2019_0-3m/01F66E4BR5XTJENFTSACWB55DM",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2019_0-3m/01ED81R5BX4EB3W7TB3Z8ZE89S",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2019_0-3m/01F66E4BR5XTJENFTSACWB55DM/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2019_0-3m/01ED81R5BX4EB3W7TB3Z8ZE89S/",
       "name": "bay-of-plenty-rural-2019-0.3m",
       "title": "Bay of Plenty 0.3m Rural Aerial Photos (2019)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn8240-1983-0.75m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn8240-1983-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8240_1983_0.75m/01H8J8RDS8Z603AJSEY5Y525AJ",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8240_1983_0.75m/01H8J8RC1E8RT597NQA3FCDJZ5",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8240_1983_0.75m/01H8J8RDS8Z603AJSEY5Y525AJ/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8240_1983_0.75m/01H8J8RC1E8RT597NQA3FCDJZ5/",
       "name": "bay-of-plenty-sn8240-1983-0.75m",
       "title": "Bay of Plenty 0.75m SN8240 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn8540-1985-1986-0.375m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn8540-1985-1986-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8540_1985-1986_0.375m/01H8J8RDMECK36AQFNKESQPEKG",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8540_1985-1986_0.375m/01H8J8REJC2NHK3RXHBFDN01TX",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8540_1985-1986_0.375m/01H8J8RDMECK36AQFNKESQPEKG/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8540_1985-1986_0.375m/01H8J8REJC2NHK3RXHBFDN01TX/",
       "name": "bay-of-plenty-sn8540-1985-1986-0.375m",
       "title": "Bay of Plenty 0.375m SN8540 (1985-1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn8626-1986-0.4m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn8626-1986-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8626_1986_0.4m/01H8J8RG6M35RK4Z6QT20C5MWC",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8626_1986_0.4m/01H8J8RG8878Q4W97J37A49SJS",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8626_1986_0.4m/01H8J8RG6M35RK4Z6QT20C5MWC/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8626_1986_0.4m/01H8J8RG8878Q4W97J37A49SJS/",
       "name": "bay-of-plenty-sn8626-1986-0.4m",
       "title": "Bay of Plenty 0.4m SN8626 (1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn8732-1987-0.15m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn8732-1987-0.15m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8732_1987_0.15m/01H8J8RHQZJSVZA7TJGKHZE0DQ",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8732_1987_0.15m/01H8J8RHN5QZAJ04R4FM2VQ78X",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8732_1987_0.15m/01H8J8RHQZJSVZA7TJGKHZE0DQ/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8732_1987_0.15m/01H8J8RHN5QZAJ04R4FM2VQ78X/",
       "name": "bay-of-plenty-sn8732-1987-0.15m",
       "title": "Bay of Plenty 0.15m SN8732 (1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn9383-1994-0.75m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-sn9383-1994-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn9383_1994_0.75m/01H8J9TH2XK6NNFFDSWT25NDMC",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn9383_1994_0.75m/01H8J9TH7JDZX8QXSP0E8NT3KV",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn9383_1994_0.75m/01H8J9TH2XK6NNFFDSWT25NDMC/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn9383_1994_0.75m/01H8J9TH7JDZX8QXSP0E8NT3KV/",
       "name": "bay-of-plenty-sn9383-1994-0.75m",
       "title": "Bay of Plenty 0.75m SN9383 (1994)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-snc25059-2001-0.75m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-snc25059-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc25059_2001_0.75m/01H8MV0MDV05G2KSM1YVNJV9D7",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc25059_2001_0.75m/01H8MV0MD8NA83R7WMH0EN9JFF",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc25059_2001_0.75m/01H8MV0MDV05G2KSM1YVNJV9D7/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc25059_2001_0.75m/01H8MV0MD8NA83R7WMH0EN9JFF/",
       "name": "bay-of-plenty-snc25059-2001-0.75m",
       "title": "Bay of Plenty 0.75m SNC25059 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-snc30006a-2002-0.75m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-snc30006a-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc30006a_2002_0.75m/01H8J9Z4YFVG6AZ2NG5WQKWPEK",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc30006a_2002_0.75m/01H8J9Z4XG259145C7CVH6BNAA",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc30006a_2002_0.75m/01H8J9Z4YFVG6AZ2NG5WQKWPEK/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc30006a_2002_0.75m/01H8J9Z4XG259145C7CVH6BNAA/",
       "name": "bay-of-plenty-snc30006a-2002-0.75m",
       "title": "Bay of Plenty 0.75m SNC30006a (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-snc50515-2003-0.625m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-snc50515-2003-0.625m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc50515_2003_0.625m/01H8JA1X42E6644NF8VVXKBV4B",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc50515_2003_0.625m/01H8JA1QH0SHD8CDB0VG97EM6H",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc50515_2003_0.625m/01H8JA1X42E6644NF8VVXKBV4B/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc50515_2003_0.625m/01H8JA1QH0SHD8CDB0VG97EM6H/",
       "name": "bay-of-plenty-snc50515-2003-0.625m",
       "title": "Bay of Plenty 0.625m SNC50515 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2014-2015-0.125m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2014-2015-0.125m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2014-15_0-125m/01F66E4JBVW1AW4VKGRN95SDGZ",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2014-15_0-125m/01ED81RPD7YEYNTPM2WZZK3X1A",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2014-15_0-125m/01F66E4JBVW1AW4VKGRN95SDGZ/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2014-15_0-125m/01ED81RPD7YEYNTPM2WZZK3X1A/",
       "name": "bay-of-plenty-urban-2014-2015-0.125m",
       "title": "Bay of Plenty 0.125m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2015-2016-0.125m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2015-2016-0.125m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2015-16_0-125m/01F66E63QY3BR3W3ARXRBPK1NP",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2015-16_0-125m/01ED81TJP9G5Q6VJKG921RT0QS",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2015-16_0-125m/01F66E63QY3BR3W3ARXRBPK1NP/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2015-16_0-125m/01ED81TJP9G5Q6VJKG921RT0QS/",
       "name": "bay-of-plenty-urban-2015-2016-0.125m",
       "title": "Bay of Plenty 0.125m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2015-2016-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2015-2016-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2015-16_0-1m/01F66E757Y78C33NKN50W9PW5C",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2015-16_0-1m/01ED81VN7AJ586W5HK2BSPHAPH",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2015-16_0-1m/01F66E757Y78C33NKN50W9PW5C/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2015-16_0-1m/01ED81VN7AJ586W5HK2BSPHAPH/",
       "name": "bay-of-plenty-urban-2015-2016-0.1m",
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2018-2019-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2018-2019-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2018-19_0-1m/01F66E7K4ESMSWZ1CNMCQ8B700",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2018-19_0-1m/01ED81W4KDQQRW9PEQ9KS7T8DV",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2018-19_0-1m/01F66E7K4ESMSWZ1CNMCQ8B700/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2018-19_0-1m/01ED81W4KDQQRW9PEQ9KS7T8DV/",
       "name": "bay-of-plenty-urban-2018-2019-0.1m",
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-waikato-snc25058-2001-0.75m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-waikato-snc25058-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_waikato_snc25058_2001_0.75m/01H8JA2S7SEX46T1Q94TR46M2H",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_waikato_snc25058_2001_0.75m/01H8JA2S6Q9RPR5EPR23JCR3EZ",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_waikato_snc25058_2001_0.75m/01H8JA2S7SEX46T1Q94TR46M2H/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_waikato_snc25058_2001_0.75m/01H8JA2S6Q9RPR5EPR23JCR3EZ/",
       "name": "bay-of-plenty-waikato-snc25058-2001-0.75m",
       "title": "Bay of Plenty / Waikato 0.75m SNC25058 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/bay-of-plenty/imagery/tauranga-city-urban-2022-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/tauranga-city-urban-2022-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tauranga-city_urban_2022_0.1m_RGB/01GD1V79CP27V3FD5XFWGCTPEM",
-      "3857": "s3://linz-basemaps/3857/tauranga-city_urban_2022_0.1m_RGB/01GD1V81RYJDH8NWK7C33PVNWR",
+      "2193": "s3://linz-basemaps/2193/tauranga-city_urban_2022_0.1m_RGB/01GD1V79CP27V3FD5XFWGCTPEM/",
+      "3857": "s3://linz-basemaps/3857/tauranga-city_urban_2022_0.1m_RGB/01GD1V81RYJDH8NWK7C33PVNWR/",
       "name": "tauranga-city-urban-2022-0.1m",
       "title": "Tauranga 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/tauranga-urban-2017-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/tauranga-urban-2017-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tauranga_urban_2017_0-1m/01F6P1W5KQ18HM9ZM9N35CXJ91",
-      "3857": "s3://linz-basemaps/3857/tauranga_urban_2017_0-1m/01ED83FS8PC1YC7Y7WKJ90P5TN",
+      "2193": "s3://linz-basemaps/2193/tauranga_urban_2017_0-1m/01F6P1W5KQ18HM9ZM9N35CXJ91/",
+      "3857": "s3://linz-basemaps/3857/tauranga_urban_2017_0-1m/01ED83FS8PC1YC7Y7WKJ90P5TN/",
       "name": "tauranga-urban-2017-0.1m",
       "title": "Tauranga 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/bay-of-plenty/imagery/tauranga-winter-2022-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/tauranga-winter-2022-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tauranga_winter_2022_0.1m/01GK5GPDK50QX6XXQ44KJEDHAW",
-      "3857": "s3://linz-basemaps/3857/tauranga_winter_2022_0.1m/01GK5GQ48BAXY62JFW6CPAH5XX",
+      "2193": "s3://linz-basemaps/2193/tauranga_winter_2022_0.1m/01GK5GPDK50QX6XXQ44KJEDHAW/",
+      "3857": "s3://linz-basemaps/3857/tauranga_winter_2022_0.1m/01GK5GQ48BAXY62JFW6CPAH5XX/",
       "name": "tauranga-winter-2022-0.1m",
       "title": "Tauranga Winter 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/ashburton-urban-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/ashburton-urban-2020-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/ashburton_urban_2020_0-075m_RGB/01FPV7HMJN6RQNSANMZ2SRY0BK",
-      "3857": "s3://linz-basemaps/3857/ashburton_urban_2020_0-075m_RGB/01FPV7ABAWS4ZCWN91VR7SDK0A",
+      "2193": "s3://linz-basemaps/2193/ashburton_urban_2020_0-075m_RGB/01FPV7HMJN6RQNSANMZ2SRY0BK/",
+      "3857": "s3://linz-basemaps/3857/ashburton_urban_2020_0-075m_RGB/01FPV7ABAWS4ZCWN91VR7SDK0A/",
       "name": "ashburton-urban-2020-0.075m",
       "title": "Ashburton 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/banks-peninsula-urban-2019-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/banks-peninsula-urban-2019-2020-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2R7RYJHP0DVXJMZ3M0QDY",
-      "3857": "s3://linz-basemaps/3857/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2SN9GVFBEW48N4V5E41ZQ",
+      "2193": "s3://linz-basemaps/2193/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2R7RYJHP0DVXJMZ3M0QDY/",
+      "3857": "s3://linz-basemaps/3857/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2SN9GVFBEW48N4V5E41ZQ/",
       "name": "banks-peninsula-urban-2019-2020-0.075m",
       "title": "Banks Peninsula 0.075m Urban Aerial Photos (2019-2020)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/canterbury-marlborough-sn8533-1985-1986-0.375m.json
+++ b/config/tileset/canterbury/imagery/canterbury-marlborough-sn8533-1985-1986-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_marlborough_sn8533_1985-1986_0.375m/01H8JA7AZNY3BE62P7VCH88DKV",
-      "3857": "s3://linz-basemaps/3857/canterbury_marlborough_sn8533_1985-1986_0.375m/01H8JA7B0DDJ0D7K9A9D4ZRYA6",
+      "2193": "s3://linz-basemaps/2193/canterbury_marlborough_sn8533_1985-1986_0.375m/01H8JA7AZNY3BE62P7VCH88DKV/",
+      "3857": "s3://linz-basemaps/3857/canterbury_marlborough_sn8533_1985-1986_0.375m/01H8JA7B0DDJ0D7K9A9D4ZRYA6/",
       "name": "canterbury-marlborough-sn8533-1985-1986-0.375m",
       "title": "Canterbury / Marlborough 0.375m SN8533 (1985-1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-otago-sn8337-1984-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-otago-sn8337-1984-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_otago_sn8337_1984_0.75m/01H8JAC7YY2QVJZ9ZB71B5T30D",
-      "3857": "s3://linz-basemaps/3857/canterbury_otago_sn8337_1984_0.75m/01H8JADH3GEXXY3QR7D8W4EGFA",
+      "2193": "s3://linz-basemaps/2193/canterbury_otago_sn8337_1984_0.75m/01H8JAC7YY2QVJZ9ZB71B5T30D/",
+      "3857": "s3://linz-basemaps/3857/canterbury_otago_sn8337_1984_0.75m/01H8JADH3GEXXY3QR7D8W4EGFA/",
       "name": "canterbury-otago-sn8337-1984-0.75m",
       "title": "Canterbury / Otago 0.75m SN8337 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-otago-sn8568-1985-1987-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-otago-sn8568-1985-1987-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_otago_sn8568_1985-1987_0.75m/01H8JAJVB2C2VV9Z157GDWH162",
-      "3857": "s3://linz-basemaps/3857/canterbury_otago_sn8568_1985-1987_0.75m/01H8JAG92BRXKP81GEVDZG14KW",
+      "2193": "s3://linz-basemaps/2193/canterbury_otago_sn8568_1985-1987_0.75m/01H8JAJVB2C2VV9Z157GDWH162/",
+      "3857": "s3://linz-basemaps/3857/canterbury_otago_sn8568_1985-1987_0.75m/01H8JAG92BRXKP81GEVDZG14KW/",
       "name": "canterbury-otago-sn8568-1985-1987-0.75m",
       "title": "Canterbury / Otago 0.75m SN8568 (1985-1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn12542-1998-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn12542-1998-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn12542_1998_0.75m/01H8JAFPHZWJX401BF10BB76BF",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn12542_1998_0.75m/01H8JAFPKXDESAM4T90N643H5J",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn12542_1998_0.75m/01H8JAFPHZWJX401BF10BB76BF/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn12542_1998_0.75m/01H8JAFPKXDESAM4T90N643H5J/",
       "name": "canterbury-sn12542-1998-0.75m",
       "title": "Canterbury 0.75m SN12542 (1998)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn12543-1998-1999-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn12543-1998-1999-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn12543_1998-1999_0.75m/01H8JAGE1S1E8X728ZWQ79QJR8",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn12543_1998-1999_0.75m/01H8JAGE2KESEHDXNQYD96TWW8",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn12543_1998-1999_0.75m/01H8JAGE1S1E8X728ZWQ79QJR8/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn12543_1998-1999_0.75m/01H8JAGE2KESEHDXNQYD96TWW8/",
       "name": "canterbury-sn12543-1998-1999-0.75m",
       "title": "Canterbury 0.75m SN12543 (1998-1999)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn25022-2000-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn25022-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn25022_2000_0.75m/01H8JAK010535HKTMW5FNQ4AMW",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn25022_2000_0.75m/01H8JAJC6ZJ7GVMYT4SC554D9E",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn25022_2000_0.75m/01H8JAK010535HKTMW5FNQ4AMW/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn25022_2000_0.75m/01H8JAJC6ZJ7GVMYT4SC554D9E/",
       "name": "canterbury-sn25022-2000-0.75m",
       "title": "Canterbury 0.75m SN25022 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn5204-1978-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn5204-1978-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn5204_1978_0.75m/01H8JBHJRQ6KJM3YTQW95M8NCJ",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn5204_1978_0.75m/01H8JBHN4NVTF3THTP6KGMA9AF",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn5204_1978_0.75m/01H8JBHJRQ6KJM3YTQW95M8NCJ/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn5204_1978_0.75m/01H8JBHN4NVTF3THTP6KGMA9AF/",
       "name": "canterbury-sn5204-1978-0.75m",
       "title": "Canterbury 0.75m SN5204 (1978)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn5771-1980-1981-0.375m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn5771-1980-1981-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn5771_1980-1981_0.375m/01H8JBHJY95FTHVPQ2XE6MH6BE",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn5771_1980-1981_0.375m/01H8JBHJJT6P1CRVH3W24RHRZK",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn5771_1980-1981_0.375m/01H8JBHJY95FTHVPQ2XE6MH6BE/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn5771_1980-1981_0.375m/01H8JBHJJT6P1CRVH3W24RHRZK/",
       "name": "canterbury-sn5771-1980-1981-0.375m",
       "title": "Canterbury 0.375m SN5771 (1980-1981)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn8261-1983-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn8261-1983-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8261_1983_0.75m/01H8JBHMZHS0XJB5RZVEZ1JAYY",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8261_1983_0.75m/01H8JBHMRZ54T418VV44PVNGSC",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8261_1983_0.75m/01H8JBHMZHS0XJB5RZVEZ1JAYY/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8261_1983_0.75m/01H8JBHMRZ54T418VV44PVNGSC/",
       "name": "canterbury-sn8261-1983-0.75m",
       "title": "Canterbury 0.75m SN8261 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn8389-1984-0.375m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn8389-1984-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8389_1984_0.375m/01H8JBHNGP0ZSG0KNAJ7KGH5QW",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8389_1984_0.375m/01H8JBHNP6T2JMTWR8H2Y0CF5R",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8389_1984_0.375m/01H8JBHNGP0ZSG0KNAJ7KGH5QW/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8389_1984_0.375m/01H8JBHNP6T2JMTWR8H2Y0CF5R/",
       "name": "canterbury-sn8389-1984-0.375m",
       "title": "Canterbury 0.375m SN8389 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn8453-1985-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn8453-1985-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8453_1985_0.75m/01H8JBHN4FKSAEHPH9XARAKSF1",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8453_1985_0.75m/01H8JBHN77AYTMD9SE0FDMZ5GY",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8453_1985_0.75m/01H8JBHN4FKSAEHPH9XARAKSF1/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8453_1985_0.75m/01H8JBHN77AYTMD9SE0FDMZ5GY/",
       "name": "canterbury-sn8453-1985-0.75m",
       "title": "Canterbury 0.75m SN8453 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn8532-1985-0.375m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn8532-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8532_1985_0.375m/01H8JBHQ2G8HX3HPTDMATCFM9E",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8532_1985_0.375m/01H8JBHPXEX5W1WG8CVH48VJZ9",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8532_1985_0.375m/01H8JBHQ2G8HX3HPTDMATCFM9E/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8532_1985_0.375m/01H8JBHPXEX5W1WG8CVH48VJZ9/",
       "name": "canterbury-sn8532-1985-0.375m",
       "title": "Canterbury 0.375m SN8532 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn8569-1985-1986-0.8m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn8569-1985-1986-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8569_1985-1986_0.8m/01H8JBHPBR494DT2ZTZS599BS5",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8569_1985-1986_0.8m/01H8JBHRAFNQGF1AMHXFZ9H74P",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8569_1985-1986_0.8m/01H8JBHPBR494DT2ZTZS599BS5/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8569_1985-1986_0.8m/01H8JBHRAFNQGF1AMHXFZ9H74P/",
       "name": "canterbury-sn8569-1985-1986-0.8m",
       "title": "Canterbury 0.8m SN8569 (1985-1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn8584-1986-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn8584-1986-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8584_1986_0.75m/01H8JBHSF3SAKBGWKT88N3KHFP",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8584_1986_0.75m/01H8JBHSD8AVY4ERM51V06BVGZ",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8584_1986_0.75m/01H8JBHSF3SAKBGWKT88N3KHFP/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8584_1986_0.75m/01H8JBHSD8AVY4ERM51V06BVGZ/",
       "name": "canterbury-sn8584-1986-0.75m",
       "title": "Canterbury 0.75m SN8584 (1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn8720-1987-0.375m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn8720-1987-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8720_1987_0.375m/01H8JBHXZ7T8N132VAMAJ0KZPJ",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8720_1987_0.375m/01H8JBHX0C71GFM6A23845YBXK",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8720_1987_0.375m/01H8JBHXZ7T8N132VAMAJ0KZPJ/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8720_1987_0.375m/01H8JBHX0C71GFM6A23845YBXK/",
       "name": "canterbury-sn8720-1987-0.375m",
       "title": "Canterbury 0.375m SN8720 (1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn8777-1987-0.375m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn8777-1987-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8777_1987_0.375m/01H8JBHZ0NC4TTW162FPKE4T5B",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8777_1987_0.375m/01H8JBHZ8AVFXS2QCJ2P6P6DQQ",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8777_1987_0.375m/01H8JBHZ0NC4TTW162FPKE4T5B/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8777_1987_0.375m/01H8JBHZ8AVFXS2QCJ2P6P6DQQ/",
       "name": "canterbury-sn8777-1987-0.375m",
       "title": "Canterbury 0.375m SN8777 (1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn9381-1994-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn9381-1994-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn9381_1994_0.75m/01H8JBHYWS9E05WE1N38P6RAGD",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn9381_1994_0.75m/01H8JBJ0NCEJE52EBJM3E969RE",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn9381_1994_0.75m/01H8JBHYWS9E05WE1N38P6RAGD/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn9381_1994_0.75m/01H8JBJ0NCEJE52EBJM3E969RE/",
       "name": "canterbury-sn9381-1994-0.75m",
       "title": "Canterbury 0.75m SN9381 (1994)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-sn9447-1995-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-sn9447-1995-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn9447_1995_0.75m/01H8JBJ239BZ05306N63Y9CBQ9",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn9447_1995_0.75m/01H8JBJ2CWPK75ADVVF9APZQY6",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn9447_1995_0.75m/01H8JBJ239BZ05306N63Y9CBQ9/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn9447_1995_0.75m/01H8JBJ2CWPK75ADVVF9APZQY6/",
       "name": "canterbury-sn9447-1995-0.75m",
       "title": "Canterbury 0.75m SN9447 (1995)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-snc25051-2000-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-snc25051-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc25051_2000_0.75m/01H8JBJ4TD82PY4BFZE274M88G",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc25051_2000_0.75m/01H8JBJ4EFB6BYY40S98ADJW2C",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc25051_2000_0.75m/01H8JBJ4TD82PY4BFZE274M88G/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc25051_2000_0.75m/01H8JBJ4EFB6BYY40S98ADJW2C/",
       "name": "canterbury-snc25051-2000-0.75m",
       "title": "Canterbury 0.75m SNC25051 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-snc25053-2001-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-snc25053-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc25053_2001_0.75m/01H8JBJ5MQDQMHPQETM02HAEJF",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc25053_2001_0.75m/01H8JBJ576DP2TDB96N7GGDGQ9",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc25053_2001_0.75m/01H8JBJ5MQDQMHPQETM02HAEJF/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc25053_2001_0.75m/01H8JBJ576DP2TDB96N7GGDGQ9/",
       "name": "canterbury-snc25053-2001-0.75m",
       "title": "Canterbury 0.75m SNC25053 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-snc25054-2000-2001-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-snc25054-2000-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc25054_2000-2001_0.75m/01H8JBJ86AEDMR04KD0RZNFQN2",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc25054_2000-2001_0.75m/01H8JBJ795K7W1XASZCVY5D630",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc25054_2000-2001_0.75m/01H8JBJ86AEDMR04KD0RZNFQN2/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc25054_2000-2001_0.75m/01H8JBJ795K7W1XASZCVY5D630/",
       "name": "canterbury-snc25054-2000-2001-0.75m",
       "title": "Canterbury 0.75m SNC25054 (2000-2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-snc30000-2002-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-snc30000-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc30000_2002_0.75m/01H8JBJ99AE6C0S9VPGXCXH4AK",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc30000_2002_0.75m/01H8JBJACQS8BHYCDT6XCVC66S",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc30000_2002_0.75m/01H8JBJ99AE6C0S9VPGXCXH4AK/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc30000_2002_0.75m/01H8JBJACQS8BHYCDT6XCVC66S/",
       "name": "canterbury-snc30000-2002-0.75m",
       "title": "Canterbury 0.75m SNC30000 (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-snc30009-2003-0.75m.json
+++ b/config/tileset/canterbury/imagery/canterbury-snc30009-2003-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc30009_2003_0.75m/01H8JBJB09Q8VPCJXPC1ZX0SYH",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc30009_2003_0.75m/01H8JBKATD5CER0QS0HJHA8W9C",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc30009_2003_0.75m/01H8JBJB09Q8VPCJXPC1ZX0SYH/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc30009_2003_0.75m/01H8JBKATD5CER0QS0HJHA8W9C/",
       "name": "canterbury-snc30009-2003-0.75m",
       "title": "Canterbury 0.75m SNC30009 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/canterbury-west-coast-sn8595-1986-1987-0.96m.json
+++ b/config/tileset/canterbury/imagery/canterbury-west-coast-sn8595-1986-1987-0.96m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_west-coast_sn8595_1986-1987_0.96m/01H8JBMB6KJ8C6AAHSEZ5RVRC8",
-      "3857": "s3://linz-basemaps/3857/canterbury_west-coast_sn8595_1986-1987_0.96m/01H8JBKR6W92Q8Y7P5WAC5ZXM6",
+      "2193": "s3://linz-basemaps/2193/canterbury_west-coast_sn8595_1986-1987_0.96m/01H8JBMB6KJ8C6AAHSEZ5RVRC8/",
+      "3857": "s3://linz-basemaps/3857/canterbury_west-coast_sn8595_1986-1987_0.96m/01H8JBKR6W92Q8Y7P5WAC5ZXM6/",
       "name": "canterbury-west-coast-sn8595-1986-1987-0.96m",
       "title": "Canterbury / West Coast 0.96m SN8595 (1986-1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/canterbury/imagery/christchurch-urban-2015-2016-0.075m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2015-2016-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2015-2016_0-075m_RGBA/01F6P0KPJJK4MJ3JZVS0DJK0Q7",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2015-2016_0-075m_RGBA/01EWEQ26HDCMDQKTZ1RHSXPBEW",
+      "2193": "s3://linz-basemaps/2193/christchurch_urban_2015-2016_0-075m_RGBA/01F6P0KPJJK4MJ3JZVS0DJK0Q7/",
+      "3857": "s3://linz-basemaps/3857/christchurch_urban_2015-2016_0-075m_RGBA/01EWEQ26HDCMDQKTZ1RHSXPBEW/",
       "name": "christchurch-urban-2015-2016-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/christchurch-urban-2018-0.075m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2018-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2018_0-075m/01F6P0NTCAD62YAXJ1DKKK2AY3",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2018_0-075m/01ED825VGXM6K9YX52DP7SMXQE",
+      "2193": "s3://linz-basemaps/2193/christchurch_urban_2018_0-075m/01F6P0NTCAD62YAXJ1DKKK2AY3/",
+      "3857": "s3://linz-basemaps/3857/christchurch_urban_2018_0-075m/01ED825VGXM6K9YX52DP7SMXQE/",
       "name": "christchurch-urban-2018-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/christchurch-urban-2018-2019-0.075m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2018-2019-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2018-2019_0-075m_RGB/01F6P0MJKAVT7XTXXPS19FQP81",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2018-2019_0-075m_RGB/01EMFHZ28DMWDCJ7VEE15HTYPZ",
+      "2193": "s3://linz-basemaps/2193/christchurch_urban_2018-2019_0-075m_RGB/01F6P0MJKAVT7XTXXPS19FQP81/",
+      "3857": "s3://linz-basemaps/3857/christchurch_urban_2018-2019_0-075m_RGB/01EMFHZ28DMWDCJ7VEE15HTYPZ/",
       "name": "christchurch-urban-2018-2019-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/christchurch-urban-2020-2021-0.075m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2020-2021-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2020-2021_0-075m_RGB/01FPXB0T4ZCASWGX1X1GVEHDQZ",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2020-2021_0-075m_RGB/01FPXB36CCAK3FC6FWCMK1D156",
+      "2193": "s3://linz-basemaps/2193/christchurch_urban_2020-2021_0-075m_RGB/01FPXB0T4ZCASWGX1X1GVEHDQZ/",
+      "3857": "s3://linz-basemaps/3857/christchurch_urban_2020-2021_0-075m_RGB/01FPXB36CCAK3FC6FWCMK1D156/",
       "name": "christchurch-urban-2020-2021-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/christchurch-urban-2021-0.05m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2021-0.05m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/christchurch_urban_2021_0-05m_RGB/01FPXAY15VB9MES5WQ0N2SPEG6",
-      "3857": "s3://linz-basemaps/3857/christchurch_urban_2021_0-05m_RGB/01FPXB6TVAQZV4W9KXWQ7H5ZQA",
+      "2193": "s3://linz-basemaps/2193/christchurch_urban_2021_0-05m_RGB/01FPXAY15VB9MES5WQ0N2SPEG6/",
+      "3857": "s3://linz-basemaps/3857/christchurch_urban_2021_0-05m_RGB/01FPXB6TVAQZV4W9KXWQ7H5ZQA/",
       "name": "christchurch-urban-2021-0.05m",
       "title": "Christchurch 0.05m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/hurunui-urban-2013-0.125m.json
+++ b/config/tileset/canterbury/imagery/hurunui-urban-2013-0.125m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hurunui_urban_2013_0-125m_RGBA/01F6P1965MX7W515NM9VR90V67",
-      "3857": "s3://linz-basemaps/3857/hurunui_urban_2013_0-125m_RGBA/01ED82CK977V2ZJ095QZDGSME6",
+      "2193": "s3://linz-basemaps/2193/hurunui_urban_2013_0-125m_RGBA/01F6P1965MX7W515NM9VR90V67/",
+      "3857": "s3://linz-basemaps/3857/hurunui_urban_2013_0-125m_RGBA/01ED82CK977V2ZJ095QZDGSME6/",
       "name": "hurunui-urban-2013-0.125m",
       "title": "Hurunui 0.125m Urban Aerial Photos (2013)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/mackenzie-urban-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/mackenzie-urban-2020-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/mackenzie_urban_2020_0-075m_RGB/01FPV7GGNZ008JBH25F35KXC71",
-      "3857": "s3://linz-basemaps/3857/mackenzie_urban_2020_0-075m_RGB/01FPV7C0KD6R4FD8TTE3S43ETF",
+      "2193": "s3://linz-basemaps/2193/mackenzie_urban_2020_0-075m_RGB/01FPV7GGNZ008JBH25F35KXC71/",
+      "3857": "s3://linz-basemaps/3857/mackenzie_urban_2020_0-075m_RGB/01FPV7C0KD6R4FD8TTE3S43ETF/",
       "name": "mackenzie-urban-2020-0.075m",
       "title": "MacKenzie 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/manawatu-urban-2019-0.125m.json
+++ b/config/tileset/canterbury/imagery/manawatu-urban-2019-0.125m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu_urban_2019_0-125m/01F6P1C55PMBG08K4W549J8EQ8",
-      "3857": "s3://linz-basemaps/3857/manawatu_urban_2019_0-125m/01ED82GV8E3DRWQ86D80SN1FPW",
+      "2193": "s3://linz-basemaps/2193/manawatu_urban_2019_0-125m/01F6P1C55PMBG08K4W549J8EQ8/",
+      "3857": "s3://linz-basemaps/3857/manawatu_urban_2019_0-125m/01ED82GV8E3DRWQ86D80SN1FPW/",
       "name": "manawatu-urban-2019-0.125m",
       "title": "Manawatu 0.125m Urban Aerial Photos (2019)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/selwyn-urban-2012-2013-0.125m.json
+++ b/config/tileset/canterbury/imagery/selwyn-urban-2012-2013-0.125m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2",
-      "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ",
+      "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2/",
+      "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ/",
       "name": "selwyn-urban-2012-2013-0.125m",
       "title": "Selwyn 0.125m Urban Aerial Photos (2012-2013)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/selwyn-urban-2018-2019-0.075m.json
+++ b/config/tileset/canterbury/imagery/selwyn-urban-2018-2019-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/selwyn_urban_2018-2019_0-075m_RGB/01F6P1Q9FCCZ9EH7HE7X2SK2Q1",
-      "3857": "s3://linz-basemaps/3857/selwyn_urban_2018-2019_0-075m_RGB/01ESPVY6HBS1SH79ZH24RW7ZSQ",
+      "2193": "s3://linz-basemaps/2193/selwyn_urban_2018-2019_0-075m_RGB/01F6P1Q9FCCZ9EH7HE7X2SK2Q1/",
+      "3857": "s3://linz-basemaps/3857/selwyn_urban_2018-2019_0-075m_RGB/01ESPVY6HBS1SH79ZH24RW7ZSQ/",
       "name": "selwyn-urban-2018-2019-0.075m",
       "title": "Selwyn 0.075m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/selwyn-urban-2019-0.075m.json
+++ b/config/tileset/canterbury/imagery/selwyn-urban-2019-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/selwyn_urban_2019_0-075m_RGB/01FMJQBZ1H9F9KBFK8VH5THM2K",
-      "3857": "s3://linz-basemaps/3857/selwyn_urban_2019_0-075m_RGB/01FMJQANZJNCWB6SZAYG7P11ZT",
+      "2193": "s3://linz-basemaps/2193/selwyn_urban_2019_0-075m_RGB/01FMJQBZ1H9F9KBFK8VH5THM2K/",
+      "3857": "s3://linz-basemaps/3857/selwyn_urban_2019_0-075m_RGB/01FMJQANZJNCWB6SZAYG7P11ZT/",
       "name": "selwyn-urban-2019-0.075m",
       "title": "Selwyn 0.075m Urban Aerial Photos (2019)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/selwyn-urban-2020-2021-0.075m.json
+++ b/config/tileset/canterbury/imagery/selwyn-urban-2020-2021-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/selwyn_urban_2020-2021_0-075m_RGB/01FSWMZ640BA2YD74DDGA1A62X",
-      "3857": "s3://linz-basemaps/3857/selwyn_urban_2020-2021_0-075m_RGB/01FSWN35JY2PC7GMHEBXYART77",
+      "2193": "s3://linz-basemaps/2193/selwyn_urban_2020-2021_0-075m_RGB/01FSWMZ640BA2YD74DDGA1A62X/",
+      "3857": "s3://linz-basemaps/3857/selwyn_urban_2020-2021_0-075m_RGB/01FSWN35JY2PC7GMHEBXYART77/",
       "name": "selwyn-urban-2020-2021-0.075m",
       "title": "Selwyn 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/timaru-urban-2012-2013-0.075m.json
+++ b/config/tileset/canterbury/imagery/timaru-urban-2012-2013-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/timaru_urban_2012-2013_0-075m_RGBA/01F6P1XAGNDZVM0DH9JCFSE7QB",
-      "3857": "s3://linz-basemaps/3857/timaru_urban_2012-2013_0-075m_RGBA/01ED83HWB82K047N1KYK9A5SKD",
+      "2193": "s3://linz-basemaps/2193/timaru_urban_2012-2013_0-075m_RGBA/01F6P1XAGNDZVM0DH9JCFSE7QB/",
+      "3857": "s3://linz-basemaps/3857/timaru_urban_2012-2013_0-075m_RGBA/01ED83HWB82K047N1KYK9A5SKD/",
       "name": "timaru-urban-2012-2013-0.075m",
       "title": "Timaru 0.075m Urban Aerial Photos (2012-2013)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/timaru-urban-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/timaru-urban-2020-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/timaru_urban_2020_0-075m_RGB/01FPV7FD7SX1JKW7TK25ESMYN1",
-      "3857": "s3://linz-basemaps/3857/timaru_urban_2020_0-075m_RGB/01FPV7DVA9TW7XQCR64SSB12DA",
+      "2193": "s3://linz-basemaps/2193/timaru_urban_2020_0-075m_RGB/01FPV7FD7SX1JKW7TK25ESMYN1/",
+      "3857": "s3://linz-basemaps/3857/timaru_urban_2020_0-075m_RGB/01FPV7DVA9TW7XQCR64SSB12DA/",
       "name": "timaru-urban-2020-0.075m",
       "title": "Timaru 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/waimakariri-urban-2013-2014-0.075m.json
+++ b/config/tileset/canterbury/imagery/waimakariri-urban-2013-2014-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2013-2014_0-075m_RGBA/01F6P20317FNJJSB1KJFH7Y35Y",
-      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2013-2014_0-075m_RGBA/01ED83PPQFH8Z8HNY1WV7W4SS5",
+      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2013-2014_0-075m_RGBA/01F6P20317FNJJSB1KJFH7Y35Y/",
+      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2013-2014_0-075m_RGBA/01ED83PPQFH8Z8HNY1WV7W4SS5/",
       "name": "waimakariri-urban-2013-2014-0.075m",
       "title": "Waimakariri 0.075m Urban Aerial Photos (2013-2014)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/waimakariri-urban-2015-2016-0.075m.json
+++ b/config/tileset/canterbury/imagery/waimakariri-urban-2015-2016-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2015-2016_0-075m_RGBA/01F6P20ANWJDXNWCTHBTK3MJNF",
-      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2015-2016_0-075m_RGBA/01ED83QD75BDF3D46932B3ZKZD",
+      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2015-2016_0-075m_RGBA/01F6P20ANWJDXNWCTHBTK3MJNF/",
+      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2015-2016_0-075m_RGBA/01ED83QD75BDF3D46932B3ZKZD/",
       "name": "waimakariri-urban-2015-2016-0.075m",
       "title": "Waimakariri 0.075m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/waimakariri-urban-2021-0.05m.json
+++ b/config/tileset/canterbury/imagery/waimakariri-urban-2021-0.05m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2021_0-05m_RGB/01FKHMHNJ130J9DF3J9CSYZ41V",
-      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2021_0-05m_RGB/01FKHMK3VK9GRFB762B8JW33HW",
+      "2193": "s3://linz-basemaps/2193/waimakariri_urban_2021_0-05m_RGB/01FKHMHNJ130J9DF3J9CSYZ41V/",
+      "3857": "s3://linz-basemaps/3857/waimakariri_urban_2021_0-05m_RGB/01FKHMK3VK9GRFB762B8JW33HW/",
       "name": "waimakariri-urban-2021-0.05m",
       "title": "Waimakariri 0.05m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/waimate-urban-2018-0.075m.json
+++ b/config/tileset/canterbury/imagery/waimate-urban-2018-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waimate_urban_2018_0-075m_RGB/01F6P20H4Y55WG0SW5RXNP6Y9J",
-      "3857": "s3://linz-basemaps/3857/waimate_urban_2018_0-075m_RGB/01ESF5HA3BXN5E50Z0608KJGTG",
+      "2193": "s3://linz-basemaps/2193/waimate_urban_2018_0-075m_RGB/01F6P20H4Y55WG0SW5RXNP6Y9J/",
+      "3857": "s3://linz-basemaps/3857/waimate_urban_2018_0-075m_RGB/01ESF5HA3BXN5E50Z0608KJGTG/",
       "name": "waimate-urban-2018-0.075m",
       "title": "Waimate 0.075m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/canterbury/imagery/waimate-urban-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/waimate-urban-2020-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waimate_urban_2020_0-075m_RGB/01FJB8FDBCP2R3VT7TJC1NWGFD",
-      "3857": "s3://linz-basemaps/3857/waimate_urban_2020_0-075m_RGB/01FJB8KPXHR48ZVDHE7M9PK6RH",
+      "2193": "s3://linz-basemaps/2193/waimate_urban_2020_0-075m_RGB/01FJB8FDBCP2R3VT7TJC1NWGFD/",
+      "3857": "s3://linz-basemaps/3857/waimate_urban_2020_0-075m_RGB/01FJB8KPXHR48ZVDHE7M9PK6RH/",
       "name": "waimate-urban-2020-0.075m",
       "title": "Waimate 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/event.cyclonegabrielle.json
+++ b/config/tileset/event.cyclonegabrielle.json
@@ -6,39 +6,39 @@
   "background": "dce9edff",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gebco_2021_Nztm2000Quad_305-75m/01G14ZABTXES5EEVZJQ0CJAX5N",
-      "3857": "s3://linz-basemaps/3857/gebco_2021_305-75m/01G1735WKA6J8M24914Y16MSWY",
+      "2193": "s3://linz-basemaps/2193/gebco_2021_Nztm2000Quad_305-75m/01G14ZABTXES5EEVZJQ0CJAX5N/",
+      "3857": "s3://linz-basemaps/3857/gebco_2021_305-75m/01G1735WKA6J8M24914Y16MSWY/",
       "name": "gebco_2021_305-75m",
       "maxZoom": 15,
       "title": "GEBCO Gridded Bathymetry (2021)",
       "category": "Bathymetry"
     },
     {
-      "2193": "s3://linz-basemaps/2193/north-island_2023_10m/01GV1YW3PFVAD8089Q96W69WYT",
-      "3857": "s3://linz-basemaps/3857/north-island_2023_10m/01GV1YWSQ3V9F2ZQ7KYCT6VR72",
+      "2193": "s3://linz-basemaps/2193/north-island_2023_10m/01GV1YW3PFVAD8089Q96W69WYT/",
+      "3857": "s3://linz-basemaps/3857/north-island_2023_10m/01GV1YWSQ3V9F2ZQ7KYCT6VR72/",
       "name": "north-island_2023_10m",
       "title": "Cyclone Gabrielle North Island 10m Satellite Imagery (18-21 February 2023)",
       "category": "Event"
     },
     {
-      "2193": "s3://linz-basemaps/2193/north-island_2023_0.5m/01GW39PB2ZMJ5KADZSSP860WRS",
-      "3857": "s3://linz-basemaps/3857/north-island_2023_0.5m/01GW39S72PRNYN6MRRWF83T82E",
+      "2193": "s3://linz-basemaps/2193/north-island_2023_0.5m/01GW39PB2ZMJ5KADZSSP860WRS/",
+      "3857": "s3://linz-basemaps/3857/north-island_2023_0.5m/01GW39S72PRNYN6MRRWF83T82E/",
       "name": "north-island_2023_0.5m",
       "title": "Cyclone Gabrielle North Island 0.5m Satellite Imagery (21 February 2023 - 8 March 2023)",
       "minZoom": 10,
       "category": "Event"
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne-cyclone-gabrielle_2023_0.2m/01HB78D84QQPQKZH8V22C754GB",
-      "3857": "s3://linz-basemaps/3857/gisborne-cyclone-gabrielle_2023_0.2m/01HB78D862TBKEF4ZQTK6BFS51",
+      "2193": "s3://linz-basemaps/2193/gisborne-cyclone-gabrielle_2023_0.2m/01HB78D84QQPQKZH8V22C754GB/",
+      "3857": "s3://linz-basemaps/3857/gisborne-cyclone-gabrielle_2023_0.2m/01HB78D862TBKEF4ZQTK6BFS51/",
       "name": "gisborne-cyclone-gabrielle-2023-0.2m",
       "title": "Cyclone Gabrielle Gisborne 0.2m Aerial Photos (20 February 2023 - 17 May 2023)",
       "minZoom": 12,
       "category": "Event"
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2M1MDGF1WQK198M68HS2N",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2Q6YCZ67HAAAYRTVHGANY",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2M1MDGF1WQK198M68HS2N/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2Q6YCZ67HAAAYRTVHGANY/",
       "name": "hawkes-bay-cyclone-gabrielle_2023_0.1m",
       "title": "Cyclone Gabrielle Hawke's Bay 0.1m Aerial Photos (19-21 February 2023)",
       "minZoom": 12,

--- a/config/tileset/gisborne/imagery/gisborne-2022-2023-0.1m.json
+++ b/config/tileset/gisborne/imagery/gisborne-2022-2023-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_2022-2023_0.1m/01GWGH1WFBNG4WFSFVR2XK316S",
-      "3857": "s3://linz-basemaps/3857/gisborne_2022-2023_0.1m/01GWGH2ED4XWY7TB96Q397FBJB",
+      "2193": "s3://linz-basemaps/2193/gisborne_2022-2023_0.1m/01GWGH1WFBNG4WFSFVR2XK316S/",
+      "3857": "s3://linz-basemaps/3857/gisborne_2022-2023_0.1m/01GWGH2ED4XWY7TB96Q397FBJB/",
       "name": "gisborne-2022-2023-0.1m",
       "title": "Gisborne 0.1m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/gisborne/imagery/gisborne-bay-of-plenty-sn5766-1980-0.375m.json
+++ b/config/tileset/gisborne/imagery/gisborne-bay-of-plenty-sn5766-1980-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_bay-of-plenty_sn5766_1980_0.375m/01H8JBJGCHGBVEFDC7FEBN87G2",
-      "3857": "s3://linz-basemaps/3857/gisborne_bay-of-plenty_sn5766_1980_0.375m/01H8JBJHFMQJ1R8H6MFB1M27GE",
+      "2193": "s3://linz-basemaps/2193/gisborne_bay-of-plenty_sn5766_1980_0.375m/01H8JBJGCHGBVEFDC7FEBN87G2/",
+      "3857": "s3://linz-basemaps/3857/gisborne_bay-of-plenty_sn5766_1980_0.375m/01H8JBJHFMQJ1R8H6MFB1M27GE/",
       "name": "gisborne-bay-of-plenty-sn5766-1980-0.375m",
       "title": "Gisborne / Bay of Plenty 0.375m SN5766 (1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/gisborne/imagery/gisborne-rural-2012-2013-0.4m.json
+++ b/config/tileset/gisborne/imagery/gisborne-rural-2012-2013-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_rural_2012-2013_0-40m_RGBA/01F6P153BFK34RSZZWPX9PRKS8",
-      "3857": "s3://linz-basemaps/3857/gisborne_rural_2012-2013_0-40m_RGBA/01EDMTSQF19FQB09MS46ZFWWRM",
+      "2193": "s3://linz-basemaps/2193/gisborne_rural_2012-2013_0-40m_RGBA/01F6P153BFK34RSZZWPX9PRKS8/",
+      "3857": "s3://linz-basemaps/3857/gisborne_rural_2012-2013_0-40m_RGBA/01EDMTSQF19FQB09MS46ZFWWRM/",
       "name": "gisborne-rural-2012-2013-0.4m",
       "title": "Gisborne 0.4m Rural Aerial Photos (2012-2013)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/gisborne/imagery/gisborne-sn12540-1998-0.75m.json
+++ b/config/tileset/gisborne/imagery/gisborne-sn12540-1998-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn12540_1998_0.75m/01H8JBJHVQAF1HE6R5A04TFFRY",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn12540_1998_0.75m/01H8JBJT1Y4PZRYX8PQ989SVAE",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn12540_1998_0.75m/01H8JBJHVQAF1HE6R5A04TFFRY/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn12540_1998_0.75m/01H8JBJT1Y4PZRYX8PQ989SVAE/",
       "name": "gisborne-sn12540-1998-0.75m",
       "title": "Gisborne 0.75m SN12540 (1998)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/gisborne/imagery/gisborne-sn8132-1982-0.375m.json
+++ b/config/tileset/gisborne/imagery/gisborne-sn8132-1982-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn8132_1982_0.375m/01H8JBKYPK82BBH2P41B34H5F4",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn8132_1982_0.375m/01H8JBMB01PDKG4D7HMDTNBD26",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn8132_1982_0.375m/01H8JBKYPK82BBH2P41B34H5F4/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn8132_1982_0.375m/01H8JBMB01PDKG4D7HMDTNBD26/",
       "name": "gisborne-sn8132-1982-0.375m",
       "title": "Gisborne 0.375m SN8132 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/gisborne/imagery/gisborne-sn8418-1984-1985-0.375m.json
+++ b/config/tileset/gisborne/imagery/gisborne-sn8418-1984-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn8418_1984-1985_0.375m/01H8JBKVAKXH3N8ZYXM92FJ5T7",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn8418_1984-1985_0.375m/01H8JBMQWQJHPDNM8Z8D3FJ3FP",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn8418_1984-1985_0.375m/01H8JBKVAKXH3N8ZYXM92FJ5T7/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn8418_1984-1985_0.375m/01H8JBMQWQJHPDNM8Z8D3FJ3FP/",
       "name": "gisborne-sn8418-1984-1985-0.375m",
       "title": "Gisborne 0.375m SN8418 (1984-1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/gisborne/imagery/gisborne-sn8538-1985-0.375m.json
+++ b/config/tileset/gisborne/imagery/gisborne-sn8538-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn8538_1985_0.375m/01H8JBNY3YHJN1AZCZ422SKQGG",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn8538_1985_0.375m/01H8JBJZ5GEVZYR73KDZFAZVYQ",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn8538_1985_0.375m/01H8JBNY3YHJN1AZCZ422SKQGG/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn8538_1985_0.375m/01H8JBJZ5GEVZYR73KDZFAZVYQ/",
       "name": "gisborne-sn8538-1985-0.375m",
       "title": "Gisborne 0.375m SN8538 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/gisborne/imagery/gisborne-sn8941-1988-0.15m.json
+++ b/config/tileset/gisborne/imagery/gisborne-sn8941-1988-0.15m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn8941_1988_0.15m/01H8JBKJ08QZFFKDXGHGY0NQXR",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn8941_1988_0.15m/01H8JBKDWSGNWMWKD6S0WK6SEW",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn8941_1988_0.15m/01H8JBKJ08QZFFKDXGHGY0NQXR/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn8941_1988_0.15m/01H8JBKDWSGNWMWKD6S0WK6SEW/",
       "name": "gisborne-sn8941-1988-0.15m",
       "title": "Gisborne 0.15m SN8941 (1988)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/gisborne/imagery/gisborne-snc25046-2000-0.75m.json
+++ b/config/tileset/gisborne/imagery/gisborne-snc25046-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_snc25046_2000_0.75m/01H8JBKX1TYX5KBKAKY35Q3WW1",
-      "3857": "s3://linz-basemaps/3857/gisborne_snc25046_2000_0.75m/01H8JBJZ6HQ7G9QZM3QS2HCTW2",
+      "2193": "s3://linz-basemaps/2193/gisborne_snc25046_2000_0.75m/01H8JBKX1TYX5KBKAKY35Q3WW1/",
+      "3857": "s3://linz-basemaps/3857/gisborne_snc25046_2000_0.75m/01H8JBJZ6HQ7G9QZM3QS2HCTW2/",
       "name": "gisborne-snc25046-2000-0.75m",
       "title": "Gisborne 0.75m SNC25046 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/gisborne/imagery/gisborne-snc8309-1983-0.4m.json
+++ b/config/tileset/gisborne/imagery/gisborne-snc8309-1983-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_snc8309_1983_0.4m/01H8JBQ5DQTYBGE95RN86Z9JFA",
-      "3857": "s3://linz-basemaps/3857/gisborne_snc8309_1983_0.4m/01H8JBPW86YVK5HDAQZZPTZQ4M",
+      "2193": "s3://linz-basemaps/2193/gisborne_snc8309_1983_0.4m/01H8JBQ5DQTYBGE95RN86Z9JFA/",
+      "3857": "s3://linz-basemaps/3857/gisborne_snc8309_1983_0.4m/01H8JBPW86YVK5HDAQZZPTZQ4M/",
       "name": "gisborne-snc8309-1983-0.4m",
       "title": "Gisborne 0.4m SNC8309 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/gisborne/imagery/gisborne-urban-2017-2018-0.1m.json
+++ b/config/tileset/gisborne/imagery/gisborne-urban-2017-2018-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_urban_2017-18_0-1m/01F6P168K626GCA0RY790XHRVY",
-      "3857": "s3://linz-basemaps/3857/gisborne_urban_2017-18_0-1m/01ECTS33A3VYA5A8ZBHCDFYFR8",
+      "2193": "s3://linz-basemaps/2193/gisborne_urban_2017-18_0-1m/01F6P168K626GCA0RY790XHRVY/",
+      "3857": "s3://linz-basemaps/3857/gisborne_urban_2017-18_0-1m/01ECTS33A3VYA5A8ZBHCDFYFR8/",
       "name": "gisborne-urban-2017-2018-0.1m",
       "title": "Gisborne 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/hawkes-bay/imagery/central-hawkes-bay-urban-2017-2018-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/central-hawkes-bay-urban-2017-2018-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/central-hawkes-bay_urban_2017-18_0-1m/01F66EDQC993D73W17EG40HJ2N",
-      "3857": "s3://linz-basemaps/3857/central-hawkes-bay_urban_2017-18_0-1m/01ED823PTAVX9DQ7GE9WBACX8C",
+      "2193": "s3://linz-basemaps/2193/central-hawkes-bay_urban_2017-18_0-1m/01F66EDQC993D73W17EG40HJ2N/",
+      "3857": "s3://linz-basemaps/3857/central-hawkes-bay_urban_2017-18_0-1m/01ED823PTAVX9DQ7GE9WBACX8C/",
       "name": "central-hawkes-bay-urban-2017-2018-0.1m",
       "title": "Central Hawke's Bay 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/hawkes-bay/imagery/hastings-district-urban-2014-2015-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/hastings-district-urban-2014-2015-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hastings-district_urban_2014-2015_0-10m_RGB/01F6P172EQ3JF930CN3XNVVVJ9",
-      "3857": "s3://linz-basemaps/3857/hastings-district_urban_2014-2015_0-10m_RGB/01EDN0YH2TM1B5NWHR4RHGBMPF",
+      "2193": "s3://linz-basemaps/2193/hastings-district_urban_2014-2015_0-10m_RGB/01F6P172EQ3JF930CN3XNVVVJ9/",
+      "3857": "s3://linz-basemaps/3857/hastings-district_urban_2014-2015_0-10m_RGB/01EDN0YH2TM1B5NWHR4RHGBMPF/",
       "name": "hastings-district-urban-2014-2015-0.1m",
       "title": "Hastings District 0.1m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/hawkes-bay/imagery/hastings-district-urban-2017-2018-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/hastings-district-urban-2017-2018-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hastings-district_urban_2017-18_0-1m/01F6P17PSJ1SWNYV2V28922WKY",
-      "3857": "s3://linz-basemaps/3857/hastings-district_urban_2017-18_0-1m/01ED82A7KFS8RMNPRYDQ60MCQ1",
+      "2193": "s3://linz-basemaps/2193/hastings-district_urban_2017-18_0-1m/01F6P17PSJ1SWNYV2V28922WKY/",
+      "3857": "s3://linz-basemaps/3857/hastings-district_urban_2017-18_0-1m/01ED82A7KFS8RMNPRYDQ60MCQ1/",
       "name": "hastings-district-urban-2017-2018-0.1m",
       "title": "Hastings 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-bay-of-plenty-snc50516-2004-0.75m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-bay-of-plenty-snc50516-2004-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/01H8JBKN06SVAZCEQFW1SNKSDK",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/01H8JBQ9TFYJEQX4GYJYZ12XT3",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/01H8JBKN06SVAZCEQFW1SNKSDK/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/01H8JBQ9TFYJEQX4GYJYZ12XT3/",
       "name": "hawkes-bay-bay-of-plenty-snc50516-2004-0.75m",
       "title": "Hawkes Bay / Bay of Plenty 0.75m SNC50516 (2004)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-cyclone-gabrielle-2023-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-cyclone-gabrielle-2023-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Event",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2M1MDGF1WQK198M68HS2N",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2Q6YCZ67HAAAYRTVHGANY",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2M1MDGF1WQK198M68HS2N/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay-cyclone-gabrielle_2023_0.1m/01GTF2Q6YCZ67HAAAYRTVHGANY/",
       "name": "hawkes-bay-cyclone-gabrielle-2023-0.1m",
       "title": "Cyclone Gabrielle Hawke's Bay 0.1m Aerial Photos (19-21 February 2023)",
       "category": "Event",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-manawatu-whanganui-sn5752-1980-0.375m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-manawatu-whanganui-sn5752-1980-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/01H8JBKPPY4936V5SREYAN3AMD",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/01H8JBKQ9B507FW7S4SBDTNASY",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/01H8JBKPPY4936V5SREYAN3AMD/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/01H8JBKQ9B507FW7S4SBDTNASY/",
       "name": "hawkes-bay-manawatu-whanganui-sn5752-1980-0.375m",
       "title": "Hawkes Bay / Manawatū-Whanganui 0.375m SN5752 (1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-manawatu-whanganui-sn5761-1980-0.375m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-manawatu-whanganui-sn5761-1980-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/01H8JBMA16AAPPQQNG0R1PT2YN",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/01H8JBKKDVTE10YT04581P92Z7",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/01H8JBMA16AAPPQQNG0R1PT2YN/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/01H8JBKKDVTE10YT04581P92Z7/",
       "name": "hawkes-bay-manawatu-whanganui-sn5761-1980-0.375m",
       "title": "Hawkes Bay / Manawatū-Whanganui 0.375m SN5761 (1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-manawatu-whanganui-snc30001-2002-0.75m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-manawatu-whanganui-snc30001-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/01H8JBMM4W3P00PG4QP0ZEY9HH",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/01H8JBMAQX8JJT7347NMJS9MZ2",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/01H8JBMM4W3P00PG4QP0ZEY9HH/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/01H8JBMAQX8JJT7347NMJS9MZ2/",
       "name": "hawkes-bay-manawatu-whanganui-snc30001-2002-0.75m",
       "title": "Hawkes Bay / Manawatū-Whanganui 0.75m SNC30001 (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-rural-2014-2015-0.3m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-rural-2014-2015-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2014-2015_0-30m_RGBA/01F6P182DFPVC4HCAKPP42PCWN",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2014-2015_0-30m_RGBA/01ED82B3R581HMXNDS7HP3ATQ2",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2014-2015_0-30m_RGBA/01F6P182DFPVC4HCAKPP42PCWN/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2014-2015_0-30m_RGBA/01ED82B3R581HMXNDS7HP3ATQ2/",
       "name": "hawkes-bay-rural-2014-2015-0.3m",
       "title": "Hawke's Bay 0.3m Rural Aerial Photos (2014-2015)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-rural-2019-2020-0.3m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-rural-2019-2020-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2019-2020_0-3m_RGB/01FC200TCKR7ZTJEN6Q8ZJAET1",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2019-2020_0-3m_RGB/01FC1ZY5V4XCEXDSWT3FE3A8VM",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2019-2020_0-3m_RGB/01FC200TCKR7ZTJEN6Q8ZJAET1/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2019-2020_0-3m_RGB/01FC1ZY5V4XCEXDSWT3FE3A8VM/",
       "name": "hawkes-bay-rural-2019-2020-0.3m",
       "title": "Hawke's Bay 0.3m Rural Aerial Photos (2019-2020)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-sn7786-1989-0.48m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-sn7786-1989-0.48m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn7786_1989_0.48m/01H8JBM09ZBGC0ZFQQTTNPM9F8",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn7786_1989_0.48m/01H8JBPW7Y14X7D1Y4GCT6TCB9",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn7786_1989_0.48m/01H8JBM09ZBGC0ZFQQTTNPM9F8/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn7786_1989_0.48m/01H8JBPW7Y14X7D1Y4GCT6TCB9/",
       "name": "hawkes-bay-sn7786-1989-0.48m",
       "title": "Hawkes Bay 0.48m SN7786 (1989)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-sn8675-1986-0.375m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-sn8675-1986-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn8675_1986_0.375m/01H8JBMB8PT8R97BWH7S9ZNC7Z",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn8675_1986_0.375m/01H8JBNA282DTDKXRG7F2GQR9G",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn8675_1986_0.375m/01H8JBMB8PT8R97BWH7S9ZNC7Z/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn8675_1986_0.375m/01H8JBNA282DTDKXRG7F2GQR9G/",
       "name": "hawkes-bay-sn8675-1986-0.375m",
       "title": "Hawkes Bay 0.375m SN8675 (1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-sn8985-1988-0.4m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-sn8985-1988-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn8985_1988_0.4m/01H8JBPSXPS58QAVBF1MWGZVCD",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn8985_1988_0.4m/01H8JBPK1ZW6GQ1683GG16GANF",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn8985_1988_0.4m/01H8JBPSXPS58QAVBF1MWGZVCD/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn8985_1988_0.4m/01H8JBPK1ZW6GQ1683GG16GANF/",
       "name": "hawkes-bay-sn8985-1988-0.4m",
       "title": "Hawkes Bay 0.4m SN8985 (1988)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9037-1989-0.75m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9037-1989-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9037_1989_0.75m/01H8JBK25GAHVCR7ED1Q66KCTC",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9037_1989_0.75m/01H8JBQKB4QQT956KJ1R736ETR",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9037_1989_0.75m/01H8JBK25GAHVCR7ED1Q66KCTC/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9037_1989_0.75m/01H8JBQKB4QQT956KJ1R736ETR/",
       "name": "hawkes-bay-sn9037-1989-0.75m",
       "title": "Hawkes Bay 0.75m SN9037 (1989)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9410-1995-0.375m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9410-1995-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9410_1995_0.375m/01H8JBM28A986YR4N98Y0Q6154",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9410_1995_0.375m/01H8JBMFKZVRX9XC054HNJGJT1",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9410_1995_0.375m/01H8JBM28A986YR4N98Y0Q6154/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9410_1995_0.375m/01H8JBMFKZVRX9XC054HNJGJT1/",
       "name": "hawkes-bay-sn9410-1995-0.375m",
       "title": "Hawkes Bay 0.375m SN9410 (1995)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9452-1995-0.375m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9452-1995-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9452_1995_0.375m/01H8JBMYT5D7Y3XD2Y9C5QRZ2H",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9452_1995_0.375m/01H8JBPGB4AD3T2TCDN76XRT0N",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9452_1995_0.375m/01H8JBMYT5D7Y3XD2Y9C5QRZ2H/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9452_1995_0.375m/01H8JBPGB4AD3T2TCDN76XRT0N/",
       "name": "hawkes-bay-sn9452-1995-0.375m",
       "title": "Hawkes Bay 0.375m SN9452 (1995)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9485-1995-1996-0.375m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9485-1995-1996-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9485_1995-1996_0.375m/01H8JC5ZE7QNEYW5AJ16KJ9X11",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9485_1995-1996_0.375m/01H8JC5YM30GA0P6GWPFEJ34JJ",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9485_1995-1996_0.375m/01H8JC5ZE7QNEYW5AJ16KJ9X11/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9485_1995-1996_0.375m/01H8JC5YM30GA0P6GWPFEJ34JJ/",
       "name": "hawkes-bay-sn9485-1995-1996-0.375m",
       "title": "Hawkes Bay 0.375m SN9485 (1995-1996)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9585-1996-0.8m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-sn9585-1996-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9585_1996_0.8m/01H8JBK7T3F25XJKQ5TB701QBZ",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9585_1996_0.8m/01H8JBKT1MKG1JP8ZBCNZ4C35E",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9585_1996_0.8m/01H8JBK7T3F25XJKQ5TB701QBZ/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9585_1996_0.8m/01H8JBKT1MKG1JP8ZBCNZ4C35E/",
       "name": "hawkes-bay-sn9585-1996-0.8m",
       "title": "Hawkes Bay 0.8m SN9585 (1996)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50126-2003-0.6m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50126-2003-0.6m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50126_2003_0.6m/01H8JBPXD5E69MHD4J6QHPARQC",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50126_2003_0.6m/01H8JBNMRFFZZ10ARPDAR5P8X3",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50126_2003_0.6m/01H8JBPXD5E69MHD4J6QHPARQC/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50126_2003_0.6m/01H8JBNMRFFZZ10ARPDAR5P8X3/",
       "name": "hawkes-bay-snc50126-2003-0.6m",
       "title": "Hawkes Bay 0.6m SNC50126 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50450-2004-0.75m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50450-2004-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50450_2004_0.75m/01H8JBR00MW41YJ63BDMD1SXC4",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50450_2004_0.75m/01H8JBR00G7XHWM8873KN5VEJ5",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50450_2004_0.75m/01H8JBR00MW41YJ63BDMD1SXC4/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50450_2004_0.75m/01H8JBR00G7XHWM8873KN5VEJ5/",
       "name": "hawkes-bay-snc50450-2004-0.75m",
       "title": "Hawkes Bay 0.75m SNC50450 (2004)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50518-2004-0.75m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50518-2004-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50518_2004_0.75m/01H8MV0MDAA9ZD73NQS05SMH0S",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50518_2004_0.75m/01H8MV0MDCF8R48ENH8N0RYC19",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50518_2004_0.75m/01H8MV0MDAA9ZD73NQS05SMH0S/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50518_2004_0.75m/01H8MV0MDCF8R48ENH8N0RYC19/",
       "name": "hawkes-bay-snc50518-2004-0.75m",
       "title": "Hawkes Bay 0.75m SNC50518 (2004)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50519-2004-0.64m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50519-2004-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50519_2004_0.64m/01H8JBR017XD3ARJND2K3RD6V9",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50519_2004_0.64m/01H8JBR00NGJSXE3DYYMCW821W",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50519_2004_0.64m/01H8JBR017XD3ARJND2K3RD6V9/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50519_2004_0.64m/01H8JBR00NGJSXE3DYYMCW821W/",
       "name": "hawkes-bay-snc50519-2004-0.64m",
       "title": "Hawkes Bay 0.64m SNC50519 (2004)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50520-2004-0.64m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-snc50520-2004-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50520_2004_0.64m/01H8JBNBRE160A817HZQAPAFHG",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50520_2004_0.64m/01H8JBMG47BG6N1JYB346RABFZ",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50520_2004_0.64m/01H8JBNBRE160A817HZQAPAFHG/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50520_2004_0.64m/01H8JBMG47BG6N1JYB346RABFZ/",
       "name": "hawkes-bay-snc50520-2004-0.64m",
       "title": "Hawkes Bay 0.64m SNC50520 (2004)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-snc8912-1987-0.375m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-snc8912-1987-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc8912_1987_0.375m/01H8JBP1T9J9V7Z8KQ00CWKR66",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc8912_1987_0.375m/01H8JBP1SY9HKM1NWZJDF0R8NB",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc8912_1987_0.375m/01H8JBP1T9J9V7Z8KQ00CWKR66/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc8912_1987_0.375m/01H8JBP1SY9HKM1NWZJDF0R8NB/",
       "name": "hawkes-bay-snc8912-1987-0.375m",
       "title": "Hawkes Bay 0.375m SNC8912 (1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-waikato-sn8260-1983-0.75m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-waikato-sn8260-1983-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_waikato_sn8260_1983_0.75m/01H8JBNY5KSE63QJD65AZB08G5",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_waikato_sn8260_1983_0.75m/01H8JBP6KZTJF747759825FVZF",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_waikato_sn8260_1983_0.75m/01H8JBNY5KSE63QJD65AZB08G5/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_waikato_sn8260_1983_0.75m/01H8JBP6KZTJF747759825FVZF/",
       "name": "hawkes-bay-waikato-sn8260-1983-0.75m",
       "title": "Hawkes Bay / Waikato 0.75m SN8260 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/hawkes-bay/imagery/napier-city-urban-2017-2018-0.05m.json
+++ b/config/tileset/hawkes-bay/imagery/napier-city-urban-2017-2018-0.05m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-05m/01F6P1F7BT85M2T5S01FXWAPPD",
-      "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-05m/01ED82S7R88B0CGQWZKH4V7R2H",
+      "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-05m/01F6P1F7BT85M2T5S01FXWAPPD/",
+      "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-05m/01ED82S7R88B0CGQWZKH4V7R2H/",
       "name": "napier-city-urban-2017-2018-0.05m",
       "title": "Napier 0.05m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/hawkes-bay/imagery/napier-city-urban-2017-2018-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/napier-city-urban-2017-2018-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-1m/01F6P1FCJZWD8JY7DJEDEB45K7",
-      "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-1m/01ED82SKPVV12M4RYHRK08DWG4",
+      "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-1m/01F6P1FCJZWD8JY7DJEDEB45K7/",
+      "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-1m/01ED82SKPVV12M4RYHRK08DWG4/",
       "name": "napier-city-urban-2017-2018-0.1m",
       "title": "Napier 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/hawkes-bay/imagery/wairoa-urban-2014-2015-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/wairoa-urban-2014-2015-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wairoa_urban_2014-2015_0-10m_RGBA/01F6P20PT6TN7XVJGPSA7NPQ93",
-      "3857": "s3://linz-basemaps/3857/wairoa_urban_2014-2015_0-10m_RGBA/01ED83R64ZX665P14R805CJVE2",
+      "2193": "s3://linz-basemaps/2193/wairoa_urban_2014-2015_0-10m_RGBA/01F6P20PT6TN7XVJGPSA7NPQ93/",
+      "3857": "s3://linz-basemaps/3857/wairoa_urban_2014-2015_0-10m_RGBA/01ED83R64ZX665P14R805CJVE2/",
       "name": "wairoa-urban-2014-2015-0.1m",
       "title": "Wairoa 0.1m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/health.json
+++ b/config/tileset/health.json
@@ -5,16 +5,16 @@
   "background": "dce9edff",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/gebco_2020_Nztm2000Quad_305-75m/01F1BFJN8R8P7BXN3XTHC5MT5G",
-      "3857": "s3://linz-basemaps/3857/gebco_2020_305-75m/01EDMTM3P563P06TWYQAZRA9F6",
+      "2193": "s3://linz-basemaps/2193/gebco_2020_Nztm2000Quad_305-75m/01F1BFJN8R8P7BXN3XTHC5MT5G/",
+      "3857": "s3://linz-basemaps/3857/gebco_2020_305-75m/01EDMTM3P563P06TWYQAZRA9F6/",
       "name": "gebco_2020_305-75m",
       "title": "GEBCO Gridded Bathymetry (2020)",
       "category": "Bathymetry",
       "maxZoom": 15
     },
     {
-      "2193": "s3://linz-basemaps/2193/new_zealand_sentinel_2019-2020_10m/01F6P1G0S78XYXAQB7Y375MZ2Q",
-      "3857": "s3://linz-basemaps/3857/new_zealand_sentinel_2019-2020_10m/01ED82TFB1ZE9C75CH5VY3Z92B",
+      "2193": "s3://linz-basemaps/2193/new_zealand_sentinel_2019-2020_10m/01F6P1G0S78XYXAQB7Y375MZ2Q/",
+      "3857": "s3://linz-basemaps/3857/new_zealand_sentinel_2019-2020_10m/01ED82TFB1ZE9C75CH5VY3Z92B/",
       "name": "new_zealand_sentinel_2019-2020_10m",
       "title": "New Zealand 10m Satellite Imagery (2019-2020)",
       "category": "Satellite Imagery"

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-hawkes-bay-sn12541-1999-0.75m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-hawkes-bay-sn12541-1999-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/01H8JBKR3C1Y5HFCZPTN4E1Y7Y",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/01H8JBMA78JZY4HJSD2NZKYMGX",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/01H8JBKR3C1Y5HFCZPTN4E1Y7Y/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/01H8JBMA78JZY4HJSD2NZKYMGX/",
       "name": "manawatu-whanganui-hawkes-bay-sn12541-1999-0.75m",
       "title": "Manawatū-Whanganui / Hawkes Bay 0.75m SN12541 (1999)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-hawkes-bay-snc50517-2003-0.75m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-hawkes-bay-snc50517-2003-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/01H8JBNK0RZDSHW1TABKEM48S8",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/01H8JBPD36YC935ZHJ8S581560",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/01H8JBNK0RZDSHW1TABKEM48S8/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/01H8JBPD36YC935ZHJ8S581560/",
       "name": "manawatu-whanganui-hawkes-bay-snc50517-2003-0.75m",
       "title": "Manawatū-Whanganui / Hawkes Bay 0.75m SNC50517 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-rural-2015-2016-0.3m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-rural-2015-2016-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2015-16_0-3m/01F6P1B7SH0X2FETDDT3RWT9Q9",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2015-16_0-3m/01ED82HKA5T8V6S1KZ4WN9EFNN",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2015-16_0-3m/01F6P1B7SH0X2FETDDT3RWT9Q9/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2015-16_0-3m/01ED82HKA5T8V6S1KZ4WN9EFNN/",
       "name": "manawatu-whanganui-rural-2015-2016-0.3m",
       "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-rural-2016-2017-0.3m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-rural-2016-2017-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2016-17_0-3m/01F6P1BSQ6V27WZK0KM56M4Z1C",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2016-17_0-3m/01ED82JQASJDFZ6XEM018RJQN0",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2016-17_0-3m/01F6P1BSQ6V27WZK0KM56M4Z1C/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2016-17_0-3m/01ED82JQASJDFZ6XEM018RJQN0/",
       "name": "manawatu-whanganui-rural-2016-2017-0.3m",
       "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn25017-2000-0.64m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn25017-2000-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn25017_2000_0.64m/01H8JBMCS9XZNYH6HWYFGZMAGT",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn25017_2000_0.64m/01H8JBN0TNYFAQ104YWNHBKZDA",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn25017_2000_0.64m/01H8JBMCS9XZNYH6HWYFGZMAGT/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn25017_2000_0.64m/01H8JBN0TNYFAQ104YWNHBKZDA/",
       "name": "manawatu-whanganui-sn25017-2000-0.64m",
       "title": "Manawatū-Whanganui 0.64m SN25017 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn5291-1978-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn5291-1978-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn5291_1978_0.375m/01H8JBNX51M2HYCJBB951MXD1V",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn5291_1978_0.375m/01H8JBPXFP8803NS5P9JT4Q6R7",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn5291_1978_0.375m/01H8JBNX51M2HYCJBB951MXD1V/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn5291_1978_0.375m/01H8JBPXFP8803NS5P9JT4Q6R7/",
       "name": "manawatu-whanganui-sn5291-1978-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN5291 (1978)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn5408-1979-1980-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn5408-1979-1980-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn5408_1979-1980_0.375m/01H8JBN7ZAXNNC4WK1P7ZQBJMM",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn5408_1979-1980_0.375m/01H8JBNGNNFY6NHKPW46811CR9",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn5408_1979-1980_0.375m/01H8JBN7ZAXNNC4WK1P7ZQBJMM/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn5408_1979-1980_0.375m/01H8JBNGNNFY6NHKPW46811CR9/",
       "name": "manawatu-whanganui-sn5408-1979-1980-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN5408 (1979-1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn8005-1982-0.8m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn8005-1982-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8005_1982_0.8m/01H8JCTHB228DJATCH790BHK9T",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8005_1982_0.8m/01H8JCQ5MRMF08HAJFVF5ES0ZC",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8005_1982_0.8m/01H8JCTHB228DJATCH790BHK9T/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8005_1982_0.8m/01H8JCQ5MRMF08HAJFVF5ES0ZC/",
       "name": "manawatu-whanganui-sn8005-1982-0.8m",
       "title": "Manawatū-Whanganui 0.8m SN8005 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn8158-1983-0.4m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn8158-1983-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8158_1983_0.4m/01H8JDDC4Y6N93CJBDMS1W8AQY",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8158_1983_0.4m/01H8JDCVX3HF901K5Y3YXPB9VE",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8158_1983_0.4m/01H8JDDC4Y6N93CJBDMS1W8AQY/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8158_1983_0.4m/01H8JDCVX3HF901K5Y3YXPB9VE/",
       "name": "manawatu-whanganui-sn8158-1983-0.4m",
       "title": "Manawatū-Whanganui 0.4m SN8158 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn8303-1984-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn8303-1984-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8303_1984_0.375m/01H8JDCMV0P03ZF0NCJY719C66",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8303_1984_0.375m/01H8JDC2VS4K2NXVPM6SKRQ9N9",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8303_1984_0.375m/01H8JDCMV0P03ZF0NCJY719C66/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8303_1984_0.375m/01H8JDC2VS4K2NXVPM6SKRQ9N9/",
       "name": "manawatu-whanganui-sn8303-1984-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN8303 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn8316-1984-0.4m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn8316-1984-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8316_1984_0.4m/01H8JEE1FCF7NGVTV01XTD2XE0",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8316_1984_0.4m/01H8JE9M5SR7Z1PSH9JGFCN48V",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8316_1984_0.4m/01H8JEE1FCF7NGVTV01XTD2XE0/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8316_1984_0.4m/01H8JE9M5SR7Z1PSH9JGFCN48V/",
       "name": "manawatu-whanganui-sn8316-1984-0.4m",
       "title": "Manawatū-Whanganui 0.4m SN8316 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn9158-1991-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn9158-1991-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9158_1991_0.375m/01H8JF29R6S2NT7QXNC7GK90D4",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9158_1991_0.375m/01H8JF2RZ225TJG7FPACV6DVRC",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9158_1991_0.375m/01H8JF29R6S2NT7QXNC7GK90D4/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9158_1991_0.375m/01H8JF2RZ225TJG7FPACV6DVRC/",
       "name": "manawatu-whanganui-sn9158-1991-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN9158 (1991)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn9364-1994-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn9364-1994-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9364_1994_0.375m/01H8JFAZB78MTYS53MT1ZN15V3",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9364_1994_0.375m/01H8JFCRKVN7X0NYQRX0XF8B1B",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9364_1994_0.375m/01H8JFAZB78MTYS53MT1ZN15V3/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9364_1994_0.375m/01H8JFCRKVN7X0NYQRX0XF8B1B/",
       "name": "manawatu-whanganui-sn9364-1994-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN9364 (1994)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn9470-1995-1996-0.8m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-sn9470-1995-1996-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9470_1995-1996_0.8m/01H8JFKD1R3RE5Y81YNA2VJSMB",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9470_1995-1996_0.8m/01H8JFKD2GA5NA444DRQXF0SER",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9470_1995-1996_0.8m/01H8JFKD1R3RE5Y81YNA2VJSMB/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9470_1995-1996_0.8m/01H8JFKD2GA5NA444DRQXF0SER/",
       "name": "manawatu-whanganui-sn9470-1995-1996-0.8m",
       "title": "Manawatū-Whanganui 0.8m SN9470 (1995-1996)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc12781-2003-0.75m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc12781-2003-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc12781_2003_0.75m/01H8JKV9PKGEG5ZPRR51S0P4MW",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc12781_2003_0.75m/01H8JFS8AZJB4Z7F6MBQEC46TG",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc12781_2003_0.75m/01H8JKV9PKGEG5ZPRR51S0P4MW/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc12781_2003_0.75m/01H8JFS8AZJB4Z7F6MBQEC46TG/",
       "name": "manawatu-whanganui-snc12781-2003-0.75m",
       "title": "Manawatū-Whanganui 0.75m SNC12781 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc25045-2001-0.75m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc25045-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc25045_2001_0.75m/01H8JFW5DY2CMJAHYEV3MN4SQY",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc25045_2001_0.75m/01H8JFTW8BBZBR3MQA5XZTTP7G",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc25045_2001_0.75m/01H8JFW5DY2CMJAHYEV3MN4SQY/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc25045_2001_0.75m/01H8JFTW8BBZBR3MQA5XZTTP7G/",
       "name": "manawatu-whanganui-snc25045-2001-0.75m",
       "title": "Manawatū-Whanganui 0.75m SNC25045 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc25061-2001-0.75m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc25061-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc25061_2001_0.75m/01H8JFWM82K3F0YKSFDBB7DTWH",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc25061_2001_0.75m/01H8JJWNQ32F3VY5BF8Q5HQ4JF",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc25061_2001_0.75m/01H8JFWM82K3F0YKSFDBB7DTWH/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc25061_2001_0.75m/01H8JJWNQ32F3VY5BF8Q5HQ4JF/",
       "name": "manawatu-whanganui-snc25061-2001-0.75m",
       "title": "Manawatū-Whanganui 0.75m SNC25061 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc8650-1986-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc8650-1986-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc8650_1986_0.375m/01H8JG3AAJ1J6FX57XQ8Y8BR1Q",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc8650_1986_0.375m/01H8JG4FBX9EYNTED3FC4R055A",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc8650_1986_0.375m/01H8JG3AAJ1J6FX57XQ8Y8BR1Q/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc8650_1986_0.375m/01H8JG4FBX9EYNTED3FC4R055A/",
       "name": "manawatu-whanganui-snc8650-1986-0.375m",
       "title": "Manawatū-Whanganui 0.375m SNC8650 (1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc8914-1988-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-snc8914-1988-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc8914_1988_0.375m/01H8JG2MP81PQ6HXQNPGY0X1AS",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc8914_1988_0.375m/01H8JG2MPKDEK3VJW32W5Y8HWD",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc8914_1988_0.375m/01H8JG2MP81PQ6HXQNPGY0X1AS/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc8914_1988_0.375m/01H8JG2MPKDEK3VJW32W5Y8HWD/",
       "name": "manawatu-whanganui-snc8914-1988-0.375m",
       "title": "Manawatū-Whanganui 0.375m SNC8914 (1988)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-taranaki-sn8004-1982-0.75m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-taranaki-sn8004-1982-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8004_1982_0.75m/01H8JG6Q5XMF7FCFJHSMFGKJ8K",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8004_1982_0.75m/01H8JG6Q6K867J9PAQR428N7B1",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8004_1982_0.75m/01H8JG6Q5XMF7FCFJHSMFGKJ8K/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8004_1982_0.75m/01H8JG6Q6K867J9PAQR428N7B1/",
       "name": "manawatu-whanganui-taranaki-sn8004-1982-0.75m",
       "title": "Manawatū-Whanganui / Taranaki 0.75m SN8004 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-taranaki-sn8157-1983-0.8m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-taranaki-sn8157-1983-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8157_1983_0.8m/01H8JG8C43ZJTKJZPCERH1APXT",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8157_1983_0.8m/01H8JG8C3D1HMPPEN2CNH73AGR",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8157_1983_0.8m/01H8JG8C43ZJTKJZPCERH1APXT/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8157_1983_0.8m/01H8JG8C3D1HMPPEN2CNH73AGR/",
       "name": "manawatu-whanganui-taranaki-sn8157-1983-0.8m",
       "title": "Manawatū-Whanganui / Taranaki 0.8m SN8157 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-taranaki-sn8549-1985-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-taranaki-sn8549-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8549_1985_0.375m/01H8JG8D1K07560HVP17ZXSXTE",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8549_1985_0.375m/01H8JG8D19RGGBDYAKW9G3VFBB",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8549_1985_0.375m/01H8JG8D1K07560HVP17ZXSXTE/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8549_1985_0.375m/01H8JG8D19RGGBDYAKW9G3VFBB/",
       "name": "manawatu-whanganui-taranaki-sn8549-1985-0.375m",
       "title": "Manawatū-Whanganui / Taranaki 0.375m SN8549 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-taranaki-sn8686-1986-1987-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-taranaki-sn8686-1986-1987-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/01H8JG98DTM7NKR76E6RQ6YE7V",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/01H8JG97G7QTEYTM0HZRYRE90M",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/01H8JG98DTM7NKR76E6RQ6YE7V/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/01H8JG97G7QTEYTM0HZRYRE90M/",
       "name": "manawatu-whanganui-taranaki-sn8686-1986-1987-0.375m",
       "title": "Manawatū-Whanganui / Taranaki 0.375m SN8686 (1986-1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-waikato-sn8440-1984-1985-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-waikato-sn8440-1984-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/01H8JG9BFVAQK5P689CDRZJ80R",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/01H8JG9BFDNPF1ZPYS43FWSJEB",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/01H8JG9BFVAQK5P689CDRZJ80R/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/01H8JG9BFDNPF1ZPYS43FWSJEB/",
       "name": "manawatu-whanganui-waikato-sn8440-1984-1985-0.375m",
       "title": "Manawatū-Whanganui / Waikato 0.375m SN8440 (1984-1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-wellington-sn5310-1978-1979-0.375m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-wellington-sn5310-1978-1979-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/01H8JGYX7CBZQ9XFH1TTED6FJH",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/01H8JGN7RMHWC6716JPE7CJ1HR",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/01H8JGYX7CBZQ9XFH1TTED6FJH/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/01H8JGN7RMHWC6716JPE7CJ1HR/",
       "name": "manawatu-whanganui-wellington-sn5310-1978-1979-0.375m",
       "title": "Manawatū-Whanganui / Wellington 0.375m SN5310 (1978-1979)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-wellington-sn9284-1993-0.75m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-wellington-sn9284-1993-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn9284_1993_0.75m/01H8JGPGS61J0G5TFZFM1TYWRW",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn9284_1993_0.75m/01H8JGPFTVHYD30R3T8X677PKE",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn9284_1993_0.75m/01H8JGPGS61J0G5TFZFM1TYWRW/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn9284_1993_0.75m/01H8JGPFTVHYD30R3T8X677PKE/",
       "name": "manawatu-whanganui-wellington-sn9284-1993-0.75m",
       "title": "Manawatū-Whanganui / Wellington 0.75m SN9284 (1993)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-wellington-sn9911-2000-0.75m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-wellington-sn9911-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn9911_2000_0.75m/01H8JGVP963WRWJJAYFRG99JDF",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn9911_2000_0.75m/01H8JGVP851KTQGN72MFYC4MEH",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn9911_2000_0.75m/01H8JGVP963WRWJJAYFRG99JDF/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn9911_2000_0.75m/01H8JGVP851KTQGN72MFYC4MEH/",
       "name": "manawatu-whanganui-wellington-sn9911-2000-0.75m",
       "title": "Manawatū-Whanganui / Wellington 0.75m SN9911 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/manawatu-whanganui/imagery/palmerston-north-city-urban-2014-2015-0.125m.json
+++ b/config/tileset/manawatu-whanganui/imagery/palmerston-north-city-urban-2014-2015-0.125m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/palmerston-north-city_urban_2014-15_0-125m/01F6P1P22165F058BN82D3ZY8Q",
-      "3857": "s3://linz-basemaps/3857/palmerston-north-city_urban_2014-15_0-125m/01ED8346J2H15Z24G6P9SZ7S0P",
+      "2193": "s3://linz-basemaps/2193/palmerston-north-city_urban_2014-15_0-125m/01F6P1P22165F058BN82D3ZY8Q/",
+      "3857": "s3://linz-basemaps/3857/palmerston-north-city_urban_2014-15_0-125m/01ED8346J2H15Z24G6P9SZ7S0P/",
       "name": "palmerston-north-city-urban-2014-2015-0.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2015)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/manawatu-whanganui/imagery/palmerston-north-urban-2016-2017-1.125m.json
+++ b/config/tileset/manawatu-whanganui/imagery/palmerston-north-urban-2016-2017-1.125m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2016-17_1-125m/01F6P1P8H7KNRQQR0ADDKQRJ6S",
-      "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2016-17_1-125m/01ED833N7FD05YRW6ZR5799SAZ",
+      "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2016-17_1-125m/01F6P1P8H7KNRQQR0ADDKQRJ6S/",
+      "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2016-17_1-125m/01ED833N7FD05YRW6ZR5799SAZ/",
       "name": "palmerston-north-urban-2016-2017-1.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/manawatu-whanganui/imagery/palmerston-north-urban-2018-2019-0.125m.json
+++ b/config/tileset/manawatu-whanganui/imagery/palmerston-north-urban-2018-2019-0.125m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2018-2019_0-125m_RGB/01F6P1PF375AH4BPQ9PTQA7GYD",
-      "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2018-2019_0-125m_RGB/01ESF5MHFP5RCKQW94Z2947CES",
+      "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2018-2019_0-125m_RGB/01F6P1PF375AH4BPQ9PTQA7GYD/",
+      "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2018-2019_0-125m_RGB/01ESF5MHFP5RCKQW94Z2947CES/",
       "name": "palmerston-north-urban-2018-2019-0.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/manawatu-whanganui/imagery/whanganui-urban-2015-2016-0.1m.json
+++ b/config/tileset/manawatu-whanganui/imagery/whanganui-urban-2015-2016-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/whanganui_urban_2015-16_0-1m/01F63WK62MCAAH3Q1RQ21EGHJ1",
-      "3857": "s3://linz-basemaps/3857/whanganui_urban_2015-16_0-1m/01ED83WV5VV20JWAP0MT3D7W4W",
+      "2193": "s3://linz-basemaps/2193/whanganui_urban_2015-16_0-1m/01F63WK62MCAAH3Q1RQ21EGHJ1/",
+      "3857": "s3://linz-basemaps/3857/whanganui_urban_2015-16_0-1m/01ED83WV5VV20JWAP0MT3D7W4W/",
       "name": "whanganui-urban-2015-2016-0.1m",
       "title": "Whanganui 0.1m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/manawatu-whanganui/imagery/whanganui-urban-2017-2018-0.075m.json
+++ b/config/tileset/manawatu-whanganui/imagery/whanganui-urban-2017-2018-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/whanganui_urban_2017-18_0-075m/01F6P22D2ENZ889MYXP3WN950N",
-      "3857": "s3://linz-basemaps/3857/whanganui_urban_2017-18_0-075m/01ED83XAAFYRNDQFZJRBSH21TF",
+      "2193": "s3://linz-basemaps/2193/whanganui_urban_2017-18_0-075m/01F6P22D2ENZ889MYXP3WN950N/",
+      "3857": "s3://linz-basemaps/3857/whanganui_urban_2017-18_0-075m/01ED83XAAFYRNDQFZJRBSH21TF/",
       "name": "whanganui-urban-2017-2018-0.075m",
       "title": "Whanganui 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/marlborough/imagery/marlborough-rural-2011-2012-0.4m.json
+++ b/config/tileset/marlborough/imagery/marlborough-rural-2011-2012-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_rural_2011-2012_0-40m_RGBA/01F6P1CMT137757Y7M473TP4MG",
-      "3857": "s3://linz-basemaps/3857/marlborough_rural_2011-2012_0-40m_RGBA/01ED82KF10YWWCA59936P87R9B",
+      "2193": "s3://linz-basemaps/2193/marlborough_rural_2011-2012_0-40m_RGBA/01F6P1CMT137757Y7M473TP4MG/",
+      "3857": "s3://linz-basemaps/3857/marlborough_rural_2011-2012_0-40m_RGBA/01ED82KF10YWWCA59936P87R9B/",
       "name": "marlborough-rural-2011-2012-0.4m",
       "title": "Marlborough 0.4m Rural Aerial Photos (2011-2012)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/marlborough/imagery/marlborough-rural-2015-2016-0.2m.json
+++ b/config/tileset/marlborough/imagery/marlborough-rural-2015-2016-0.2m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_rural_2015-2016_0-20m_RGBA/01F6P1D8DJGBN4QNAB2Y64DVV3",
-      "3857": "s3://linz-basemaps/3857/marlborough_rural_2015-2016_0-20m_RGBA/01ED82MG0Q6A8VFAJSY7Q543N5",
+      "2193": "s3://linz-basemaps/2193/marlborough_rural_2015-2016_0-20m_RGBA/01F6P1D8DJGBN4QNAB2Y64DVV3/",
+      "3857": "s3://linz-basemaps/3857/marlborough_rural_2015-2016_0-20m_RGBA/01ED82MG0Q6A8VFAJSY7Q543N5/",
       "name": "marlborough-rural-2015-2016-0.2m",
       "title": "Marlborough 0.2m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/marlborough/imagery/marlborough-sn5100-1977-0.75m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn5100-1977-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn5100_1977_0.75m/01H8JGWVHJFER7QX1WA1ZYSXF1",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn5100_1977_0.75m/01H8JGWVHZXWJR7QEBCANAJ7FX",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn5100_1977_0.75m/01H8JGWVHJFER7QX1WA1ZYSXF1/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn5100_1977_0.75m/01H8JGWVHZXWJR7QEBCANAJ7FX/",
       "name": "marlborough-sn5100-1977-0.75m",
       "title": "Marlborough 0.75m SN5100 (1977)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-sn5638-1979-1980-0.375m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn5638-1979-1980-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn5638_1979-1980_0.375m/01H8JH0DNT3VKPMHKP4ACYNR72",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn5638_1979-1980_0.375m/01H8JH0DP9TA3E9WDMRF69D71A",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn5638_1979-1980_0.375m/01H8JH0DNT3VKPMHKP4ACYNR72/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn5638_1979-1980_0.375m/01H8JH0DP9TA3E9WDMRF69D71A/",
       "name": "marlborough-sn5638-1979-1980-0.375m",
       "title": "Marlborough 0.375m SN5638 (1979-1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-sn8000-1982-0.75m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn8000-1982-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn8000_1982_0.75m/01H8JH1E1FZM47HEGK4PB0M5QN",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn8000_1982_0.75m/01H8JH1E27XGRYKF5SPH643D04",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn8000_1982_0.75m/01H8JH1E1FZM47HEGK4PB0M5QN/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn8000_1982_0.75m/01H8JH1E27XGRYKF5SPH643D04/",
       "name": "marlborough-sn8000-1982-0.75m",
       "title": "Marlborough 0.75m SN8000 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-sn8049-1982-0.8m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn8049-1982-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn8049_1982_0.8m/01H8JH8VA9F3FF0NGQ6YGM2YAX",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn8049_1982_0.8m/01H8JH6XD8BS7XE1ESQQRJC7NB",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn8049_1982_0.8m/01H8JH8VA9F3FF0NGQ6YGM2YAX/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn8049_1982_0.8m/01H8JH6XD8BS7XE1ESQQRJC7NB/",
       "name": "marlborough-sn8049-1982-0.8m",
       "title": "Marlborough 0.8m SN8049 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-sn8200-1983-0.375m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn8200-1983-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn8200_1983_0.375m/01H8JH81FZSMC3255DB1F2Y8J6",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn8200_1983_0.375m/01H8JH81GPM3C8GEX1D9HMDBA2",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn8200_1983_0.375m/01H8JH81FZSMC3255DB1F2Y8J6/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn8200_1983_0.375m/01H8JH81GPM3C8GEX1D9HMDBA2/",
       "name": "marlborough-sn8200-1983-0.375m",
       "title": "Marlborough 0.375m SN8200 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-sn8262-1983-0.375m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn8262-1983-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn8262_1983_0.375m/01H8JHC3NXE1K4CCZFH3FH3BSR",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn8262_1983_0.375m/01H8JHF046XWBVSSJ7WECJ08SG",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn8262_1983_0.375m/01H8JHC3NXE1K4CCZFH3FH3BSR/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn8262_1983_0.375m/01H8JHF046XWBVSSJ7WECJ08SG/",
       "name": "marlborough-sn8262-1983-0.375m",
       "title": "Marlborough 0.375m SN8262 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-sn9360-1994-0.75m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn9360-1994-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn9360_1994_0.75m/01H8JHE63564ZQSWRQHW6V0QZ6",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn9360_1994_0.75m/01H8JHHTYNTQEGETWAQHP0DHTZ",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn9360_1994_0.75m/01H8JHE63564ZQSWRQHW6V0QZ6/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn9360_1994_0.75m/01H8JHHTYNTQEGETWAQHP0DHTZ/",
       "name": "marlborough-sn9360-1994-0.75m",
       "title": "Marlborough 0.75m SN9360 (1994)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-sn9471-1995-0.8m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn9471-1995-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn9471_1995_0.8m/01H8JHFJ6G0PQ198DN59KJMVQZ",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn9471_1995_0.8m/01H8JHFJ5ZEGG6813Y4JTFE4Y0",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn9471_1995_0.8m/01H8JHFJ6G0PQ198DN59KJMVQZ/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn9471_1995_0.8m/01H8JHFJ5ZEGG6813Y4JTFE4Y0/",
       "name": "marlborough-sn9471-1995-0.8m",
       "title": "Marlborough 0.8m SN9471 (1995)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-sn9586-1996-0.32m.json
+++ b/config/tileset/marlborough/imagery/marlborough-sn9586-1996-0.32m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn9586_1996_0.32m/01H8JHGBMH29KDA07NRS7VFS2K",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn9586_1996_0.32m/01H8JHGBKW6SQN9346F1MHJW89",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn9586_1996_0.32m/01H8JHGBMH29KDA07NRS7VFS2K/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn9586_1996_0.32m/01H8JHGBKW6SQN9346F1MHJW89/",
       "name": "marlborough-sn9586-1996-0.32m",
       "title": "Marlborough 0.32m SN9586 (1996)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-snc25048-2000-0.75m.json
+++ b/config/tileset/marlborough/imagery/marlborough-snc25048-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_snc25048_2000_0.75m/01H8JHHWKHBJKATYTKQ3X917QK",
-      "3857": "s3://linz-basemaps/3857/marlborough_snc25048_2000_0.75m/01H8JHHWMNZM68EQV2Z7THK349",
+      "2193": "s3://linz-basemaps/2193/marlborough_snc25048_2000_0.75m/01H8JHHWKHBJKATYTKQ3X917QK/",
+      "3857": "s3://linz-basemaps/3857/marlborough_snc25048_2000_0.75m/01H8JHHWMNZM68EQV2Z7THK349/",
       "name": "marlborough-snc25048-2000-0.75m",
       "title": "Marlborough 0.75m SNC25048 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-snc2887-1975-0.3m.json
+++ b/config/tileset/marlborough/imagery/marlborough-snc2887-1975-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_snc2887_1975_0.3m/01H8JKMXEJGX9WCBE7N1PGW0WH",
-      "3857": "s3://linz-basemaps/3857/marlborough_snc2887_1975_0.3m/01H8JHVMHS0NBPT3NJ3CSTDHDW",
+      "2193": "s3://linz-basemaps/2193/marlborough_snc2887_1975_0.3m/01H8JKMXEJGX9WCBE7N1PGW0WH/",
+      "3857": "s3://linz-basemaps/3857/marlborough_snc2887_1975_0.3m/01H8JHVMHS0NBPT3NJ3CSTDHDW/",
       "name": "marlborough-snc2887-1975-0.3m",
       "title": "Marlborough 0.3m SNC2887 (1975)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-snc30007-2002-0.75m.json
+++ b/config/tileset/marlborough/imagery/marlborough-snc30007-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_snc30007_2002_0.75m/01H8JHTXZ548BH9330YZ9M2M4R",
-      "3857": "s3://linz-basemaps/3857/marlborough_snc30007_2002_0.75m/01H8JHTXZ16WXY3BVTJJ40DSQX",
+      "2193": "s3://linz-basemaps/2193/marlborough_snc30007_2002_0.75m/01H8JHTXZ548BH9330YZ9M2M4R/",
+      "3857": "s3://linz-basemaps/3857/marlborough_snc30007_2002_0.75m/01H8JHTXZ16WXY3BVTJJ40DSQX/",
       "name": "marlborough-snc30007-2002-0.75m",
       "title": "Marlborough 0.75m SNC30007 (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-snc8294-1983-0.375m.json
+++ b/config/tileset/marlborough/imagery/marlborough-snc8294-1983-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_snc8294_1983_0.375m/01H8JJ1K46R4W7X0V69KGRCV6V",
-      "3857": "s3://linz-basemaps/3857/marlborough_snc8294_1983_0.375m/01H8JJ1K4MSDCCACGE3T97PEQ0",
+      "2193": "s3://linz-basemaps/2193/marlborough_snc8294_1983_0.375m/01H8JJ1K46R4W7X0V69KGRCV6V/",
+      "3857": "s3://linz-basemaps/3857/marlborough_snc8294_1983_0.375m/01H8JJ1K4MSDCCACGE3T97PEQ0/",
       "name": "marlborough-snc8294-1983-0.375m",
       "title": "Marlborough 0.375m SNC8294 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-tasman-canterbury-sn8452-1985-0.75m.json
+++ b/config/tileset/marlborough/imagery/marlborough-tasman-canterbury-sn8452-1985-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_tasman_canterbury_sn8452_1985_0.75m/01H8JJ4DD3HYEHEQH2PAAM3DBJ",
-      "3857": "s3://linz-basemaps/3857/marlborough_tasman_canterbury_sn8452_1985_0.75m/01H8JJ4F7HV3E6AQSFEM3Q3G7P",
+      "2193": "s3://linz-basemaps/2193/marlborough_tasman_canterbury_sn8452_1985_0.75m/01H8JJ4DD3HYEHEQH2PAAM3DBJ/",
+      "3857": "s3://linz-basemaps/3857/marlborough_tasman_canterbury_sn8452_1985_0.75m/01H8JJ4F7HV3E6AQSFEM3Q3G7P/",
       "name": "marlborough-tasman-canterbury-sn8452-1985-0.75m",
       "title": "Marlborough / Tasman / Canterbury 0.75m SN8452 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-tasman-sn8415-1984-0.375m.json
+++ b/config/tileset/marlborough/imagery/marlborough-tasman-sn8415-1984-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_tasman_sn8415_1984_0.375m/01H8JJ73R2M08BME04C0K304WX",
-      "3857": "s3://linz-basemaps/3857/marlborough_tasman_sn8415_1984_0.375m/01H8JJCWKVMYD04XF6WAPWQCFQ",
+      "2193": "s3://linz-basemaps/2193/marlborough_tasman_sn8415_1984_0.375m/01H8JJ73R2M08BME04C0K304WX/",
+      "3857": "s3://linz-basemaps/3857/marlborough_tasman_sn8415_1984_0.375m/01H8JJCWKVMYD04XF6WAPWQCFQ/",
       "name": "marlborough-tasman-sn8415-1984-0.375m",
       "title": "Marlborough / Tasman 0.375m SN8415 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-tasman-snc8423-1984-0.375m.json
+++ b/config/tileset/marlborough/imagery/marlborough-tasman-snc8423-1984-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_tasman_snc8423_1984_0.375m/01H8JJ90E6NY1RBQ8QF7X2EQRB",
-      "3857": "s3://linz-basemaps/3857/marlborough_tasman_snc8423_1984_0.375m/01H8JJBKHYZYP5VP3SV14HMT2G",
+      "2193": "s3://linz-basemaps/2193/marlborough_tasman_snc8423_1984_0.375m/01H8JJ90E6NY1RBQ8QF7X2EQRB/",
+      "3857": "s3://linz-basemaps/3857/marlborough_tasman_snc8423_1984_0.375m/01H8JJBKHYZYP5VP3SV14HMT2G/",
       "name": "marlborough-tasman-snc8423-1984-0.375m",
       "title": "Marlborough / Tasman 0.375m SNC8423 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/marlborough/imagery/marlborough-urban-2017-2018-0.1m.json
+++ b/config/tileset/marlborough/imagery/marlborough-urban-2017-2018-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_urban_2017-18_0-1m/01F6P1EM0AK6GZN9TG913VB6CH",
-      "3857": "s3://linz-basemaps/3857/marlborough_urban_2017-18_0-1m/01ED82QS0GBHX38Z6B1YHQNZM0",
+      "2193": "s3://linz-basemaps/2193/marlborough_urban_2017-18_0-1m/01F6P1EM0AK6GZN9TG913VB6CH/",
+      "3857": "s3://linz-basemaps/3857/marlborough_urban_2017-18_0-1m/01ED82QS0GBHX38Z6B1YHQNZM0/",
       "name": "marlborough-urban-2017-2018-0.1m",
       "title": "Marlborough 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/marlborough/imagery/marlborough-urban-2020-2021-0.1m.json
+++ b/config/tileset/marlborough/imagery/marlborough-urban-2020-2021-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_urban_2020-2021_0-1m_RGB/01FCKSW2KY42Z0HA11BJ4RMZ0S",
-      "3857": "s3://linz-basemaps/3857/marlborough_urban_2020-2021_0-1m_RGB/01FCKSYT6Y3ZJJ4SAKKB4GEK52",
+      "2193": "s3://linz-basemaps/2193/marlborough_urban_2020-2021_0-1m_RGB/01FCKSW2KY42Z0HA11BJ4RMZ0S/",
+      "3857": "s3://linz-basemaps/3857/marlborough_urban_2020-2021_0-1m_RGB/01FCKSYT6Y3ZJJ4SAKKB4GEK52/",
       "name": "marlborough-urban-2020-2021-0.1m",
       "title": "Marlborough 0.1m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/marlborough/imagery/marlborough-wellington-snc50451-2004-2005-0.75m.json
+++ b/config/tileset/marlborough/imagery/marlborough-wellington-snc50451-2004-2005-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_wellington_snc50451_2004-2005_0.75m/01H8JJA9FYMW42C4XHW9GZEPRK",
-      "3857": "s3://linz-basemaps/3857/marlborough_wellington_snc50451_2004-2005_0.75m/01H8JJ5NT8WP4ZHH19HHH9PB8S",
+      "2193": "s3://linz-basemaps/2193/marlborough_wellington_snc50451_2004-2005_0.75m/01H8JJA9FYMW42C4XHW9GZEPRK/",
+      "3857": "s3://linz-basemaps/3857/marlborough_wellington_snc50451_2004-2005_0.75m/01H8JJ5NT8WP4ZHH19HHH9PB8S/",
       "name": "marlborough-wellington-snc50451-2004-2005-0.75m",
       "title": "Marlborough / Wellington 0.75m SNC50451 (2004-2005)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/nelson/imagery/top-of-the-south-flood-2022-0.15m.json
+++ b/config/tileset/nelson/imagery/top-of-the-south-flood-2022-0.15m.json
@@ -6,8 +6,8 @@
   "category": "Event",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/top-of-the-south_flood_2022_0.15m/01GGDTRTDV2BA47P4TQ6CGWMFR",
-      "3857": "s3://linz-basemaps/3857/top-of-the-south_flood_2022_0.15m/01GGDTSGRK0Z4C70WXBYMEXK4X",
+      "2193": "s3://linz-basemaps/2193/top-of-the-south_flood_2022_0.15m/01GGDTRTDV2BA47P4TQ6CGWMFR/",
+      "3857": "s3://linz-basemaps/3857/top-of-the-south_flood_2022_0.15m/01GGDTSGRK0Z4C70WXBYMEXK4X/",
       "name": "top-of-the-south-flood-2022-0.15m",
       "title": "Top of the South Flood 0.15m Aerial Photos (2022)",
       "category": "Event",

--- a/config/tileset/new-zealand/imagery/north-island-2023-0.5m.json
+++ b/config/tileset/new-zealand/imagery/north-island-2023-0.5m.json
@@ -6,8 +6,8 @@
   "category": "Event",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/north-island_2023_0.5m/01GW39PB2ZMJ5KADZSSP860WRS",
-      "3857": "s3://linz-basemaps/3857/north-island_2023_0.5m/01GW39S72PRNYN6MRRWF83T82E",
+      "2193": "s3://linz-basemaps/2193/north-island_2023_0.5m/01GW39PB2ZMJ5KADZSSP860WRS/",
+      "3857": "s3://linz-basemaps/3857/north-island_2023_0.5m/01GW39S72PRNYN6MRRWF83T82E/",
       "name": "north-island-2023-0.5m",
       "title": "Cyclone Gabrielle North Island 0.5m Satellite Imagery (21 February 2023 - 8 March 2023)",
       "category": "Event",

--- a/config/tileset/new-zealand/imagery/north-island-2023-10m.json
+++ b/config/tileset/new-zealand/imagery/north-island-2023-10m.json
@@ -6,8 +6,8 @@
   "category": "Event",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/north-island_2023_10m/01GV1YW3PFVAD8089Q96W69WYT",
-      "3857": "s3://linz-basemaps/3857/north-island_2023_10m/01GV1YWSQ3V9F2ZQ7KYCT6VR72",
+      "2193": "s3://linz-basemaps/2193/north-island_2023_10m/01GV1YW3PFVAD8089Q96W69WYT/",
+      "3857": "s3://linz-basemaps/3857/north-island_2023_10m/01GV1YWSQ3V9F2ZQ7KYCT6VR72/",
       "name": "north-island-2023-10m",
       "title": "Cyclone Gabrielle North Island 10m Satellite Imagery (18-21 February 2023)",
       "category": "Event",

--- a/config/tileset/new-zealand/imagery/north-island-pre-cyclone-gabrielle-2022-10m.json
+++ b/config/tileset/new-zealand/imagery/north-island-pre-cyclone-gabrielle-2022-10m.json
@@ -6,8 +6,8 @@
   "category": "Event",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/north-island-pre-cyclone-gabrielle_2022_10m/01GTFV298JMC5EDMA3YVJEPBEX",
-      "3857": "s3://linz-basemaps/3857/north-island-pre-cyclone-gabrielle_2022_10m/01GTFV2P4GH36AS9P3AZ88ABYY",
+      "2193": "s3://linz-basemaps/2193/north-island-pre-cyclone-gabrielle_2022_10m/01GTFV298JMC5EDMA3YVJEPBEX/",
+      "3857": "s3://linz-basemaps/3857/north-island-pre-cyclone-gabrielle_2022_10m/01GTFV2P4GH36AS9P3AZ88ABYY/",
       "name": "north-island-pre-cyclone-gabrielle-2022-10m",
       "title": "Cyclone Gabrielle [Before] North Island 10m Satellite Imagery (22 November 2022)",
       "category": "Event",

--- a/config/tileset/new-zealand/imagery/nz-satellite-2019-2020-10m.json
+++ b/config/tileset/new-zealand/imagery/nz-satellite-2019-2020-10m.json
@@ -6,8 +6,8 @@
   "category": "Satellite Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/new_zealand_sentinel_2019-2020_10m/01F6P1G0S78XYXAQB7Y375MZ2Q",
-      "3857": "s3://linz-basemaps/3857/new_zealand_sentinel_2019-2020_10m/01ED82TFB1ZE9C75CH5VY3Z92B",
+      "2193": "s3://linz-basemaps/2193/new_zealand_sentinel_2019-2020_10m/01F6P1G0S78XYXAQB7Y375MZ2Q/",
+      "3857": "s3://linz-basemaps/3857/new_zealand_sentinel_2019-2020_10m/01ED82TFB1ZE9C75CH5VY3Z92B/",
       "name": "nz-satellite-2019-2020-10m",
       "title": "New Zealand 10m Satellite Imagery (2019-2020)",
       "category": "Satellite Imagery",

--- a/config/tileset/new-zealand/imagery/nz-satellite-2020-2021-10m.json
+++ b/config/tileset/new-zealand/imagery/nz-satellite-2020-2021-10m.json
@@ -6,8 +6,8 @@
   "category": "Satellite Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R",
-      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J",
+      "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R/",
+      "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J/",
       "name": "nz-satellite-2020-2021-10m",
       "title": "New Zealand 10m Satellite Imagery (2020-2021)",
       "category": "Satellite Imagery",

--- a/config/tileset/northland/imagery/northland-auckland-sn8104-1982-1983-0.4m.json
+++ b/config/tileset/northland/imagery/northland-auckland-sn8104-1982-1983-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_auckland_sn8104_1982-1983_0.4m/01H8JJ5ETCC5DM0HZGBWPNT0RW",
-      "3857": "s3://linz-basemaps/3857/northland_auckland_sn8104_1982-1983_0.4m/01H8JJEGJ98ZNQFT973TRRZHV0",
+      "2193": "s3://linz-basemaps/2193/northland_auckland_sn8104_1982-1983_0.4m/01H8JJ5ETCC5DM0HZGBWPNT0RW/",
+      "3857": "s3://linz-basemaps/3857/northland_auckland_sn8104_1982-1983_0.4m/01H8JJEGJ98ZNQFT973TRRZHV0/",
       "name": "northland-auckland-sn8104-1982-1983-0.4m",
       "title": "Northland / Auckland 0.4m SN8104 (1982-1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-auckland-sn9482-1995-1996-0.8m.json
+++ b/config/tileset/northland/imagery/northland-auckland-sn9482-1995-1996-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_auckland_sn9482_1995-1996_0.8m/01H8JJ9DPAVP8SJQH0J8WTMQNA",
-      "3857": "s3://linz-basemaps/3857/northland_auckland_sn9482_1995-1996_0.8m/01H8JJ9DPTXTXQXH27E9ZBP13K",
+      "2193": "s3://linz-basemaps/2193/northland_auckland_sn9482_1995-1996_0.8m/01H8JJ9DPAVP8SJQH0J8WTMQNA/",
+      "3857": "s3://linz-basemaps/3857/northland_auckland_sn9482_1995-1996_0.8m/01H8JJ9DPTXTXQXH27E9ZBP13K/",
       "name": "northland-auckland-sn9482-1995-1996-0.8m",
       "title": "Northland / Auckland 0.8m SN9482 (1995-1996)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-sn5780-1980-0.8m.json
+++ b/config/tileset/northland/imagery/northland-sn5780-1980-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_sn5780_1980_0.8m/01H8JJDF0QXKSNSBH2DGBF68YP",
-      "3857": "s3://linz-basemaps/3857/northland_sn5780_1980_0.8m/01H8JJDEZV4G7J6S1JARD1ZNGF",
+      "2193": "s3://linz-basemaps/2193/northland_sn5780_1980_0.8m/01H8JJDF0QXKSNSBH2DGBF68YP/",
+      "3857": "s3://linz-basemaps/3857/northland_sn5780_1980_0.8m/01H8JJDEZV4G7J6S1JARD1ZNGF/",
       "name": "northland-sn5780-1980-0.8m",
       "title": "Northland 0.8m SN5780 (1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-sn5932-1981-1982-0.375m.json
+++ b/config/tileset/northland/imagery/northland-sn5932-1981-1982-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_sn5932_1981-1982_0.375m/01H8JJG12FFE9DJAFHQ2VJJG8F",
-      "3857": "s3://linz-basemaps/3857/northland_sn5932_1981-1982_0.375m/01H8JJG12C1T7T7SP1HTVNS4VM",
+      "2193": "s3://linz-basemaps/2193/northland_sn5932_1981-1982_0.375m/01H8JJG12FFE9DJAFHQ2VJJG8F/",
+      "3857": "s3://linz-basemaps/3857/northland_sn5932_1981-1982_0.375m/01H8JJG12C1T7T7SP1HTVNS4VM/",
       "name": "northland-sn5932-1981-1982-0.375m",
       "title": "Northland 0.375m SN5932 (1981-1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-sn8328-1984-1986-0.8m.json
+++ b/config/tileset/northland/imagery/northland-sn8328-1984-1986-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_sn8328_1984-1986_0.8m/01H8JJKQR9XYDCQBVGW7J36NQH",
-      "3857": "s3://linz-basemaps/3857/northland_sn8328_1984-1986_0.8m/01H8JJKQRBZ1B7QMFX121GSFVA",
+      "2193": "s3://linz-basemaps/2193/northland_sn8328_1984-1986_0.8m/01H8JJKQR9XYDCQBVGW7J36NQH/",
+      "3857": "s3://linz-basemaps/3857/northland_sn8328_1984-1986_0.8m/01H8JJKQRBZ1B7QMFX121GSFVA/",
       "name": "northland-sn8328-1984-1986-0.8m",
       "title": "Northland 0.8m SN8328 (1984-1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-sn9281-1993-0.6m.json
+++ b/config/tileset/northland/imagery/northland-sn9281-1993-0.6m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_sn9281_1993_0.6m/01H8JJWQ2CYGWSVP6P880A516K",
-      "3857": "s3://linz-basemaps/3857/northland_sn9281_1993_0.6m/01H8JJWQFK7RXM19D6CDGMDV3Z",
+      "2193": "s3://linz-basemaps/2193/northland_sn9281_1993_0.6m/01H8JJWQ2CYGWSVP6P880A516K/",
+      "3857": "s3://linz-basemaps/3857/northland_sn9281_1993_0.6m/01H8JJWQFK7RXM19D6CDGMDV3Z/",
       "name": "northland-sn9281-1993-0.6m",
       "title": "Northland 0.6m SN9281 (1993)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-snc12835-2005-0.64m.json
+++ b/config/tileset/northland/imagery/northland-snc12835-2005-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_snc12835_2005_0.64m/01H8JJWV76DJ7PD2HB3CTCTF20",
-      "3857": "s3://linz-basemaps/3857/northland_snc12835_2005_0.64m/01H8JJWV61MGZN6Y6WM3DDK2FE",
+      "2193": "s3://linz-basemaps/2193/northland_snc12835_2005_0.64m/01H8JJWV76DJ7PD2HB3CTCTF20/",
+      "3857": "s3://linz-basemaps/3857/northland_snc12835_2005_0.64m/01H8JJWV61MGZN6Y6WM3DDK2FE/",
       "name": "northland-snc12835-2005-0.64m",
       "title": "Northland 0.64m SNC12835 (2005)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-snc5797-1980-0.375m.json
+++ b/config/tileset/northland/imagery/northland-snc5797-1980-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_snc5797_1980_0.375m/01H8JJWWZ9WA9YV83B4PRSM460",
-      "3857": "s3://linz-basemaps/3857/northland_snc5797_1980_0.375m/01H8JJWWYHV7RGGPAB3YXVH215",
+      "2193": "s3://linz-basemaps/2193/northland_snc5797_1980_0.375m/01H8JJWWZ9WA9YV83B4PRSM460/",
+      "3857": "s3://linz-basemaps/3857/northland_snc5797_1980_0.375m/01H8JJWWYHV7RGGPAB3YXVH215/",
       "name": "northland-snc5797-1980-0.375m",
       "title": "Northland 0.375m SNC5797 (1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-snc8573-1985-0.3m.json
+++ b/config/tileset/northland/imagery/northland-snc8573-1985-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_snc8573_1985_0.3m/01H8JJX1T63VBXTGD2QA6PF317",
-      "3857": "s3://linz-basemaps/3857/northland_snc8573_1985_0.3m/01H8JJX1T9XJX0JMXPR5XVWWR3",
+      "2193": "s3://linz-basemaps/2193/northland_snc8573_1985_0.3m/01H8JJX1T63VBXTGD2QA6PF317/",
+      "3857": "s3://linz-basemaps/3857/northland_snc8573_1985_0.3m/01H8JJX1T9XJX0JMXPR5XVWWR3/",
       "name": "northland-snc8573-1985-0.3m",
       "title": "Northland 0.3m SNC8573 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/northland/imagery/northland-snc9935-2000-2003-0.75m.json
+++ b/config/tileset/northland/imagery/northland-snc9935-2000-2003-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_snc9935_2000-2003_0.75m/01H8JJX7PMH7HKVB8D9AHZ25QJ",
-      "3857": "s3://linz-basemaps/3857/northland_snc9935_2000-2003_0.75m/01H8JJX7NKKRKW7CN6RQTZJYX1",
+      "2193": "s3://linz-basemaps/2193/northland_snc9935_2000-2003_0.75m/01H8JJX7PMH7HKVB8D9AHZ25QJ/",
+      "3857": "s3://linz-basemaps/3857/northland_snc9935_2000-2003_0.75m/01H8JJX7NKKRKW7CN6RQTZJYX1/",
       "name": "northland-snc9935-2000-2003-0.75m",
       "title": "Northland 0.75m SNC9935 (2000-2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/dunedin-rural-2013-0.4m.json
+++ b/config/tileset/otago/imagery/dunedin-rural-2013-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/dunedin_rural_2013_0-40m_RGBA/01F6P12CMF8AKCDGVCGRB06B0G",
-      "3857": "s3://linz-basemaps/3857/dunedin_rural_2013_0-40m_RGBA/01ED8265AEHZM2DHB43GBFE5BG",
+      "2193": "s3://linz-basemaps/2193/dunedin_rural_2013_0-40m_RGBA/01F6P12CMF8AKCDGVCGRB06B0G/",
+      "3857": "s3://linz-basemaps/3857/dunedin_rural_2013_0-40m_RGBA/01ED8265AEHZM2DHB43GBFE5BG/",
       "name": "dunedin-rural-2013-0.4m",
       "title": "Dunedin 0.4m Rural Aerial Photos (2013)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/otago/imagery/otago-canterbury-sn9933-2000-0.75m.json
+++ b/config/tileset/otago/imagery/otago-canterbury-sn9933-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_canterbury_sn9933_2000_0.75m/01H8JJYKZBWEMVSDDZ0SD181S7",
-      "3857": "s3://linz-basemaps/3857/otago_canterbury_sn9933_2000_0.75m/01H8JJYKZBM32HBS9P8NPRCZVJ",
+      "2193": "s3://linz-basemaps/2193/otago_canterbury_sn9933_2000_0.75m/01H8JJYKZBWEMVSDDZ0SD181S7/",
+      "3857": "s3://linz-basemaps/3857/otago_canterbury_sn9933_2000_0.75m/01H8JJYKZBM32HBS9P8NPRCZVJ/",
       "name": "otago-canterbury-sn9933-2000-0.75m",
       "title": "Otago / Canterbury 0.75m SN9933 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-rural-2013-2014-0.4m.json
+++ b/config/tileset/otago/imagery/otago-rural-2013-2014-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_rural_2013-2014_0-40m_RGBA/01F6P1MWWWTB2CE6FSCWPX6AKR",
-      "3857": "s3://linz-basemaps/3857/otago_rural_2013-2014_0-40m_RGBA/01ED8312YJGXG5195GMTGY9MNK",
+      "2193": "s3://linz-basemaps/2193/otago_rural_2013-2014_0-40m_RGBA/01F6P1MWWWTB2CE6FSCWPX6AKR/",
+      "3857": "s3://linz-basemaps/3857/otago_rural_2013-2014_0-40m_RGBA/01ED8312YJGXG5195GMTGY9MNK/",
       "name": "otago-rural-2013-2014-0.4m",
       "title": "Otago 0.4m Rural Aerial Photos (2013-2014)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/otago/imagery/otago-sn12544-1998-0.75m.json
+++ b/config/tileset/otago/imagery/otago-sn12544-1998-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn12544_1998_0.75m/01H8JJZ2R6CP5FYRY1W173GEG3",
-      "3857": "s3://linz-basemaps/3857/otago_sn12544_1998_0.75m/01H8JJZ2RGQ0V55D9DTJKQESDH",
+      "2193": "s3://linz-basemaps/2193/otago_sn12544_1998_0.75m/01H8JJZ2R6CP5FYRY1W173GEG3/",
+      "3857": "s3://linz-basemaps/3857/otago_sn12544_1998_0.75m/01H8JJZ2RGQ0V55D9DTJKQESDH/",
       "name": "otago-sn12544-1998-0.75m",
       "title": "Otago 0.75m SN12544 (1998)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn3806-1975-0.375m.json
+++ b/config/tileset/otago/imagery/otago-sn3806-1975-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn3806_1975_0.375m/01H8JJZ4PQ7SFDZ21DQR9GJ8AZ",
-      "3857": "s3://linz-basemaps/3857/otago_sn3806_1975_0.375m/01H8JJZ4M9C83EJDJCMQB4ED8B",
+      "2193": "s3://linz-basemaps/2193/otago_sn3806_1975_0.375m/01H8JJZ4PQ7SFDZ21DQR9GJ8AZ/",
+      "3857": "s3://linz-basemaps/3857/otago_sn3806_1975_0.375m/01H8JJZ4M9C83EJDJCMQB4ED8B/",
       "name": "otago-sn3806-1975-0.375m",
       "title": "Otago 0.375m SN3806 (1975)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn5220-1978-0.75m.json
+++ b/config/tileset/otago/imagery/otago-sn5220-1978-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn5220_1978_0.75m/01H8JK3ZXTSBJ9WP3M5975S6ZM",
-      "3857": "s3://linz-basemaps/3857/otago_sn5220_1978_0.75m/01H8JNADYW744FT5T501Y5MCAH",
+      "2193": "s3://linz-basemaps/2193/otago_sn5220_1978_0.75m/01H8JK3ZXTSBJ9WP3M5975S6ZM/",
+      "3857": "s3://linz-basemaps/3857/otago_sn5220_1978_0.75m/01H8JNADYW744FT5T501Y5MCAH/",
       "name": "otago-sn5220-1978-0.75m",
       "title": "Otago 0.75m SN5220 (1978)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn5359-1979-0.375m.json
+++ b/config/tileset/otago/imagery/otago-sn5359-1979-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn5359_1979_0.375m/01H8JK4EXEEC9YNEAKYNB4SNPB",
-      "3857": "s3://linz-basemaps/3857/otago_sn5359_1979_0.375m/01H8JK38135F3SNYTG3WVMW0CA",
+      "2193": "s3://linz-basemaps/2193/otago_sn5359_1979_0.375m/01H8JK4EXEEC9YNEAKYNB4SNPB/",
+      "3857": "s3://linz-basemaps/3857/otago_sn5359_1979_0.375m/01H8JK38135F3SNYTG3WVMW0CA/",
       "name": "otago-sn5359-1979-0.375m",
       "title": "Otago 0.375m SN5359 (1979)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn8180-1983-0.75m.json
+++ b/config/tileset/otago/imagery/otago-sn8180-1983-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8180_1983_0.75m/01H8JM4JGPBEJPE1X2BVFPR353",
-      "3857": "s3://linz-basemaps/3857/otago_sn8180_1983_0.75m/01H8JK184G1NCE8ZK1M6KNH9B3",
+      "2193": "s3://linz-basemaps/2193/otago_sn8180_1983_0.75m/01H8JM4JGPBEJPE1X2BVFPR353/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8180_1983_0.75m/01H8JK184G1NCE8ZK1M6KNH9B3/",
       "name": "otago-sn8180-1983-0.75m",
       "title": "Otago 0.75m SN8180 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn8215-1983-1984-0.8m.json
+++ b/config/tileset/otago/imagery/otago-sn8215-1983-1984-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8215_1983-1984_0.8m/01H8JK4G4ARGY7PBNHNEZAXYSK",
-      "3857": "s3://linz-basemaps/3857/otago_sn8215_1983-1984_0.8m/01H8JKZ90XEY62C2B9N2BWJDSQ",
+      "2193": "s3://linz-basemaps/2193/otago_sn8215_1983-1984_0.8m/01H8JK4G4ARGY7PBNHNEZAXYSK/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8215_1983-1984_0.8m/01H8JKZ90XEY62C2B9N2BWJDSQ/",
       "name": "otago-sn8215-1983-1984-0.8m",
       "title": "Otago 0.8m SN8215 (1983-1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn8286-1984-0.8m.json
+++ b/config/tileset/otago/imagery/otago-sn8286-1984-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8286_1984_0.8m/01H8JK4JS7S71JY44EV7922QGS",
-      "3857": "s3://linz-basemaps/3857/otago_sn8286_1984_0.8m/01H8JK4JS3FWJEV55TR2C5HHNJ",
+      "2193": "s3://linz-basemaps/2193/otago_sn8286_1984_0.8m/01H8JK4JS7S71JY44EV7922QGS/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8286_1984_0.8m/01H8JK4JS3FWJEV55TR2C5HHNJ/",
       "name": "otago-sn8286-1984-0.8m",
       "title": "Otago 0.8m SN8286 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn8436-1984-0.64m.json
+++ b/config/tileset/otago/imagery/otago-sn8436-1984-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8436_1984_0.64m/01H8JK6KMBVH8XCC5PYQX76Z6Y",
-      "3857": "s3://linz-basemaps/3857/otago_sn8436_1984_0.64m/01H8JK6NFQV9DVCDXG4B08JG9R",
+      "2193": "s3://linz-basemaps/2193/otago_sn8436_1984_0.64m/01H8JK6KMBVH8XCC5PYQX76Z6Y/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8436_1984_0.64m/01H8JK6NFQV9DVCDXG4B08JG9R/",
       "name": "otago-sn8436-1984-0.64m",
       "title": "Otago 0.64m SN8436 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn8479-1985-0.375m.json
+++ b/config/tileset/otago/imagery/otago-sn8479-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8479_1985_0.375m/01H8JK6MM3JASK9BPHAACX6PQN",
-      "3857": "s3://linz-basemaps/3857/otago_sn8479_1985_0.375m/01H8JK6MK9XB5VPA7AK31XBKE2",
+      "2193": "s3://linz-basemaps/2193/otago_sn8479_1985_0.375m/01H8JK6MM3JASK9BPHAACX6PQN/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8479_1985_0.375m/01H8JK6MK9XB5VPA7AK31XBKE2/",
       "name": "otago-sn8479-1985-0.375m",
       "title": "Otago 0.375m SN8479 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn8733-1987-0.375m.json
+++ b/config/tileset/otago/imagery/otago-sn8733-1987-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8733_1987_0.375m/01H8JKB7660GZ58R761D1YRBV4",
-      "3857": "s3://linz-basemaps/3857/otago_sn8733_1987_0.375m/01H8JKCA1S044XJ0K1Q94M76DY",
+      "2193": "s3://linz-basemaps/2193/otago_sn8733_1987_0.375m/01H8JKB7660GZ58R761D1YRBV4/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8733_1987_0.375m/01H8JKCA1S044XJ0K1Q94M76DY/",
       "name": "otago-sn8733-1987-0.375m",
       "title": "Otago 0.375m SN8733 (1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn9087-1990-1991-0.75m.json
+++ b/config/tileset/otago/imagery/otago-sn9087-1990-1991-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn9087_1990-1991_0.75m/01H8JKATBC8G9ZQHEZ3RSQQKRW",
-      "3857": "s3://linz-basemaps/3857/otago_sn9087_1990-1991_0.75m/01H8JKATAWX98A14QNKVBF14WH",
+      "2193": "s3://linz-basemaps/2193/otago_sn9087_1990-1991_0.75m/01H8JKATBC8G9ZQHEZ3RSQQKRW/",
+      "3857": "s3://linz-basemaps/3857/otago_sn9087_1990-1991_0.75m/01H8JKATAWX98A14QNKVBF14WH/",
       "name": "otago-sn9087-1990-1991-0.75m",
       "title": "Otago 0.75m SN9087 (1990-1991)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn9457-1995-1997-0.75m.json
+++ b/config/tileset/otago/imagery/otago-sn9457-1995-1997-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn9457_1995-1997_0.75m/01H8JKCGK804B44VG2SNWV7R41",
-      "3857": "s3://linz-basemaps/3857/otago_sn9457_1995-1997_0.75m/01H8JKCGMP78WB22YWGAFA3SF7",
+      "2193": "s3://linz-basemaps/2193/otago_sn9457_1995-1997_0.75m/01H8JKCGK804B44VG2SNWV7R41/",
+      "3857": "s3://linz-basemaps/3857/otago_sn9457_1995-1997_0.75m/01H8JKCGMP78WB22YWGAFA3SF7/",
       "name": "otago-sn9457-1995-1997-0.75m",
       "title": "Otago 0.75m SN9457 (1995-1997)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-sn9937-2000-0.75m.json
+++ b/config/tileset/otago/imagery/otago-sn9937-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn9937_2000_0.75m/01H8JKCHEVFDNAR1MM8JD48FX6",
-      "3857": "s3://linz-basemaps/3857/otago_sn9937_2000_0.75m/01H8JKCJA7PXCPXZ7EJYZ01SRR",
+      "2193": "s3://linz-basemaps/2193/otago_sn9937_2000_0.75m/01H8JKCHEVFDNAR1MM8JD48FX6/",
+      "3857": "s3://linz-basemaps/3857/otago_sn9937_2000_0.75m/01H8JKCJA7PXCPXZ7EJYZ01SRR/",
       "name": "otago-sn9937-2000-0.75m",
       "title": "Otago 0.75m SN9937 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-snc12780-2003-0.64m.json
+++ b/config/tileset/otago/imagery/otago-snc12780-2003-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_snc12780_2003_0.64m/01H8JKE55NK8QQZTVD1HYDDHA0",
-      "3857": "s3://linz-basemaps/3857/otago_snc12780_2003_0.64m/01H8JKE5JAVQ7187CJ48SZ9ERA",
+      "2193": "s3://linz-basemaps/2193/otago_snc12780_2003_0.64m/01H8JKE55NK8QQZTVD1HYDDHA0/",
+      "3857": "s3://linz-basemaps/3857/otago_snc12780_2003_0.64m/01H8JKE5JAVQ7187CJ48SZ9ERA/",
       "name": "otago-snc12780-2003-0.64m",
       "title": "Otago 0.64m SNC12780 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-snc25055-2001-0.75m.json
+++ b/config/tileset/otago/imagery/otago-snc25055-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_snc25055_2001_0.75m/01H8JKK96ZMRT5KC3HSK167AJ7",
-      "3857": "s3://linz-basemaps/3857/otago_snc25055_2001_0.75m/01H8JKK97QYPD7SN5FBQJS94JD",
+      "2193": "s3://linz-basemaps/2193/otago_snc25055_2001_0.75m/01H8JKK96ZMRT5KC3HSK167AJ7/",
+      "3857": "s3://linz-basemaps/3857/otago_snc25055_2001_0.75m/01H8JKK97QYPD7SN5FBQJS94JD/",
       "name": "otago-snc25055-2001-0.75m",
       "title": "Otago 0.75m SNC25055 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-snc25057-2001-0.75m.json
+++ b/config/tileset/otago/imagery/otago-snc25057-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_snc25057_2001_0.75m/01H8JKMAST7B8R9JT26VASAYCA",
-      "3857": "s3://linz-basemaps/3857/otago_snc25057_2001_0.75m/01H8JKMAV260422QGPZX6D351D",
+      "2193": "s3://linz-basemaps/2193/otago_snc25057_2001_0.75m/01H8JKMAST7B8R9JT26VASAYCA/",
+      "3857": "s3://linz-basemaps/3857/otago_snc25057_2001_0.75m/01H8JKMAV260422QGPZX6D351D/",
       "name": "otago-snc25057-2001-0.75m",
       "title": "Otago 0.75m SNC25057 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/otago/imagery/otago-southland-west-coast-sn8426-1984-1985-0.75m.json
+++ b/config/tileset/otago/imagery/otago-southland-west-coast-sn8426-1984-1985-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_southland_west-coast_sn8426_1984-1985_0.75m/01H8JKP0SS6Y2PG6W20MB31V0X",
-      "3857": "s3://linz-basemaps/3857/otago_southland_west-coast_sn8426_1984-1985_0.75m/01H8JKP0S9SMM3Z8D540RJTNME",
+      "2193": "s3://linz-basemaps/2193/otago_southland_west-coast_sn8426_1984-1985_0.75m/01H8JKP0SS6Y2PG6W20MB31V0X/",
+      "3857": "s3://linz-basemaps/3857/otago_southland_west-coast_sn8426_1984-1985_0.75m/01H8JKP0S9SMM3Z8D540RJTNME/",
       "name": "otago-southland-west-coast-sn8426-1984-1985-0.75m",
       "title": "Otago / Southland / West Coast 0.75m SN8426 (1984-1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/reliefshade.json
+++ b/config/tileset/reliefshade.json
@@ -5,7 +5,7 @@
   "background": "00000000",
   "layers": [
     {
-      "3857": "s3://linz-basemaps/3857/geographx_nz_dem_2012_8-0m/01FM8DEN1XG1QGNT229A4T3KZ6",
+      "3857": "s3://linz-basemaps/3857/geographx_nz_dem_2012_8-0m/01FM8DEN1XG1QGNT229A4T3KZ6/",
       "name": "geographx_nz_dem_2012_8-0m",
       "title": "New Zealand 8m DEM Hillshade (2012)",
       "category": "Elevation"

--- a/config/tileset/scanned.post19891231.json
+++ b/config/tileset/scanned.post19891231.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/northland_snc12835_2005_0.64m/01H8JJWV76DJ7PD2HB3CTCTF20",
-      "3857": "s3://linz-basemaps/3857/northland_snc12835_2005_0.64m/01H8JJWV61MGZN6Y6WM3DDK2FE",
+      "2193": "s3://linz-basemaps/2193/northland_snc12835_2005_0.64m/01H8JJWV76DJ7PD2HB3CTCTF20/",
+      "3857": "s3://linz-basemaps/3857/northland_snc12835_2005_0.64m/01H8JJWV61MGZN6Y6WM3DDK2FE/",
       "name": "northland-snc12835-2005-0.64m",
       "title": "Northland 0.64m SNC12835 (2005)",
       "category": "Scanned Aerial Imagery",
@@ -15,8 +15,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_wellington_snc50451_2004-2005_0.75m/01H8JJA9FYMW42C4XHW9GZEPRK",
-      "3857": "s3://linz-basemaps/3857/marlborough_wellington_snc50451_2004-2005_0.75m/01H8JJ5NT8WP4ZHH19HHH9PB8S",
+      "2193": "s3://linz-basemaps/2193/marlborough_wellington_snc50451_2004-2005_0.75m/01H8JJA9FYMW42C4XHW9GZEPRK/",
+      "3857": "s3://linz-basemaps/3857/marlborough_wellington_snc50451_2004-2005_0.75m/01H8JJ5NT8WP4ZHH19HHH9PB8S/",
       "name": "marlborough-wellington-snc50451-2004-2005-0.75m",
       "title": "Marlborough / Wellington 0.75m SNC50451 (2004-2005)",
       "category": "Scanned Aerial Imagery",
@@ -24,8 +24,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50450_2004_0.75m/01H8JBR00MW41YJ63BDMD1SXC4",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50450_2004_0.75m/01H8JBR00G7XHWM8873KN5VEJ5",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50450_2004_0.75m/01H8JBR00MW41YJ63BDMD1SXC4/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50450_2004_0.75m/01H8JBR00G7XHWM8873KN5VEJ5/",
       "name": "hawkes-bay-snc50450-2004-0.75m",
       "title": "Hawkes Bay 0.75m SNC50450 (2004)",
       "category": "Scanned Aerial Imagery",
@@ -33,8 +33,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_west-coast_snc50452_2004-2005_0.64m/01H8JN9V262AGSEMFFNZXWM5GZ",
-      "3857": "s3://linz-basemaps/3857/tasman_west-coast_snc50452_2004-2005_0.64m/01H8JN9V27EZRXPQ4XG644Y7GJ",
+      "2193": "s3://linz-basemaps/2193/tasman_west-coast_snc50452_2004-2005_0.64m/01H8JN9V262AGSEMFFNZXWM5GZ/",
+      "3857": "s3://linz-basemaps/3857/tasman_west-coast_snc50452_2004-2005_0.64m/01H8JN9V27EZRXPQ4XG644Y7GJ/",
       "name": "tasman-west-coast-snc50452-2004-2005-0.64m",
       "title": "Tasman / West Coast 0.64m SNC50452 (2004-2005)",
       "category": "Scanned Aerial Imagery",
@@ -42,8 +42,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50518_2004_0.75m/01H8MV0MDAA9ZD73NQS05SMH0S",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50518_2004_0.75m/01H8MV0MDCF8R48ENH8N0RYC19",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50518_2004_0.75m/01H8MV0MDAA9ZD73NQS05SMH0S/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50518_2004_0.75m/01H8MV0MDCF8R48ENH8N0RYC19/",
       "name": "hawkes-bay-snc50518-2004-0.75m",
       "title": "Hawkes Bay 0.75m SNC50518 (2004)",
       "category": "Scanned Aerial Imagery",
@@ -51,8 +51,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_snc12836_2004_0.625m/01H8JNDK5XZ5RX8HYCW0FDA54A",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_snc12836_2004_0.625m/01H8JNDK644BE3597KE9HYD045",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_snc12836_2004_0.625m/01H8JNDK5XZ5RX8HYCW0FDA54A/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_snc12836_2004_0.625m/01H8JNDK644BE3597KE9HYD045/",
       "name": "waikato-bay-of-plenty-snc12836-2004-0.625m",
       "title": "Waikato / Bay of Plenty 0.625m SNC12836 (2004)",
       "category": "Scanned Aerial Imagery",
@@ -60,8 +60,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/01H8JBKN06SVAZCEQFW1SNKSDK",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/01H8JBQ9TFYJEQX4GYJYZ12XT3",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/01H8JBKN06SVAZCEQFW1SNKSDK/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/01H8JBQ9TFYJEQX4GYJYZ12XT3/",
       "name": "hawkes-bay-bay-of-plenty-snc50516-2004-0.75m",
       "title": "Hawkes Bay / Bay of Plenty 0.75m SNC50516 (2004)",
       "category": "Scanned Aerial Imagery",
@@ -69,8 +69,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50519_2004_0.64m/01H8JBR017XD3ARJND2K3RD6V9",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50519_2004_0.64m/01H8JBR00NGJSXE3DYYMCW821W",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50519_2004_0.64m/01H8JBR017XD3ARJND2K3RD6V9/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50519_2004_0.64m/01H8JBR00NGJSXE3DYYMCW821W/",
       "name": "hawkes-bay-snc50519-2004-0.64m",
       "title": "Hawkes Bay 0.64m SNC50519 (2004)",
       "category": "Scanned Aerial Imagery",
@@ -78,8 +78,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50520_2004_0.64m/01H8JBNBRE160A817HZQAPAFHG",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50520_2004_0.64m/01H8JBMG47BG6N1JYB346RABFZ",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50520_2004_0.64m/01H8JBNBRE160A817HZQAPAFHG/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50520_2004_0.64m/01H8JBMG47BG6N1JYB346RABFZ/",
       "name": "hawkes-bay-snc50520-2004-0.64m",
       "title": "Hawkes Bay 0.64m SNC50520 (2004)",
       "category": "Scanned Aerial Imagery",
@@ -87,8 +87,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc50515_2003_0.625m/01H8JA1X42E6644NF8VVXKBV4B",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc50515_2003_0.625m/01H8JA1QH0SHD8CDB0VG97EM6H",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc50515_2003_0.625m/01H8JA1X42E6644NF8VVXKBV4B/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc50515_2003_0.625m/01H8JA1QH0SHD8CDB0VG97EM6H/",
       "name": "bay-of-plenty-snc50515-2003-0.625m",
       "title": "Bay of Plenty 0.625m SNC50515 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -96,8 +96,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/01H8JBNK0RZDSHW1TABKEM48S8",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/01H8JBPD36YC935ZHJ8S581560",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/01H8JBNK0RZDSHW1TABKEM48S8/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/01H8JBPD36YC935ZHJ8S581560/",
       "name": "manawatu-whanganui-hawkes-bay-snc50517-2003-0.75m",
       "title": "Manawatū-Whanganui / Hawkes Bay 0.75m SNC50517 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -105,8 +105,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_snc12837_2003_0.75m/01H8JPCS6X93S52CYMFRBXTG15",
-      "3857": "s3://linz-basemaps/3857/waikato_snc12837_2003_0.75m/01H8JPCS7JJN7CPNRYZ4X5NDSE",
+      "2193": "s3://linz-basemaps/2193/waikato_snc12837_2003_0.75m/01H8JPCS6X93S52CYMFRBXTG15/",
+      "3857": "s3://linz-basemaps/3857/waikato_snc12837_2003_0.75m/01H8JPCS7JJN7CPNRYZ4X5NDSE/",
       "name": "waikato-snc12837-2003-0.75m",
       "title": "Waikato 0.75m SNC12837 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -114,8 +114,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_snc50347_2003-2004_0.75m/01H8J8R2RMBRQH6V66M8Q82K7R",
-      "3857": "s3://linz-basemaps/3857/auckland_snc50347_2003-2004_0.75m/01H8J8R3YN3C1XHZ2BMBW0VZ74",
+      "2193": "s3://linz-basemaps/2193/auckland_snc50347_2003-2004_0.75m/01H8J8R2RMBRQH6V66M8Q82K7R/",
+      "3857": "s3://linz-basemaps/3857/auckland_snc50347_2003-2004_0.75m/01H8J8R3YN3C1XHZ2BMBW0VZ74/",
       "name": "auckland-snc50347-2003-2004-0.75m",
       "title": "Auckland 0.75m SNC50347 (2003-2004)",
       "category": "Scanned Aerial Imagery",
@@ -123,8 +123,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc12781_2003_0.75m/01H8JKV9PKGEG5ZPRR51S0P4MW",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc12781_2003_0.75m/01H8JFS8AZJB4Z7F6MBQEC46TG",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc12781_2003_0.75m/01H8JKV9PKGEG5ZPRR51S0P4MW/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc12781_2003_0.75m/01H8JFS8AZJB4Z7F6MBQEC46TG/",
       "name": "manawatu-whanganui-snc12781-2003-0.75m",
       "title": "Manawatū-Whanganui 0.75m SNC12781 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -132,8 +132,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_snc12780_2003_0.64m/01H8JKE55NK8QQZTVD1HYDDHA0",
-      "3857": "s3://linz-basemaps/3857/otago_snc12780_2003_0.64m/01H8JKE5JAVQ7187CJ48SZ9ERA",
+      "2193": "s3://linz-basemaps/2193/otago_snc12780_2003_0.64m/01H8JKE55NK8QQZTVD1HYDDHA0/",
+      "3857": "s3://linz-basemaps/3857/otago_snc12780_2003_0.64m/01H8JKE5JAVQ7187CJ48SZ9ERA/",
       "name": "otago-snc12780-2003-0.64m",
       "title": "Otago 0.64m SNC12780 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -141,8 +141,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_snc30012_2003_0.75m/01H8JM6SQBD1ST5Z50KDE5FQJ2",
-      "3857": "s3://linz-basemaps/3857/southland_otago_snc30012_2003_0.75m/01H8JM6SQY8E4ZX321XJ6KK8PB",
+      "2193": "s3://linz-basemaps/2193/southland_otago_snc30012_2003_0.75m/01H8JM6SQBD1ST5Z50KDE5FQJ2/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_snc30012_2003_0.75m/01H8JM6SQY8E4ZX321XJ6KK8PB/",
       "name": "southland-otago-snc30012-2003-0.75m",
       "title": "Southland / Otago 0.75m SNC30012 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -150,8 +150,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_snc30005b_2003_0.75m/01H8JMC4N3FNSWWRXE3YDT0A81",
-      "3857": "s3://linz-basemaps/3857/southland_snc30005b_2003_0.75m/01H8JMC506FM3GSXAYPKRWBGDS",
+      "2193": "s3://linz-basemaps/2193/southland_snc30005b_2003_0.75m/01H8JMC4N3FNSWWRXE3YDT0A81/",
+      "3857": "s3://linz-basemaps/3857/southland_snc30005b_2003_0.75m/01H8JMC506FM3GSXAYPKRWBGDS/",
       "name": "southland-snc30005b-2003-0.75m",
       "title": "Southland 0.75m SNC30005b (2003)",
       "category": "Scanned Aerial Imagery",
@@ -159,8 +159,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_snc30011_2003_0.75m/01H8JMCJ3Y9BG3EFV7YC8NCRG1",
-      "3857": "s3://linz-basemaps/3857/southland_snc30011_2003_0.75m/01H8JMCJ3C1X3WY25CYZVATT53",
+      "2193": "s3://linz-basemaps/2193/southland_snc30011_2003_0.75m/01H8JMCJ3Y9BG3EFV7YC8NCRG1/",
+      "3857": "s3://linz-basemaps/3857/southland_snc30011_2003_0.75m/01H8JMCJ3C1X3WY25CYZVATT53/",
       "name": "southland-snc30011-2003-0.75m",
       "title": "Southland 0.75m SNC30011 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -168,8 +168,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc30009_2003_0.75m/01H8JBJB09Q8VPCJXPC1ZX0SYH",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc30009_2003_0.75m/01H8JBKATD5CER0QS0HJHA8W9C",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc30009_2003_0.75m/01H8JBJB09Q8VPCJXPC1ZX0SYH/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc30009_2003_0.75m/01H8JBKATD5CER0QS0HJHA8W9C/",
       "name": "canterbury-snc30009-2003-0.75m",
       "title": "Canterbury 0.75m SNC30009 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -177,8 +177,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50126_2003_0.6m/01H8JBPXD5E69MHD4J6QHPARQC",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50126_2003_0.6m/01H8JBNMRFFZZ10ARPDAR5P8X3",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc50126_2003_0.6m/01H8JBPXD5E69MHD4J6QHPARQC/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc50126_2003_0.6m/01H8JBNMRFFZZ10ARPDAR5P8X3/",
       "name": "hawkes-bay-snc50126-2003-0.6m",
       "title": "Hawkes Bay 0.6m SNC50126 (2003)",
       "category": "Scanned Aerial Imagery",
@@ -186,8 +186,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_snc30007_2002_0.75m/01H8JHTXZ548BH9330YZ9M2M4R",
-      "3857": "s3://linz-basemaps/3857/marlborough_snc30007_2002_0.75m/01H8JHTXZ16WXY3BVTJJ40DSQX",
+      "2193": "s3://linz-basemaps/2193/marlborough_snc30007_2002_0.75m/01H8JHTXZ548BH9330YZ9M2M4R/",
+      "3857": "s3://linz-basemaps/3857/marlborough_snc30007_2002_0.75m/01H8JHTXZ16WXY3BVTJJ40DSQX/",
       "name": "marlborough-snc30007-2002-0.75m",
       "title": "Marlborough 0.75m SNC30007 (2002)",
       "category": "Scanned Aerial Imagery",
@@ -195,8 +195,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_snc30010_2002_0.75m/01H8JQDYMM0W853QVFA4GSWKMX",
-      "3857": "s3://linz-basemaps/3857/wellington_snc30010_2002_0.75m/01H8JQE8MGH8AMBD578MDX9W0M",
+      "2193": "s3://linz-basemaps/2193/wellington_snc30010_2002_0.75m/01H8JQDYMM0W853QVFA4GSWKMX/",
+      "3857": "s3://linz-basemaps/3857/wellington_snc30010_2002_0.75m/01H8JQE8MGH8AMBD578MDX9W0M/",
       "name": "wellington-snc30010-2002-0.75m",
       "title": "Wellington 0.75m SNC30010 (2002)",
       "category": "Scanned Aerial Imagery",
@@ -204,8 +204,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc30006a_2002_0.75m/01H8J9Z4YFVG6AZ2NG5WQKWPEK",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc30006a_2002_0.75m/01H8J9Z4XG259145C7CVH6BNAA",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc30006a_2002_0.75m/01H8J9Z4YFVG6AZ2NG5WQKWPEK/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc30006a_2002_0.75m/01H8J9Z4XG259145C7CVH6BNAA/",
       "name": "bay-of-plenty-snc30006a-2002-0.75m",
       "title": "Bay of Plenty 0.75m SNC30006a (2002)",
       "category": "Scanned Aerial Imagery",
@@ -213,8 +213,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_snc30005a_2002_0.75m/01H8JMB9NPBEC3168KZ24DK6QW",
-      "3857": "s3://linz-basemaps/3857/southland_snc30005a_2002_0.75m/01H8JMB9R6J1GNCT2D0MB8VYX6",
+      "2193": "s3://linz-basemaps/2193/southland_snc30005a_2002_0.75m/01H8JMB9NPBEC3168KZ24DK6QW/",
+      "3857": "s3://linz-basemaps/3857/southland_snc30005a_2002_0.75m/01H8JMB9R6J1GNCT2D0MB8VYX6/",
       "name": "southland-snc30005a-2002-0.75m",
       "title": "Southland 0.75m SNC30005a (2002)",
       "category": "Scanned Aerial Imagery",
@@ -222,8 +222,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_snc30002_2002_0.75m/01H8JN7WN6Q04XGEPR1PFVPC69",
-      "3857": "s3://linz-basemaps/3857/tasman_snc30002_2002_0.75m/01H8JN7WNVQYWQ74FE2XQ393BQ",
+      "2193": "s3://linz-basemaps/2193/tasman_snc30002_2002_0.75m/01H8JN7WN6Q04XGEPR1PFVPC69/",
+      "3857": "s3://linz-basemaps/3857/tasman_snc30002_2002_0.75m/01H8JN7WNVQYWQ74FE2XQ393BQ/",
       "name": "tasman-snc30002-2002-0.75m",
       "title": "Tasman 0.75m SNC30002 (2002)",
       "category": "Scanned Aerial Imagery",
@@ -231,8 +231,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_snc30004_2002_0.75m/01H8JN1FK2ASF438EQA5F0DDB8",
-      "3857": "s3://linz-basemaps/3857/taranaki_snc30004_2002_0.75m/01H8JN1FH0M30F8NB7YSV4R4BG",
+      "2193": "s3://linz-basemaps/2193/taranaki_snc30004_2002_0.75m/01H8JN1FK2ASF438EQA5F0DDB8/",
+      "3857": "s3://linz-basemaps/3857/taranaki_snc30004_2002_0.75m/01H8JN1FH0M30F8NB7YSV4R4BG/",
       "name": "taranaki-snc30004-2002-0.75m",
       "title": "Taranaki 0.75m SNC30004 (2002)",
       "category": "Scanned Aerial Imagery",
@@ -240,8 +240,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_snc30003_2002_0.75m/01H8JRKG48T0SHF8FT4GTN13G2",
-      "3857": "s3://linz-basemaps/3857/west-coast_snc30003_2002_0.75m/01H8JRA4H62PC3BW6PGTA74DKF",
+      "2193": "s3://linz-basemaps/2193/west-coast_snc30003_2002_0.75m/01H8JRKG48T0SHF8FT4GTN13G2/",
+      "3857": "s3://linz-basemaps/3857/west-coast_snc30003_2002_0.75m/01H8JRA4H62PC3BW6PGTA74DKF/",
       "name": "west-coast-snc30003-2002-0.75m",
       "title": "West Coast 0.75m SNC30003 (2002)",
       "category": "Scanned Aerial Imagery",
@@ -249,8 +249,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_snc12731_2002_0.75m/01H8JM01HJNA5J3P29WH13ZMRP",
-      "3857": "s3://linz-basemaps/3857/southland_otago_snc12731_2002_0.75m/01H8JM01F9KPMJ7B5YKJJK0NJJ",
+      "2193": "s3://linz-basemaps/2193/southland_otago_snc12731_2002_0.75m/01H8JM01HJNA5J3P29WH13ZMRP/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_snc12731_2002_0.75m/01H8JM01F9KPMJ7B5YKJJK0NJJ/",
       "name": "southland-otago-snc12731-2002-0.75m",
       "title": "Southland / Otago 0.75m SNC12731 (2002)",
       "category": "Scanned Aerial Imagery",
@@ -258,8 +258,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc30000_2002_0.75m/01H8JBJ99AE6C0S9VPGXCXH4AK",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc30000_2002_0.75m/01H8JBJACQS8BHYCDT6XCVC66S",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc30000_2002_0.75m/01H8JBJ99AE6C0S9VPGXCXH4AK/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc30000_2002_0.75m/01H8JBJACQS8BHYCDT6XCVC66S/",
       "name": "canterbury-snc30000-2002-0.75m",
       "title": "Canterbury 0.75m SNC30000 (2002)",
       "category": "Scanned Aerial Imagery",
@@ -267,8 +267,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/01H8JBMM4W3P00PG4QP0ZEY9HH",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/01H8JBMAQX8JJT7347NMJS9MZ2",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/01H8JBMM4W3P00PG4QP0ZEY9HH/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/01H8JBMAQX8JJT7347NMJS9MZ2/",
       "name": "hawkes-bay-manawatu-whanganui-snc30001-2002-0.75m",
       "title": "Hawkes Bay / Manawatū-Whanganui 0.75m SNC30001 (2002)",
       "category": "Scanned Aerial Imagery",
@@ -276,8 +276,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_snc9990_2001-2003_0.6m/01H8JPFA86KNXMC1VWKY4TKQPF",
-      "3857": "s3://linz-basemaps/3857/waikato_snc9990_2001-2003_0.6m/01H8JPGGE02AAR5S5A8M0D7G4N",
+      "2193": "s3://linz-basemaps/2193/waikato_snc9990_2001-2003_0.6m/01H8JPFA86KNXMC1VWKY4TKQPF/",
+      "3857": "s3://linz-basemaps/3857/waikato_snc9990_2001-2003_0.6m/01H8JPGGE02AAR5S5A8M0D7G4N/",
       "name": "waikato-snc9990-2001-2003-0.6m",
       "title": "Waikato 0.6m SNC9990 (2001-2003)",
       "category": "Scanned Aerial Imagery",
@@ -285,8 +285,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_snc25044_2001_0.75m/01H8JN1FH0DCS9CADVJNXSVTGH",
-      "3857": "s3://linz-basemaps/3857/taranaki_snc25044_2001_0.75m/01H8JN1FJHXM99TQ6KZ8FYFDY6",
+      "2193": "s3://linz-basemaps/2193/taranaki_snc25044_2001_0.75m/01H8JN1FH0DCS9CADVJNXSVTGH/",
+      "3857": "s3://linz-basemaps/3857/taranaki_snc25044_2001_0.75m/01H8JN1FJHXM99TQ6KZ8FYFDY6/",
       "name": "taranaki-snc25044-2001-0.75m",
       "title": "Taranaki 0.75m SNC25044 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -294,8 +294,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc25061_2001_0.75m/01H8JFWM82K3F0YKSFDBB7DTWH",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc25061_2001_0.75m/01H8JJWNQ32F3VY5BF8Q5HQ4JF",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc25061_2001_0.75m/01H8JFWM82K3F0YKSFDBB7DTWH/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc25061_2001_0.75m/01H8JJWNQ32F3VY5BF8Q5HQ4JF/",
       "name": "manawatu-whanganui-snc25061-2001-0.75m",
       "title": "Manawatū-Whanganui 0.75m SNC25061 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -303,8 +303,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_snc25055_2001_0.75m/01H8JKK96ZMRT5KC3HSK167AJ7",
-      "3857": "s3://linz-basemaps/3857/otago_snc25055_2001_0.75m/01H8JKK97QYPD7SN5FBQJS94JD",
+      "2193": "s3://linz-basemaps/2193/otago_snc25055_2001_0.75m/01H8JKK96ZMRT5KC3HSK167AJ7/",
+      "3857": "s3://linz-basemaps/3857/otago_snc25055_2001_0.75m/01H8JKK97QYPD7SN5FBQJS94JD/",
       "name": "otago-snc25055-2001-0.75m",
       "title": "Otago 0.75m SNC25055 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -312,8 +312,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_snc25057_2001_0.75m/01H8JKMAST7B8R9JT26VASAYCA",
-      "3857": "s3://linz-basemaps/3857/otago_snc25057_2001_0.75m/01H8JKMAV260422QGPZX6D351D",
+      "2193": "s3://linz-basemaps/2193/otago_snc25057_2001_0.75m/01H8JKMAST7B8R9JT26VASAYCA/",
+      "3857": "s3://linz-basemaps/3857/otago_snc25057_2001_0.75m/01H8JKMAV260422QGPZX6D351D/",
       "name": "otago-snc25057-2001-0.75m",
       "title": "Otago 0.75m SNC25057 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -321,8 +321,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc25053_2001_0.75m/01H8JBJ5MQDQMHPQETM02HAEJF",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc25053_2001_0.75m/01H8JBJ576DP2TDB96N7GGDGQ9",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc25053_2001_0.75m/01H8JBJ5MQDQMHPQETM02HAEJF/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc25053_2001_0.75m/01H8JBJ576DP2TDB96N7GGDGQ9/",
       "name": "canterbury-snc25053-2001-0.75m",
       "title": "Canterbury 0.75m SNC25053 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -330,8 +330,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_snc25060_2001_0.75m/01H8JNHQ93AQS66ZXYHQZPHT9G",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_snc25060_2001_0.75m/01H8JNHQ7KNBDNS2MMKT3ADJXS",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_snc25060_2001_0.75m/01H8JNHQ93AQS66ZXYHQZPHT9G/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_snc25060_2001_0.75m/01H8JNHQ7KNBDNS2MMKT3ADJXS/",
       "name": "waikato-bay-of-plenty-snc25060-2001-0.75m",
       "title": "Waikato / Bay of Plenty 0.75m SNC25060 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -339,8 +339,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_waikato_snc25058_2001_0.75m/01H8JA2S7SEX46T1Q94TR46M2H",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_waikato_snc25058_2001_0.75m/01H8JA2S6Q9RPR5EPR23JCR3EZ",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_waikato_snc25058_2001_0.75m/01H8JA2S7SEX46T1Q94TR46M2H/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_waikato_snc25058_2001_0.75m/01H8JA2S6Q9RPR5EPR23JCR3EZ/",
       "name": "bay-of-plenty-waikato-snc25058-2001-0.75m",
       "title": "Bay of Plenty / Waikato 0.75m SNC25058 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -348,8 +348,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc25045_2001_0.75m/01H8JFW5DY2CMJAHYEV3MN4SQY",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc25045_2001_0.75m/01H8JFTW8BBZBR3MQA5XZTTP7G",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc25045_2001_0.75m/01H8JFW5DY2CMJAHYEV3MN4SQY/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc25045_2001_0.75m/01H8JFTW8BBZBR3MQA5XZTTP7G/",
       "name": "manawatu-whanganui-snc25045-2001-0.75m",
       "title": "Manawatū-Whanganui 0.75m SNC25045 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -357,8 +357,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc25059_2001_0.75m/01H8MV0MDV05G2KSM1YVNJV9D7",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc25059_2001_0.75m/01H8MV0MD8NA83R7WMH0EN9JFF",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_snc25059_2001_0.75m/01H8MV0MDV05G2KSM1YVNJV9D7/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_snc25059_2001_0.75m/01H8MV0MD8NA83R7WMH0EN9JFF/",
       "name": "bay-of-plenty-snc25059-2001-0.75m",
       "title": "Bay of Plenty 0.75m SNC25059 (2001)",
       "category": "Scanned Aerial Imagery",
@@ -366,8 +366,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_snc25046_2000_0.75m/01H8JBKX1TYX5KBKAKY35Q3WW1",
-      "3857": "s3://linz-basemaps/3857/gisborne_snc25046_2000_0.75m/01H8JBJZ6HQ7G9QZM3QS2HCTW2",
+      "2193": "s3://linz-basemaps/2193/gisborne_snc25046_2000_0.75m/01H8JBKX1TYX5KBKAKY35Q3WW1/",
+      "3857": "s3://linz-basemaps/3857/gisborne_snc25046_2000_0.75m/01H8JBJZ6HQ7G9QZM3QS2HCTW2/",
       "name": "gisborne-snc25046-2000-0.75m",
       "title": "Gisborne 0.75m SNC25046 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -375,8 +375,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc25051_2000_0.75m/01H8JBJ4TD82PY4BFZE274M88G",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc25051_2000_0.75m/01H8JBJ4EFB6BYY40S98ADJW2C",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc25051_2000_0.75m/01H8JBJ4TD82PY4BFZE274M88G/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc25051_2000_0.75m/01H8JBJ4EFB6BYY40S98ADJW2C/",
       "name": "canterbury-snc25051-2000-0.75m",
       "title": "Canterbury 0.75m SNC25051 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -384,8 +384,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_snc25054_2000-2001_0.75m/01H8JBJ86AEDMR04KD0RZNFQN2",
-      "3857": "s3://linz-basemaps/3857/canterbury_snc25054_2000-2001_0.75m/01H8JBJ795K7W1XASZCVY5D630",
+      "2193": "s3://linz-basemaps/2193/canterbury_snc25054_2000-2001_0.75m/01H8JBJ86AEDMR04KD0RZNFQN2/",
+      "3857": "s3://linz-basemaps/3857/canterbury_snc25054_2000-2001_0.75m/01H8JBJ795K7W1XASZCVY5D630/",
       "name": "canterbury-snc25054-2000-2001-0.75m",
       "title": "Canterbury 0.75m SNC25054 (2000-2001)",
       "category": "Scanned Aerial Imagery",
@@ -393,8 +393,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_snc25049_2000_0.75m/01H8JN8G6DSJXF71833N0YG5QS",
-      "3857": "s3://linz-basemaps/3857/tasman_snc25049_2000_0.75m/01H8JN7ET3W1A8HWPY1814DZQA",
+      "2193": "s3://linz-basemaps/2193/tasman_snc25049_2000_0.75m/01H8JN8G6DSJXF71833N0YG5QS/",
+      "3857": "s3://linz-basemaps/3857/tasman_snc25049_2000_0.75m/01H8JN7ET3W1A8HWPY1814DZQA/",
       "name": "tasman-snc25049-2000-0.75m",
       "title": "Tasman 0.75m SNC25049 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -402,8 +402,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_snc25062_2000_0.75m/01H8JRABWXZF4X2HJDSH6MJ0VC",
-      "3857": "s3://linz-basemaps/3857/wellington_snc25062_2000_0.75m/01H8JQFFC9S81YG77X4HEXBKR0",
+      "2193": "s3://linz-basemaps/2193/wellington_snc25062_2000_0.75m/01H8JRABWXZF4X2HJDSH6MJ0VC/",
+      "3857": "s3://linz-basemaps/3857/wellington_snc25062_2000_0.75m/01H8JQFFC9S81YG77X4HEXBKR0/",
       "name": "wellington-snc25062-2000-0.75m",
       "title": "Wellington 0.75m SNC25062 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -411,8 +411,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_snc25048_2000_0.75m/01H8JHHWKHBJKATYTKQ3X917QK",
-      "3857": "s3://linz-basemaps/3857/marlborough_snc25048_2000_0.75m/01H8JHHWMNZM68EQV2Z7THK349",
+      "2193": "s3://linz-basemaps/2193/marlborough_snc25048_2000_0.75m/01H8JHHWKHBJKATYTKQ3X917QK/",
+      "3857": "s3://linz-basemaps/3857/marlborough_snc25048_2000_0.75m/01H8JHHWMNZM68EQV2Z7THK349/",
       "name": "marlborough-snc25048-2000-0.75m",
       "title": "Marlborough 0.75m SNC25048 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -420,8 +420,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_snc25047_2000_0.75m/01H8JPJZZQMY8KWFBSXMKKP8FS",
-      "3857": "s3://linz-basemaps/3857/wellington_snc25047_2000_0.75m/01H8JPK000T892DXZPPJSDBB42",
+      "2193": "s3://linz-basemaps/2193/wellington_snc25047_2000_0.75m/01H8JPJZZQMY8KWFBSXMKKP8FS/",
+      "3857": "s3://linz-basemaps/3857/wellington_snc25047_2000_0.75m/01H8JPK000T892DXZPPJSDBB42/",
       "name": "wellington-snc25047-2000-0.75m",
       "title": "Wellington 0.75m SNC25047 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -429,8 +429,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_canterbury_sn9933_2000_0.75m/01H8JJYKZBWEMVSDDZ0SD181S7",
-      "3857": "s3://linz-basemaps/3857/otago_canterbury_sn9933_2000_0.75m/01H8JJYKZBM32HBS9P8NPRCZVJ",
+      "2193": "s3://linz-basemaps/2193/otago_canterbury_sn9933_2000_0.75m/01H8JJYKZBWEMVSDDZ0SD181S7/",
+      "3857": "s3://linz-basemaps/3857/otago_canterbury_sn9933_2000_0.75m/01H8JJYKZBM32HBS9P8NPRCZVJ/",
       "name": "otago-canterbury-sn9933-2000-0.75m",
       "title": "Otago / Canterbury 0.75m SN9933 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -438,8 +438,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn9937_2000_0.75m/01H8JKCHEVFDNAR1MM8JD48FX6",
-      "3857": "s3://linz-basemaps/3857/otago_sn9937_2000_0.75m/01H8JKCJA7PXCPXZ7EJYZ01SRR",
+      "2193": "s3://linz-basemaps/2193/otago_sn9937_2000_0.75m/01H8JKCHEVFDNAR1MM8JD48FX6/",
+      "3857": "s3://linz-basemaps/3857/otago_sn9937_2000_0.75m/01H8JKCJA7PXCPXZ7EJYZ01SRR/",
       "name": "otago-sn9937-2000-0.75m",
       "title": "Otago 0.75m SN9937 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -447,8 +447,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn9911_2000_0.75m/01H8JGVP963WRWJJAYFRG99JDF",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn9911_2000_0.75m/01H8JGVP851KTQGN72MFYC4MEH",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn9911_2000_0.75m/01H8JGVP963WRWJJAYFRG99JDF/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn9911_2000_0.75m/01H8JGVP851KTQGN72MFYC4MEH/",
       "name": "manawatu-whanganui-wellington-sn9911-2000-0.75m",
       "title": "Manawatū-Whanganui / Wellington 0.75m SN9911 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -456,8 +456,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_auckland_sn9919_2000_0.75m/01H8JNA0P0WG07ZNJMP5WZGKGN",
-      "3857": "s3://linz-basemaps/3857/waikato_auckland_sn9919_2000_0.75m/01H8JNA0NXYKNK00N7RAYHGS28",
+      "2193": "s3://linz-basemaps/2193/waikato_auckland_sn9919_2000_0.75m/01H8JNA0P0WG07ZNJMP5WZGKGN/",
+      "3857": "s3://linz-basemaps/3857/waikato_auckland_sn9919_2000_0.75m/01H8JNA0NXYKNK00N7RAYHGS28/",
       "name": "waikato-auckland-sn9919-2000-0.75m",
       "title": "Waikato / Auckland 0.75m SN9919 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -465,8 +465,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_snc9935_2000-2003_0.75m/01H8JJX7PMH7HKVB8D9AHZ25QJ",
-      "3857": "s3://linz-basemaps/3857/northland_snc9935_2000-2003_0.75m/01H8JJX7NKKRKW7CN6RQTZJYX1",
+      "2193": "s3://linz-basemaps/2193/northland_snc9935_2000-2003_0.75m/01H8JJX7PMH7HKVB8D9AHZ25QJ/",
+      "3857": "s3://linz-basemaps/3857/northland_snc9935_2000-2003_0.75m/01H8JJX7NKKRKW7CN6RQTZJYX1/",
       "name": "northland-snc9935-2000-2003-0.75m",
       "title": "Northland 0.75m SNC9935 (2000-2003)",
       "category": "Scanned Aerial Imagery",
@@ -474,8 +474,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn25017_2000_0.64m/01H8JBMCS9XZNYH6HWYFGZMAGT",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn25017_2000_0.64m/01H8JBN0TNYFAQ104YWNHBKZDA",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn25017_2000_0.64m/01H8JBMCS9XZNYH6HWYFGZMAGT/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn25017_2000_0.64m/01H8JBN0TNYFAQ104YWNHBKZDA/",
       "name": "manawatu-whanganui-sn25017-2000-0.64m",
       "title": "Manawatū-Whanganui 0.64m SN25017 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -483,8 +483,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn25016_2000_0.75m/01H8JMK0GTXMZWWZ6CCSNCBG3P",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn25016_2000_0.75m/01H8JMK0H32K24G228YH2RZW75",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn25016_2000_0.75m/01H8JMK0GTXMZWWZ6CCSNCBG3P/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn25016_2000_0.75m/01H8JMK0H32K24G228YH2RZW75/",
       "name": "taranaki-sn25016-2000-0.75m",
       "title": "Taranaki 0.75m SN25016 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -492,8 +492,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn25022_2000_0.75m/01H8JAK010535HKTMW5FNQ4AMW",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn25022_2000_0.75m/01H8JAJC6ZJ7GVMYT4SC554D9E",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn25022_2000_0.75m/01H8JAK010535HKTMW5FNQ4AMW/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn25022_2000_0.75m/01H8JAJC6ZJ7GVMYT4SC554D9E/",
       "name": "canterbury-sn25022-2000-0.75m",
       "title": "Canterbury 0.75m SN25022 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -501,8 +501,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_marlborough_nelson_sn25020_2000_0.75m/01H8JN1Y33RDQDQGEDRQJGY8SF",
-      "3857": "s3://linz-basemaps/3857/tasman_marlborough_nelson_sn25020_2000_0.75m/01H8JN1Y3AHNJSGDEHQAHG85KR",
+      "2193": "s3://linz-basemaps/2193/tasman_marlborough_nelson_sn25020_2000_0.75m/01H8JN1Y33RDQDQGEDRQJGY8SF/",
+      "3857": "s3://linz-basemaps/3857/tasman_marlborough_nelson_sn25020_2000_0.75m/01H8JN1Y3AHNJSGDEHQAHG85KR/",
       "name": "tasman-marlborough-nelson-sn25020-2000-0.75m",
       "title": "Tasman / Marlborough / Nelson 0.75m SN25020 (2000)",
       "category": "Scanned Aerial Imagery",
@@ -510,8 +510,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9859_1999_0.625m/01H8JPCDS96PH32JZ2ERQ5C2BH",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9859_1999_0.625m/01H8JPCDV33DRXD3TGSTZK98AV",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9859_1999_0.625m/01H8JPCDS96PH32JZ2ERQ5C2BH/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9859_1999_0.625m/01H8JPCDV33DRXD3TGSTZK98AV/",
       "name": "waikato-sn9859-1999-0.625m",
       "title": "Waikato 0.625m SN9859 (1999)",
       "category": "Scanned Aerial Imagery",
@@ -519,8 +519,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/01H8JBKR3C1Y5HFCZPTN4E1Y7Y",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/01H8JBMA78JZY4HJSD2NZKYMGX",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/01H8JBKR3C1Y5HFCZPTN4E1Y7Y/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/01H8JBMA78JZY4HJSD2NZKYMGX/",
       "name": "manawatu-whanganui-hawkes-bay-sn12541-1999-0.75m",
       "title": "Manawatū-Whanganui / Hawkes Bay 0.75m SN12541 (1999)",
       "category": "Scanned Aerial Imagery",
@@ -528,8 +528,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn12539_1999_0.75m/01H8JNAW9EWM95YX3ARBYB0ZAB",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn12539_1999_0.75m/01H8JNC6TC4Y6HQYY6M5ESVFC0",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn12539_1999_0.75m/01H8JNAW9EWM95YX3ARBYB0ZAB/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn12539_1999_0.75m/01H8JNC6TC4Y6HQYY6M5ESVFC0/",
       "name": "waikato-bay-of-plenty-sn12539-1999-0.75m",
       "title": "Waikato / Bay of Plenty 0.75m SN12539 (1999)",
       "category": "Scanned Aerial Imagery",
@@ -537,8 +537,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn12545a_1998_0.75m/01H8JM6SQCZW0P3NZ0A47WPFT9",
-      "3857": "s3://linz-basemaps/3857/southland_sn12545a_1998_0.75m/01H8JM6SJWSGXE5VKANA3XMB0R",
+      "2193": "s3://linz-basemaps/2193/southland_sn12545a_1998_0.75m/01H8JM6SQCZW0P3NZ0A47WPFT9/",
+      "3857": "s3://linz-basemaps/3857/southland_sn12545a_1998_0.75m/01H8JM6SJWSGXE5VKANA3XMB0R/",
       "name": "southland-sn12545a-1998-0.75m",
       "title": "Southland 0.75m SN12545A (1998)",
       "category": "Scanned Aerial Imagery",
@@ -546,8 +546,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn12543_1998-1999_0.75m/01H8JAGE1S1E8X728ZWQ79QJR8",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn12543_1998-1999_0.75m/01H8JAGE2KESEHDXNQYD96TWW8",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn12543_1998-1999_0.75m/01H8JAGE1S1E8X728ZWQ79QJR8/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn12543_1998-1999_0.75m/01H8JAGE2KESEHDXNQYD96TWW8/",
       "name": "canterbury-sn12543-1998-1999-0.75m",
       "title": "Canterbury 0.75m SN12543 (1998-1999)",
       "category": "Scanned Aerial Imagery",
@@ -555,8 +555,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn12544_1998_0.75m/01H8JJZ2R6CP5FYRY1W173GEG3",
-      "3857": "s3://linz-basemaps/3857/otago_sn12544_1998_0.75m/01H8JJZ2RGQ0V55D9DTJKQESDH",
+      "2193": "s3://linz-basemaps/2193/otago_sn12544_1998_0.75m/01H8JJZ2R6CP5FYRY1W173GEG3/",
+      "3857": "s3://linz-basemaps/3857/otago_sn12544_1998_0.75m/01H8JJZ2RGQ0V55D9DTJKQESDH/",
       "name": "otago-sn12544-1998-0.75m",
       "title": "Otago 0.75m SN12544 (1998)",
       "category": "Scanned Aerial Imagery",
@@ -564,8 +564,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn12542_1998_0.75m/01H8JAFPHZWJX401BF10BB76BF",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn12542_1998_0.75m/01H8JAFPKXDESAM4T90N643H5J",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn12542_1998_0.75m/01H8JAFPHZWJX401BF10BB76BF/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn12542_1998_0.75m/01H8JAFPKXDESAM4T90N643H5J/",
       "name": "canterbury-sn12542-1998-0.75m",
       "title": "Canterbury 0.75m SN12542 (1998)",
       "category": "Scanned Aerial Imagery",
@@ -573,8 +573,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn12540_1998_0.75m/01H8JBJHVQAF1HE6R5A04TFFRY",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn12540_1998_0.75m/01H8JBJT1Y4PZRYX8PQ989SVAE",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn12540_1998_0.75m/01H8JBJHVQAF1HE6R5A04TFFRY/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn12540_1998_0.75m/01H8JBJT1Y4PZRYX8PQ989SVAE/",
       "name": "gisborne-sn12540-1998-0.75m",
       "title": "Gisborne 0.75m SN12540 (1998)",
       "category": "Scanned Aerial Imagery",
@@ -582,8 +582,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn9641_1997_0.75m/01H8JQNB71Z2QHW3NRCDGGT6SE",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn9641_1997_0.75m/01H8JQNB6SY4Q8ZWTHJ9T7ANHJ",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn9641_1997_0.75m/01H8JQNB71Z2QHW3NRCDGGT6SE/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn9641_1997_0.75m/01H8JQNB6SY4Q8ZWTHJ9T7ANHJ/",
       "name": "west-coast-sn9641-1997-0.75m",
       "title": "West Coast 0.75m SN9641 (1997)",
       "category": "Scanned Aerial Imagery",
@@ -591,8 +591,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn9613_1997_0.75m/01H8JKZED3BMX7H3H982A46542",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn9613_1997_0.75m/01H8JKZED3SXF3XE4HM3ER9B4Q",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn9613_1997_0.75m/01H8JKZED3BMX7H3H982A46542/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn9613_1997_0.75m/01H8JKZED3SXF3XE4HM3ER9B4Q/",
       "name": "southland-otago-sn9613-1997-0.75m",
       "title": "Southland / Otago 0.75m SN9613 (1997)",
       "category": "Scanned Aerial Imagery",
@@ -600,8 +600,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9615_1997_0.8m/01H8JPCDRE2CYQJVM2R1TDH62K",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9615_1997_0.8m/01H8JPCDQRPWC1K1R0PZJC9FKT",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9615_1997_0.8m/01H8JPCDRE2CYQJVM2R1TDH62K/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9615_1997_0.8m/01H8JPCDQRPWC1K1R0PZJC9FKT/",
       "name": "waikato-sn9615-1997-0.8m",
       "title": "Waikato 0.8m SN9615 (1997)",
       "category": "Scanned Aerial Imagery",
@@ -609,8 +609,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn9586_1996_0.32m/01H8JHGBMH29KDA07NRS7VFS2K",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn9586_1996_0.32m/01H8JHGBKW6SQN9346F1MHJW89",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn9586_1996_0.32m/01H8JHGBMH29KDA07NRS7VFS2K/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn9586_1996_0.32m/01H8JHGBKW6SQN9346F1MHJW89/",
       "name": "marlborough-sn9586-1996-0.32m",
       "title": "Marlborough 0.32m SN9586 (1996)",
       "category": "Scanned Aerial Imagery",
@@ -618,8 +618,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9585_1996_0.8m/01H8JBK7T3F25XJKQ5TB701QBZ",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9585_1996_0.8m/01H8JBKT1MKG1JP8ZBCNZ4C35E",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9585_1996_0.8m/01H8JBK7T3F25XJKQ5TB701QBZ/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9585_1996_0.8m/01H8JBKT1MKG1JP8ZBCNZ4C35E/",
       "name": "hawkes-bay-sn9585-1996-0.8m",
       "title": "Hawkes Bay 0.8m SN9585 (1996)",
       "category": "Scanned Aerial Imagery",
@@ -627,8 +627,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9584_1996-1997_0.64m/01H8JPCDRV8XRVE31YHMJBV7E4",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9584_1996-1997_0.64m/01H8JPCDRRQ3N2XZY09E2JTS2X",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9584_1996-1997_0.64m/01H8JPCDRV8XRVE31YHMJBV7E4/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9584_1996-1997_0.64m/01H8JPCDRRQ3N2XZY09E2JTS2X/",
       "name": "waikato-sn9584-1996-1997-0.64m",
       "title": "Waikato 0.64m SN9584 (1996-1997)",
       "category": "Scanned Aerial Imagery",
@@ -636,8 +636,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn9493_1996_0.75m/01H8JQM3YS7GV1BYPJ11DGY4PN",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn9493_1996_0.75m/01H8JQM48NQC38PYH3RBCZN5PQ",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn9493_1996_0.75m/01H8JQM3YS7GV1BYPJ11DGY4PN/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn9493_1996_0.75m/01H8JQM48NQC38PYH3RBCZN5PQ/",
       "name": "west-coast-sn9493-1996-0.75m",
       "title": "West Coast 0.75m SN9493 (1996)",
       "category": "Scanned Aerial Imagery",
@@ -645,8 +645,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9485_1995-1996_0.375m/01H8JC5ZE7QNEYW5AJ16KJ9X11",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9485_1995-1996_0.375m/01H8JC5YM30GA0P6GWPFEJ34JJ",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9485_1995-1996_0.375m/01H8JC5ZE7QNEYW5AJ16KJ9X11/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9485_1995-1996_0.375m/01H8JC5YM30GA0P6GWPFEJ34JJ/",
       "name": "hawkes-bay-sn9485-1995-1996-0.375m",
       "title": "Hawkes Bay 0.375m SN9485 (1995-1996)",
       "category": "Scanned Aerial Imagery",
@@ -654,8 +654,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/01H8JNDFZPHZ0EB8SS21FQ61PE",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/01H8JNDG10PC59K868PN88B1XX",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/01H8JNDFZPHZ0EB8SS21FQ61PE/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/01H8JNDG10PC59K868PN88B1XX/",
       "name": "waikato-bay-of-plenty-sn9445-1995-1997-0.75m",
       "title": "Waikato / Bay of Plenty 0.75m SN9445 (1995-1997)",
       "category": "Scanned Aerial Imagery",
@@ -663,8 +663,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn9471_1995_0.8m/01H8JHFJ6G0PQ198DN59KJMVQZ",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn9471_1995_0.8m/01H8JHFJ5ZEGG6813Y4JTFE4Y0",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn9471_1995_0.8m/01H8JHFJ6G0PQ198DN59KJMVQZ/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn9471_1995_0.8m/01H8JHFJ5ZEGG6813Y4JTFE4Y0/",
       "name": "marlborough-sn9471-1995-0.8m",
       "title": "Marlborough 0.8m SN9471 (1995)",
       "category": "Scanned Aerial Imagery",
@@ -672,8 +672,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9470_1995-1996_0.8m/01H8JFKD1R3RE5Y81YNA2VJSMB",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9470_1995-1996_0.8m/01H8JFKD2GA5NA444DRQXF0SER",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9470_1995-1996_0.8m/01H8JFKD1R3RE5Y81YNA2VJSMB/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9470_1995-1996_0.8m/01H8JFKD2GA5NA444DRQXF0SER/",
       "name": "manawatu-whanganui-sn9470-1995-1996-0.8m",
       "title": "Manawatū-Whanganui 0.8m SN9470 (1995-1996)",
       "category": "Scanned Aerial Imagery",
@@ -681,8 +681,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9452_1995_0.375m/01H8JBMYT5D7Y3XD2Y9C5QRZ2H",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9452_1995_0.375m/01H8JBPGB4AD3T2TCDN76XRT0N",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9452_1995_0.375m/01H8JBMYT5D7Y3XD2Y9C5QRZ2H/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9452_1995_0.375m/01H8JBPGB4AD3T2TCDN76XRT0N/",
       "name": "hawkes-bay-sn9452-1995-0.375m",
       "title": "Hawkes Bay 0.375m SN9452 (1995)",
       "category": "Scanned Aerial Imagery",
@@ -690,8 +690,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_sn9448_1995-1997_0.75m/01H8JPJPN350V5Z6E6YQ8CJ44T",
-      "3857": "s3://linz-basemaps/3857/wellington_sn9448_1995-1997_0.75m/01H8JPJPN582A7X99QBWC69RA5",
+      "2193": "s3://linz-basemaps/2193/wellington_sn9448_1995-1997_0.75m/01H8JPJPN350V5Z6E6YQ8CJ44T/",
+      "3857": "s3://linz-basemaps/3857/wellington_sn9448_1995-1997_0.75m/01H8JPJPN582A7X99QBWC69RA5/",
       "name": "wellington-sn9448-1995-1997-0.75m",
       "title": "Wellington 0.75m SN9448 (1995-1997)",
       "category": "Scanned Aerial Imagery",
@@ -699,8 +699,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn9447_1995_0.75m/01H8JBJ239BZ05306N63Y9CBQ9",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn9447_1995_0.75m/01H8JBJ2CWPK75ADVVF9APZQY6",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn9447_1995_0.75m/01H8JBJ239BZ05306N63Y9CBQ9/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn9447_1995_0.75m/01H8JBJ2CWPK75ADVVF9APZQY6/",
       "name": "canterbury-sn9447-1995-0.75m",
       "title": "Canterbury 0.75m SN9447 (1995)",
       "category": "Scanned Aerial Imagery",
@@ -708,8 +708,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn9421_1995_0.25m/01H8JMB9V2FWNW6XD9ZGFJD3Q3",
-      "3857": "s3://linz-basemaps/3857/southland_sn9421_1995_0.25m/01H8JMB9K8N2W6K9W7RWR3W2E5",
+      "2193": "s3://linz-basemaps/2193/southland_sn9421_1995_0.25m/01H8JMB9V2FWNW6XD9ZGFJD3Q3/",
+      "3857": "s3://linz-basemaps/3857/southland_sn9421_1995_0.25m/01H8JMB9K8N2W6K9W7RWR3W2E5/",
       "name": "southland-sn9421-1995-0.25m",
       "title": "Southland 0.25m SN9421 (1995)",
       "category": "Scanned Aerial Imagery",
@@ -717,8 +717,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9410_1995_0.375m/01H8JBM28A986YR4N98Y0Q6154",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9410_1995_0.375m/01H8JBMFKZVRX9XC054HNJGJT1",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9410_1995_0.375m/01H8JBM28A986YR4N98Y0Q6154/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9410_1995_0.375m/01H8JBMFKZVRX9XC054HNJGJT1/",
       "name": "hawkes-bay-sn9410-1995-0.375m",
       "title": "Hawkes Bay 0.375m SN9410 (1995)",
       "category": "Scanned Aerial Imagery",
@@ -726,8 +726,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_auckland_sn9482_1995-1996_0.8m/01H8JJ9DPAVP8SJQH0J8WTMQNA",
-      "3857": "s3://linz-basemaps/3857/northland_auckland_sn9482_1995-1996_0.8m/01H8JJ9DPTXTXQXH27E9ZBP13K",
+      "2193": "s3://linz-basemaps/2193/northland_auckland_sn9482_1995-1996_0.8m/01H8JJ9DPAVP8SJQH0J8WTMQNA/",
+      "3857": "s3://linz-basemaps/3857/northland_auckland_sn9482_1995-1996_0.8m/01H8JJ9DPTXTXQXH27E9ZBP13K/",
       "name": "northland-auckland-sn9482-1995-1996-0.8m",
       "title": "Northland / Auckland 0.8m SN9482 (1995-1996)",
       "category": "Scanned Aerial Imagery",
@@ -735,8 +735,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn9457_1995-1997_0.75m/01H8JKCGK804B44VG2SNWV7R41",
-      "3857": "s3://linz-basemaps/3857/otago_sn9457_1995-1997_0.75m/01H8JKCGMP78WB22YWGAFA3SF7",
+      "2193": "s3://linz-basemaps/2193/otago_sn9457_1995-1997_0.75m/01H8JKCGK804B44VG2SNWV7R41/",
+      "3857": "s3://linz-basemaps/3857/otago_sn9457_1995-1997_0.75m/01H8JKCGMP78WB22YWGAFA3SF7/",
       "name": "otago-sn9457-1995-1997-0.75m",
       "title": "Otago 0.75m SN9457 (1995-1997)",
       "category": "Scanned Aerial Imagery",
@@ -744,8 +744,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9401_1995_0.75m/01H8JPG11WNB12VZAQHHBYWE5N",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9401_1995_0.75m/01H8JQ6GH7QX6RJP75XBJA785B",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9401_1995_0.75m/01H8JPG11WNB12VZAQHHBYWE5N/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9401_1995_0.75m/01H8JQ6GH7QX6RJP75XBJA785B/",
       "name": "waikato-sn9401-1995-0.75m",
       "title": "Waikato 0.75m SN9401 (1995)",
       "category": "Scanned Aerial Imagery",
@@ -753,8 +753,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn9383_1994_0.75m/01H8J9TH2XK6NNFFDSWT25NDMC",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn9383_1994_0.75m/01H8J9TH7JDZX8QXSP0E8NT3KV",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn9383_1994_0.75m/01H8J9TH2XK6NNFFDSWT25NDMC/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn9383_1994_0.75m/01H8J9TH7JDZX8QXSP0E8NT3KV/",
       "name": "bay-of-plenty-sn9383-1994-0.75m",
       "title": "Bay of Plenty 0.75m SN9383 (1994)",
       "category": "Scanned Aerial Imagery",
@@ -762,8 +762,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/01H8JPK1EER9VRQ85R0ZJT9W67",
-      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/01H8JPK1EG0GVC42Q274T3ES92",
+      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/01H8JPK1EER9VRQ85R0ZJT9W67/",
+      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/01H8JPK1EG0GVC42Q274T3ES92/",
       "name": "wellington-manawatu-whanganui-sn9382-1994-1995-0.75m",
       "title": "Wellington / Manawatū-Whanganui 0.75m SN9382 (1994-1995)",
       "category": "Scanned Aerial Imagery",
@@ -771,8 +771,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn9381_1994_0.75m/01H8JBHYWS9E05WE1N38P6RAGD",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn9381_1994_0.75m/01H8JBJ0NCEJE52EBJM3E969RE",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn9381_1994_0.75m/01H8JBHYWS9E05WE1N38P6RAGD/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn9381_1994_0.75m/01H8JBJ0NCEJE52EBJM3E969RE/",
       "name": "canterbury-sn9381-1994-0.75m",
       "title": "Canterbury 0.75m SN9381 (1994)",
       "category": "Scanned Aerial Imagery",
@@ -780,8 +780,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9364_1994_0.375m/01H8JFAZB78MTYS53MT1ZN15V3",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9364_1994_0.375m/01H8JFCRKVN7X0NYQRX0XF8B1B",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9364_1994_0.375m/01H8JFAZB78MTYS53MT1ZN15V3/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9364_1994_0.375m/01H8JFCRKVN7X0NYQRX0XF8B1B/",
       "name": "manawatu-whanganui-sn9364-1994-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN9364 (1994)",
       "category": "Scanned Aerial Imagery",
@@ -789,8 +789,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9361_1994-1995_0.75m/01H8JPHWWEWBYA3F8Q8TX2TFT3",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9361_1994-1995_0.75m/01H8JPH8XQKFXDQHXH295SEZ8Q",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9361_1994-1995_0.75m/01H8JPHWWEWBYA3F8Q8TX2TFT3/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9361_1994-1995_0.75m/01H8JPH8XQKFXDQHXH295SEZ8Q/",
       "name": "waikato-sn9361-1994-1995-0.75m",
       "title": "Waikato 0.75m SN9361 (1994-1995)",
       "category": "Scanned Aerial Imagery",
@@ -798,8 +798,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn9360_1994_0.75m/01H8JHE63564ZQSWRQHW6V0QZ6",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn9360_1994_0.75m/01H8JHHTYNTQEGETWAQHP0DHTZ",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn9360_1994_0.75m/01H8JHE63564ZQSWRQHW6V0QZ6/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn9360_1994_0.75m/01H8JHHTYNTQEGETWAQHP0DHTZ/",
       "name": "marlborough-sn9360-1994-0.75m",
       "title": "Marlborough 0.75m SN9360 (1994)",
       "category": "Scanned Aerial Imagery",
@@ -807,8 +807,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn9284_1993_0.75m/01H8JGPGS61J0G5TFZFM1TYWRW",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn9284_1993_0.75m/01H8JGPFTVHYD30R3T8X677PKE",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn9284_1993_0.75m/01H8JGPGS61J0G5TFZFM1TYWRW/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn9284_1993_0.75m/01H8JGPFTVHYD30R3T8X677PKE/",
       "name": "manawatu-whanganui-wellington-sn9284-1993-0.75m",
       "title": "Manawatū-Whanganui / Wellington 0.75m SN9284 (1993)",
       "category": "Scanned Aerial Imagery",
@@ -816,8 +816,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_sn9281_1993_0.6m/01H8JJWQ2CYGWSVP6P880A516K",
-      "3857": "s3://linz-basemaps/3857/northland_sn9281_1993_0.6m/01H8JJWQFK7RXM19D6CDGMDV3Z",
+      "2193": "s3://linz-basemaps/2193/northland_sn9281_1993_0.6m/01H8JJWQ2CYGWSVP6P880A516K/",
+      "3857": "s3://linz-basemaps/3857/northland_sn9281_1993_0.6m/01H8JJWQFK7RXM19D6CDGMDV3Z/",
       "name": "northland-sn9281-1993-0.6m",
       "title": "Northland 0.6m SN9281 (1993)",
       "category": "Scanned Aerial Imagery",
@@ -825,8 +825,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_sn9211_1992_0.4m/01H8J8R1ES1F2Y7X460FEVK1TN",
-      "3857": "s3://linz-basemaps/3857/auckland_sn9211_1992_0.4m/01H8J8R16Y4MG3M3PQZSCZ3C60",
+      "2193": "s3://linz-basemaps/2193/auckland_sn9211_1992_0.4m/01H8J8R1ES1F2Y7X460FEVK1TN/",
+      "3857": "s3://linz-basemaps/3857/auckland_sn9211_1992_0.4m/01H8J8R16Y4MG3M3PQZSCZ3C60/",
       "name": "auckland-sn9211-1992-0.4m",
       "title": "Auckland 0.4m SN9211 (1992)",
       "category": "Scanned Aerial Imagery",
@@ -834,8 +834,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9158_1991_0.375m/01H8JF29R6S2NT7QXNC7GK90D4",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9158_1991_0.375m/01H8JF2RZ225TJG7FPACV6DVRC",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn9158_1991_0.375m/01H8JF29R6S2NT7QXNC7GK90D4/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn9158_1991_0.375m/01H8JF2RZ225TJG7FPACV6DVRC/",
       "name": "manawatu-whanganui-sn9158-1991-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN9158 (1991)",
       "category": "Scanned Aerial Imagery",
@@ -843,8 +843,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_sn8821_1991_0.6m/01H8JN762SRRR460R4K3Z2SRCY",
-      "3857": "s3://linz-basemaps/3857/tasman_sn8821_1991_0.6m/01H8JN763E6QWSZD0DCWJZWQ5N",
+      "2193": "s3://linz-basemaps/2193/tasman_sn8821_1991_0.6m/01H8JN762SRRR460R4K3Z2SRCY/",
+      "3857": "s3://linz-basemaps/3857/tasman_sn8821_1991_0.6m/01H8JN763E6QWSZD0DCWJZWQ5N/",
       "name": "tasman-sn8821-1991-0.6m",
       "title": "Tasman 0.6m SN8821 (1991)",
       "category": "Scanned Aerial Imagery",
@@ -852,8 +852,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9124_1990-1991_0.48m/01H8JP0KG5642BF5PFP2737HD0",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9124_1990-1991_0.48m/01H8JP0KFZ1VN0KF2HKR2G4GTP",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9124_1990-1991_0.48m/01H8JP0KG5642BF5PFP2737HD0/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9124_1990-1991_0.48m/01H8JP0KFZ1VN0KF2HKR2G4GTP/",
       "name": "waikato-sn9124-1990-1991-0.48m",
       "title": "Waikato 0.48m SN9124 (1990-1991)",
       "category": "Scanned Aerial Imagery",
@@ -861,8 +861,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn9087_1990-1991_0.75m/01H8JKATBC8G9ZQHEZ3RSQQKRW",
-      "3857": "s3://linz-basemaps/3857/otago_sn9087_1990-1991_0.75m/01H8JKATAWX98A14QNKVBF14WH",
+      "2193": "s3://linz-basemaps/2193/otago_sn9087_1990-1991_0.75m/01H8JKATBC8G9ZQHEZ3RSQQKRW/",
+      "3857": "s3://linz-basemaps/3857/otago_sn9087_1990-1991_0.75m/01H8JKATAWX98A14QNKVBF14WH/",
       "name": "otago-sn9087-1990-1991-0.75m",
       "title": "Otago 0.75m SN9087 (1990-1991)",
       "category": "Scanned Aerial Imagery",
@@ -870,8 +870,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn9066_1990-1991_0.75m/01H8JM95ZK08TXGDN9VE4F4F9J",
-      "3857": "s3://linz-basemaps/3857/southland_sn9066_1990-1991_0.75m/01H8JM95Z48FWE603P9FK2XNM4",
+      "2193": "s3://linz-basemaps/2193/southland_sn9066_1990-1991_0.75m/01H8JM95ZK08TXGDN9VE4F4F9J/",
+      "3857": "s3://linz-basemaps/3857/southland_sn9066_1990-1991_0.75m/01H8JM95Z48FWE603P9FK2XNM4/",
       "name": "southland-sn9066-1990-1991-0.75m",
       "title": "Southland 0.75m SN9066 (1990-1991)",
       "category": "Scanned Aerial Imagery",
@@ -879,8 +879,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn9067_1990_0.75m/01H8JMABZ33MKEDMK9B75T9AN7",
-      "3857": "s3://linz-basemaps/3857/southland_sn9067_1990_0.75m/01H8JMAAW1QS4B1Q7W63WBPE06",
+      "2193": "s3://linz-basemaps/2193/southland_sn9067_1990_0.75m/01H8JMABZ33MKEDMK9B75T9AN7/",
+      "3857": "s3://linz-basemaps/3857/southland_sn9067_1990_0.75m/01H8JMAAW1QS4B1Q7W63WBPE06/",
       "name": "southland-sn9067-1990-0.75m",
       "title": "Southland 0.75m SN9067 (1990)",
       "category": "Scanned Aerial Imagery",
@@ -888,8 +888,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_otago_sn9065_1990_0.75m/01H8JQE93XAJR9VA4W88RXVDRW",
-      "3857": "s3://linz-basemaps/3857/west-coast_otago_sn9065_1990_0.75m/01H8JQE94ZCJ151DQ71NKM7D6C",
+      "2193": "s3://linz-basemaps/2193/west-coast_otago_sn9065_1990_0.75m/01H8JQE93XAJR9VA4W88RXVDRW/",
+      "3857": "s3://linz-basemaps/3857/west-coast_otago_sn9065_1990_0.75m/01H8JQE94ZCJ151DQ71NKM7D6C/",
       "name": "west-coast-otago-sn9065-1990-0.75m",
       "title": "West Coast / Otago 0.75m SN9065 (1990)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/scanned.pre19900101.json
+++ b/config/tileset/scanned.pre19900101.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn3806_1975_0.375m/01H8JJZ4PQ7SFDZ21DQR9GJ8AZ",
-      "3857": "s3://linz-basemaps/3857/otago_sn3806_1975_0.375m/01H8JJZ4M9C83EJDJCMQB4ED8B",
+      "2193": "s3://linz-basemaps/2193/otago_sn3806_1975_0.375m/01H8JJZ4PQ7SFDZ21DQR9GJ8AZ/",
+      "3857": "s3://linz-basemaps/3857/otago_sn3806_1975_0.375m/01H8JJZ4M9C83EJDJCMQB4ED8B/",
       "name": "otago-sn3806-1975-0.375m",
       "title": "Otago 0.375m SN3806 (1975)",
       "category": "Scanned Aerial Imagery",
@@ -15,8 +15,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_snc2887_1975_0.3m/01H8JKMXEJGX9WCBE7N1PGW0WH",
-      "3857": "s3://linz-basemaps/3857/marlborough_snc2887_1975_0.3m/01H8JHVMHS0NBPT3NJ3CSTDHDW",
+      "2193": "s3://linz-basemaps/2193/marlborough_snc2887_1975_0.3m/01H8JKMXEJGX9WCBE7N1PGW0WH/",
+      "3857": "s3://linz-basemaps/3857/marlborough_snc2887_1975_0.3m/01H8JHVMHS0NBPT3NJ3CSTDHDW/",
       "name": "marlborough-snc2887-1975-0.3m",
       "title": "Marlborough 0.3m SNC2887 (1975)",
       "category": "Scanned Aerial Imagery",
@@ -24,8 +24,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn5100_1977_0.75m/01H8JGWVHJFER7QX1WA1ZYSXF1",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn5100_1977_0.75m/01H8JGWVHZXWJR7QEBCANAJ7FX",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn5100_1977_0.75m/01H8JGWVHJFER7QX1WA1ZYSXF1/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn5100_1977_0.75m/01H8JGWVHZXWJR7QEBCANAJ7FX/",
       "name": "marlborough-sn5100-1977-0.75m",
       "title": "Marlborough 0.75m SN5100 (1977)",
       "category": "Scanned Aerial Imagery",
@@ -33,8 +33,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn5139_1977_0.375m/01H8JPH3E4XE4033B7S38ZWMZD",
-      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn5139_1977_0.375m/01H8JPH4PB1ZM3R9H5TEK8QT7X",
+      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn5139_1977_0.375m/01H8JPH3E4XE4033B7S38ZWMZD/",
+      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn5139_1977_0.375m/01H8JPH4PB1ZM3R9H5TEK8QT7X/",
       "name": "wellington-manawatu-whanganui-sn5139-1977-0.375m",
       "title": "Wellington / Manawatū-Whanganui 0.375m SN5139 (1977)",
       "category": "Scanned Aerial Imagery",
@@ -42,8 +42,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn5164_1977-1979_0.375m/01H8JNNA2572YPCX5249HBK6J0",
-      "3857": "s3://linz-basemaps/3857/waikato_sn5164_1977-1979_0.375m/01H8JNNA288XCWSV32ZRBZJKH1",
+      "2193": "s3://linz-basemaps/2193/waikato_sn5164_1977-1979_0.375m/01H8JNNA2572YPCX5249HBK6J0/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn5164_1977-1979_0.375m/01H8JNNA288XCWSV32ZRBZJKH1/",
       "name": "waikato-sn5164-1977-1979-0.375m",
       "title": "Waikato 0.375m SN5164 (1977-1979)",
       "category": "Scanned Aerial Imagery",
@@ -51,8 +51,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn5204_1978_0.75m/01H8JBHJRQ6KJM3YTQW95M8NCJ",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn5204_1978_0.75m/01H8JBHN4NVTF3THTP6KGMA9AF",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn5204_1978_0.75m/01H8JBHJRQ6KJM3YTQW95M8NCJ/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn5204_1978_0.75m/01H8JBHN4NVTF3THTP6KGMA9AF/",
       "name": "canterbury-sn5204-1978-0.75m",
       "title": "Canterbury 0.75m SN5204 (1978)",
       "category": "Scanned Aerial Imagery",
@@ -60,8 +60,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn5220_1978_0.75m/01H8JK3ZXTSBJ9WP3M5975S6ZM",
-      "3857": "s3://linz-basemaps/3857/otago_sn5220_1978_0.75m/01H8JNADYW744FT5T501Y5MCAH",
+      "2193": "s3://linz-basemaps/2193/otago_sn5220_1978_0.75m/01H8JK3ZXTSBJ9WP3M5975S6ZM/",
+      "3857": "s3://linz-basemaps/3857/otago_sn5220_1978_0.75m/01H8JNADYW744FT5T501Y5MCAH/",
       "name": "otago-sn5220-1978-0.75m",
       "title": "Otago 0.75m SN5220 (1978)",
       "category": "Scanned Aerial Imagery",
@@ -69,8 +69,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn5291_1978_0.375m/01H8JBNX51M2HYCJBB951MXD1V",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn5291_1978_0.375m/01H8JBPXFP8803NS5P9JT4Q6R7",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn5291_1978_0.375m/01H8JBNX51M2HYCJBB951MXD1V/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn5291_1978_0.375m/01H8JBPXFP8803NS5P9JT4Q6R7/",
       "name": "manawatu-whanganui-sn5291-1978-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN5291 (1978)",
       "category": "Scanned Aerial Imagery",
@@ -78,8 +78,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/01H8JGYX7CBZQ9XFH1TTED6FJH",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/01H8JGN7RMHWC6716JPE7CJ1HR",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/01H8JGYX7CBZQ9XFH1TTED6FJH/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/01H8JGN7RMHWC6716JPE7CJ1HR/",
       "name": "manawatu-whanganui-wellington-sn5310-1978-1979-0.375m",
       "title": "Manawatū-Whanganui / Wellington 0.375m SN5310 (1978-1979)",
       "category": "Scanned Aerial Imagery",
@@ -87,8 +87,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/01H8JPHHTXW8NPPXPV0KACK4D7",
-      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/01H8JPK1FDREW54JTW5N9DB4NH",
+      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/01H8JPHHTXW8NPPXPV0KACK4D7/",
+      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/01H8JPK1FDREW54JTW5N9DB4NH/",
       "name": "wellington-manawatu-whanganui-sn5309-1978-1981-0.64m",
       "title": "Wellington / Manawatū-Whanganui 0.64m SN5309 (1978-1981)",
       "category": "Scanned Aerial Imagery",
@@ -96,8 +96,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn5359_1979_0.375m/01H8JK4EXEEC9YNEAKYNB4SNPB",
-      "3857": "s3://linz-basemaps/3857/otago_sn5359_1979_0.375m/01H8JK38135F3SNYTG3WVMW0CA",
+      "2193": "s3://linz-basemaps/2193/otago_sn5359_1979_0.375m/01H8JK4EXEEC9YNEAKYNB4SNPB/",
+      "3857": "s3://linz-basemaps/3857/otago_sn5359_1979_0.375m/01H8JK38135F3SNYTG3WVMW0CA/",
       "name": "otago-sn5359-1979-0.375m",
       "title": "Otago 0.375m SN5359 (1979)",
       "category": "Scanned Aerial Imagery",
@@ -105,8 +105,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn5408_1979-1980_0.375m/01H8JBN7ZAXNNC4WK1P7ZQBJMM",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn5408_1979-1980_0.375m/01H8JBNGNNFY6NHKPW46811CR9",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn5408_1979-1980_0.375m/01H8JBN7ZAXNNC4WK1P7ZQBJMM/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn5408_1979-1980_0.375m/01H8JBNGNNFY6NHKPW46811CR9/",
       "name": "manawatu-whanganui-sn5408-1979-1980-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN5408 (1979-1980)",
       "category": "Scanned Aerial Imagery",
@@ -114,8 +114,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn5479_1979_0.375m/01H8JNNA3025VE8MDKKK5HSBKR",
-      "3857": "s3://linz-basemaps/3857/waikato_sn5479_1979_0.375m/01H8JNNA2CQ0BG6DMFR93H3WJ3",
+      "2193": "s3://linz-basemaps/2193/waikato_sn5479_1979_0.375m/01H8JNNA3025VE8MDKKK5HSBKR/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn5479_1979_0.375m/01H8JNNA2CQ0BG6DMFR93H3WJ3/",
       "name": "waikato-sn5479-1979-0.375m",
       "title": "Waikato 0.375m SN5479 (1979)",
       "category": "Scanned Aerial Imagery",
@@ -123,8 +123,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_sn5497_1979-1980_0.4m/01H8JPHQ1YC7K02K9TA8F4C6DZ",
-      "3857": "s3://linz-basemaps/3857/wellington_sn5497_1979-1980_0.4m/01H8JPJDFB33PWKWJQ2KRQR7FE",
+      "2193": "s3://linz-basemaps/2193/wellington_sn5497_1979-1980_0.4m/01H8JPHQ1YC7K02K9TA8F4C6DZ/",
+      "3857": "s3://linz-basemaps/3857/wellington_sn5497_1979-1980_0.4m/01H8JPJDFB33PWKWJQ2KRQR7FE/",
       "name": "wellington-sn5497-1979-1980-0.4m",
       "title": "Wellington 0.4m SN5497 (1979-1980)",
       "category": "Scanned Aerial Imagery",
@@ -132,8 +132,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_sn5600_1979_0.375m/01H8J7E74WKJYFY8FCST5F90N0",
-      "3857": "s3://linz-basemaps/3857/auckland_sn5600_1979_0.375m/01H8J7E747XFQYM268Y71E0EK1",
+      "2193": "s3://linz-basemaps/2193/auckland_sn5600_1979_0.375m/01H8J7E74WKJYFY8FCST5F90N0/",
+      "3857": "s3://linz-basemaps/3857/auckland_sn5600_1979_0.375m/01H8J7E747XFQYM268Y71E0EK1/",
       "name": "auckland-sn5600-1979-0.375m",
       "title": "Auckland 0.375m SN5600 (1979)",
       "category": "Scanned Aerial Imagery",
@@ -141,8 +141,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn5638_1979-1980_0.375m/01H8JH0DNT3VKPMHKP4ACYNR72",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn5638_1979-1980_0.375m/01H8JH0DP9TA3E9WDMRF69D71A",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn5638_1979-1980_0.375m/01H8JH0DNT3VKPMHKP4ACYNR72/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn5638_1979-1980_0.375m/01H8JH0DP9TA3E9WDMRF69D71A/",
       "name": "marlborough-sn5638-1979-1980-0.375m",
       "title": "Marlborough 0.375m SN5638 (1979-1980)",
       "category": "Scanned Aerial Imagery",
@@ -150,8 +150,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_snc5676_1980-1981_0.64m/01H8JN7X10TWV4MTYV18WV2KRQ",
-      "3857": "s3://linz-basemaps/3857/tasman_snc5676_1980-1981_0.64m/01H8JN7X0KC125E9H3SGSA029S",
+      "2193": "s3://linz-basemaps/2193/tasman_snc5676_1980-1981_0.64m/01H8JN7X10TWV4MTYV18WV2KRQ/",
+      "3857": "s3://linz-basemaps/3857/tasman_snc5676_1980-1981_0.64m/01H8JN7X0KC125E9H3SGSA029S/",
       "name": "tasman-snc5676-1980-1981-0.64m",
       "title": "Tasman 0.64m SNC5676 (1980-1981)",
       "category": "Scanned Aerial Imagery",
@@ -159,8 +159,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn5693_1980_0.75m/01H8JKPGW320P7CTWMB4GBWA8Q",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn5693_1980_0.75m/01H8JKPGW1V632KZX58G63PY3R",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn5693_1980_0.75m/01H8JKPGW320P7CTWMB4GBWA8Q/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn5693_1980_0.75m/01H8JKPGW1V632KZX58G63PY3R/",
       "name": "southland-otago-sn5693-1980-0.75m",
       "title": "Southland / Otago 0.75m SN5693 (1980)",
       "category": "Scanned Aerial Imagery",
@@ -168,8 +168,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/01H8JBKPPY4936V5SREYAN3AMD",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/01H8JBKQ9B507FW7S4SBDTNASY",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/01H8JBKPPY4936V5SREYAN3AMD/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/01H8JBKQ9B507FW7S4SBDTNASY/",
       "name": "hawkes-bay-manawatu-whanganui-sn5752-1980-0.375m",
       "title": "Hawkes Bay / Manawatū-Whanganui 0.375m SN5752 (1980)",
       "category": "Scanned Aerial Imagery",
@@ -177,8 +177,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/01H8JBMA16AAPPQQNG0R1PT2YN",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/01H8JBKKDVTE10YT04581P92Z7",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/01H8JBMA16AAPPQQNG0R1PT2YN/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/01H8JBKKDVTE10YT04581P92Z7/",
       "name": "hawkes-bay-manawatu-whanganui-sn5761-1980-0.375m",
       "title": "Hawkes Bay / Manawatū-Whanganui 0.375m SN5761 (1980)",
       "category": "Scanned Aerial Imagery",
@@ -186,8 +186,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_bay-of-plenty_sn5766_1980_0.375m/01H8JBJGCHGBVEFDC7FEBN87G2",
-      "3857": "s3://linz-basemaps/3857/gisborne_bay-of-plenty_sn5766_1980_0.375m/01H8JBJHFMQJ1R8H6MFB1M27GE",
+      "2193": "s3://linz-basemaps/2193/gisborne_bay-of-plenty_sn5766_1980_0.375m/01H8JBJGCHGBVEFDC7FEBN87G2/",
+      "3857": "s3://linz-basemaps/3857/gisborne_bay-of-plenty_sn5766_1980_0.375m/01H8JBJHFMQJ1R8H6MFB1M27GE/",
       "name": "gisborne-bay-of-plenty-sn5766-1980-0.375m",
       "title": "Gisborne / Bay of Plenty 0.375m SN5766 (1980)",
       "category": "Scanned Aerial Imagery",
@@ -195,8 +195,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn5771_1980-1981_0.375m/01H8JBHJY95FTHVPQ2XE6MH6BE",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn5771_1980-1981_0.375m/01H8JBHJJT6P1CRVH3W24RHRZK",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn5771_1980-1981_0.375m/01H8JBHJY95FTHVPQ2XE6MH6BE/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn5771_1980-1981_0.375m/01H8JBHJJT6P1CRVH3W24RHRZK/",
       "name": "canterbury-sn5771-1980-1981-0.375m",
       "title": "Canterbury 0.375m SN5771 (1980-1981)",
       "category": "Scanned Aerial Imagery",
@@ -204,8 +204,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn5781_1980_0.375m/01H8JQF9H7QGBMBEKVRFAKKN0M",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn5781_1980_0.375m/01H8JQF9G5YDS4WQNP3MYRWM8X",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn5781_1980_0.375m/01H8JQF9H7QGBMBEKVRFAKKN0M/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn5781_1980_0.375m/01H8JQF9G5YDS4WQNP3MYRWM8X/",
       "name": "west-coast-sn5781-1980-0.375m",
       "title": "West Coast 0.375m SN5781 (1980)",
       "category": "Scanned Aerial Imagery",
@@ -213,8 +213,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_sn5780_1980_0.8m/01H8JJDF0QXKSNSBH2DGBF68YP",
-      "3857": "s3://linz-basemaps/3857/northland_sn5780_1980_0.8m/01H8JJDEZV4G7J6S1JARD1ZNGF",
+      "2193": "s3://linz-basemaps/2193/northland_sn5780_1980_0.8m/01H8JJDF0QXKSNSBH2DGBF68YP/",
+      "3857": "s3://linz-basemaps/3857/northland_sn5780_1980_0.8m/01H8JJDEZV4G7J6S1JARD1ZNGF/",
       "name": "northland-sn5780-1980-0.8m",
       "title": "Northland 0.8m SN5780 (1980)",
       "category": "Scanned Aerial Imagery",
@@ -222,8 +222,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_snc5797_1980_0.375m/01H8JJWWZ9WA9YV83B4PRSM460",
-      "3857": "s3://linz-basemaps/3857/northland_snc5797_1980_0.375m/01H8JJWWYHV7RGGPAB3YXVH215",
+      "2193": "s3://linz-basemaps/2193/northland_snc5797_1980_0.375m/01H8JJWWZ9WA9YV83B4PRSM460/",
+      "3857": "s3://linz-basemaps/3857/northland_snc5797_1980_0.375m/01H8JJWWYHV7RGGPAB3YXVH215/",
       "name": "northland-snc5797-1980-0.375m",
       "title": "Northland 0.375m SNC5797 (1980)",
       "category": "Scanned Aerial Imagery",
@@ -231,8 +231,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn5817_1980_0.375m/01H8JQFDA1Y8X9XJVM0BXQDBG9",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn5817_1980_0.375m/01H8JQFDA1THJXFWWMFJ0B1YGZ",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn5817_1980_0.375m/01H8JQFDA1Y8X9XJVM0BXQDBG9/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn5817_1980_0.375m/01H8JQFDA1THJXFWWMFJ0B1YGZ/",
       "name": "west-coast-sn5817-1980-0.375m",
       "title": "West Coast 0.375m SN5817 (1980)",
       "category": "Scanned Aerial Imagery",
@@ -240,8 +240,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn5804_1981_0.375m/01H8JMN29GP081PT3YN6R5D26D",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn5804_1981_0.375m/01H8JMN280VKE9154YRPJ0CBVW",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn5804_1981_0.375m/01H8JMN29GP081PT3YN6R5D26D/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn5804_1981_0.375m/01H8JMN280VKE9154YRPJ0CBVW/",
       "name": "taranaki-sn5804-1981-0.375m",
       "title": "Taranaki 0.375m SN5804 (1981)",
       "category": "Scanned Aerial Imagery",
@@ -249,8 +249,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_snc5876_1981_0.375m/01H8JPCV7T6W2T47A6SFG4BT00",
-      "3857": "s3://linz-basemaps/3857/waikato_snc5876_1981_0.375m/01H8JPCV626WYPG26J0P8RF1TB",
+      "2193": "s3://linz-basemaps/2193/waikato_snc5876_1981_0.375m/01H8JPCV7T6W2T47A6SFG4BT00/",
+      "3857": "s3://linz-basemaps/3857/waikato_snc5876_1981_0.375m/01H8JPCV626WYPG26J0P8RF1TB/",
       "name": "waikato-snc5876-1981-0.375m",
       "title": "Waikato 0.375m SNC5876 (1981)",
       "category": "Scanned Aerial Imagery",
@@ -258,8 +258,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_sn5932_1981-1982_0.375m/01H8JJG12FFE9DJAFHQ2VJJG8F",
-      "3857": "s3://linz-basemaps/3857/northland_sn5932_1981-1982_0.375m/01H8JJG12C1T7T7SP1HTVNS4VM",
+      "2193": "s3://linz-basemaps/2193/northland_sn5932_1981-1982_0.375m/01H8JJG12FFE9DJAFHQ2VJJG8F/",
+      "3857": "s3://linz-basemaps/3857/northland_sn5932_1981-1982_0.375m/01H8JJG12C1T7T7SP1HTVNS4VM/",
       "name": "northland-sn5932-1981-1982-0.375m",
       "title": "Northland 0.375m SN5932 (1981-1982)",
       "category": "Scanned Aerial Imagery",
@@ -267,8 +267,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/01H8JNCZ06Q4CYAFHF15JKQSA2",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/01H8JND6KBAM9BP4Q26E6F6Z0Y",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/01H8JNCZ06Q4CYAFHF15JKQSA2/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/01H8JND6KBAM9BP4Q26E6F6Z0Y/",
       "name": "waikato-bay-of-plenty-sn5944-1981-1982-0.375m",
       "title": "Waikato / Bay of Plenty 0.375m SN5944 (1981-1982)",
       "category": "Scanned Aerial Imagery",
@@ -276,8 +276,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/01H8JND5ZRWHW67DRJQSK926HA",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/01H8JND7FE1N1B9QY5R71Y00GV",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/01H8JND5ZRWHW67DRJQSK926HA/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/01H8JND7FE1N1B9QY5R71Y00GV/",
       "name": "waikato-bay-of-plenty-sn5945-1981-1984-0.4m",
       "title": "Waikato / Bay of Plenty 0.4m SN5945 (1981-1984)",
       "category": "Scanned Aerial Imagery",
@@ -285,8 +285,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_gisborne_sn5975_1981_0.375m/01H8J8R5EMEX2T3HGHCWM5A2SN",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_gisborne_sn5975_1981_0.375m/01H8J8R6VBQMBS4MZFZ4K046SN",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_gisborne_sn5975_1981_0.375m/01H8J8R5EMEX2T3HGHCWM5A2SN/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_gisborne_sn5975_1981_0.375m/01H8J8R6VBQMBS4MZFZ4K046SN/",
       "name": "bay-of-plenty-gisborne-sn5975-1981-0.375m",
       "title": "Bay of Plenty / Gisborne 0.375m SN5975 (1981)",
       "category": "Scanned Aerial Imagery",
@@ -294,8 +294,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn8000_1982_0.75m/01H8JH1E1FZM47HEGK4PB0M5QN",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn8000_1982_0.75m/01H8JH1E27XGRYKF5SPH643D04",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn8000_1982_0.75m/01H8JH1E1FZM47HEGK4PB0M5QN/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn8000_1982_0.75m/01H8JH1E27XGRYKF5SPH643D04/",
       "name": "marlborough-sn8000-1982-0.75m",
       "title": "Marlborough 0.75m SN8000 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -303,8 +303,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn8049_1982_0.8m/01H8JH8VA9F3FF0NGQ6YGM2YAX",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn8049_1982_0.8m/01H8JH6XD8BS7XE1ESQQRJC7NB",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn8049_1982_0.8m/01H8JH8VA9F3FF0NGQ6YGM2YAX/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn8049_1982_0.8m/01H8JH6XD8BS7XE1ESQQRJC7NB/",
       "name": "marlborough-sn8049-1982-0.8m",
       "title": "Marlborough 0.8m SN8049 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -312,8 +312,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8008_1982_0.375m/01H8JMQSK2TF1Y6V4GNTZ21R5W",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8008_1982_0.375m/01H8JMS0B3DQ31CMCRRHGC2WPJ",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8008_1982_0.375m/01H8JMQSK2TF1Y6V4GNTZ21R5W/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8008_1982_0.375m/01H8JMS0B3DQ31CMCRRHGC2WPJ/",
       "name": "taranaki-sn8008-1982-0.375m",
       "title": "Taranaki 0.375m SN8008 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -321,8 +321,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8005_1982_0.8m/01H8JCTHB228DJATCH790BHK9T",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8005_1982_0.8m/01H8JCQ5MRMF08HAJFVF5ES0ZC",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8005_1982_0.8m/01H8JCTHB228DJATCH790BHK9T/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8005_1982_0.8m/01H8JCQ5MRMF08HAJFVF5ES0ZC/",
       "name": "manawatu-whanganui-sn8005-1982-0.8m",
       "title": "Manawatū-Whanganui 0.8m SN8005 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -330,8 +330,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8004_1982_0.75m/01H8JG6Q5XMF7FCFJHSMFGKJ8K",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8004_1982_0.75m/01H8JG6Q6K867J9PAQR428N7B1",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8004_1982_0.75m/01H8JG6Q5XMF7FCFJHSMFGKJ8K/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8004_1982_0.75m/01H8JG6Q6K867J9PAQR428N7B1/",
       "name": "manawatu-whanganui-taranaki-sn8004-1982-0.75m",
       "title": "Manawatū-Whanganui / Taranaki 0.75m SN8004 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -339,8 +339,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8003_1982_0.75m/01H8JMP5874HHRXDSRVTVQ26XC",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8003_1982_0.75m/01H8JMNXQ4T9DZR0127C0RVYAK",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8003_1982_0.75m/01H8JMP5874HHRXDSRVTVQ26XC/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8003_1982_0.75m/01H8JMNXQ4T9DZR0127C0RVYAK/",
       "name": "taranaki-sn8003-1982-0.75m",
       "title": "Taranaki 0.75m SN8003 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -348,8 +348,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn8038_1982_0.75m/01H8JM7RXPPF8XBMREZFZC5M1W",
-      "3857": "s3://linz-basemaps/3857/southland_sn8038_1982_0.75m/01H8JM7RXPXBJWVCAE32080MP2",
+      "2193": "s3://linz-basemaps/2193/southland_sn8038_1982_0.75m/01H8JM7RXPPF8XBMREZFZC5M1W/",
+      "3857": "s3://linz-basemaps/3857/southland_sn8038_1982_0.75m/01H8JM7RXPXBJWVCAE32080MP2/",
       "name": "southland-sn8038-1982-0.75m",
       "title": "Southland 0.75m SN8038 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -357,8 +357,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_snc8054_1982_0.25m/01H8JN92BVP4FY9N1AB1BBJJ1D",
-      "3857": "s3://linz-basemaps/3857/tasman_snc8054_1982_0.25m/01H8JN92C99P6ZTETDPEGPGDYW",
+      "2193": "s3://linz-basemaps/2193/tasman_snc8054_1982_0.25m/01H8JN92BVP4FY9N1AB1BBJJ1D/",
+      "3857": "s3://linz-basemaps/3857/tasman_snc8054_1982_0.25m/01H8JN92C99P6ZTETDPEGPGDYW/",
       "name": "tasman-snc8054-1982-0.25m",
       "title": "Tasman 0.25m SNC8054 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -366,8 +366,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_auckland_sn8104_1982-1983_0.4m/01H8JJ5ETCC5DM0HZGBWPNT0RW",
-      "3857": "s3://linz-basemaps/3857/northland_auckland_sn8104_1982-1983_0.4m/01H8JJEGJ98ZNQFT973TRRZHV0",
+      "2193": "s3://linz-basemaps/2193/northland_auckland_sn8104_1982-1983_0.4m/01H8JJ5ETCC5DM0HZGBWPNT0RW/",
+      "3857": "s3://linz-basemaps/3857/northland_auckland_sn8104_1982-1983_0.4m/01H8JJEGJ98ZNQFT973TRRZHV0/",
       "name": "northland-auckland-sn8104-1982-1983-0.4m",
       "title": "Northland / Auckland 0.4m SN8104 (1982-1983)",
       "category": "Scanned Aerial Imagery",
@@ -375,8 +375,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn8132_1982_0.375m/01H8JBKYPK82BBH2P41B34H5F4",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn8132_1982_0.375m/01H8JBMB01PDKG4D7HMDTNBD26",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn8132_1982_0.375m/01H8JBKYPK82BBH2P41B34H5F4/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn8132_1982_0.375m/01H8JBMB01PDKG4D7HMDTNBD26/",
       "name": "gisborne-sn8132-1982-0.375m",
       "title": "Gisborne 0.375m SN8132 (1982)",
       "category": "Scanned Aerial Imagery",
@@ -384,8 +384,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8158_1983_0.4m/01H8JDDC4Y6N93CJBDMS1W8AQY",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8158_1983_0.4m/01H8JDCVX3HF901K5Y3YXPB9VE",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8158_1983_0.4m/01H8JDDC4Y6N93CJBDMS1W8AQY/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8158_1983_0.4m/01H8JDCVX3HF901K5Y3YXPB9VE/",
       "name": "manawatu-whanganui-sn8158-1983-0.4m",
       "title": "Manawatū-Whanganui 0.4m SN8158 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -393,8 +393,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8157_1983_0.8m/01H8JG8C43ZJTKJZPCERH1APXT",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8157_1983_0.8m/01H8JG8C3D1HMPPEN2CNH73AGR",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8157_1983_0.8m/01H8JG8C43ZJTKJZPCERH1APXT/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8157_1983_0.8m/01H8JG8C3D1HMPPEN2CNH73AGR/",
       "name": "manawatu-whanganui-taranaki-sn8157-1983-0.8m",
       "title": "Manawatū-Whanganui / Taranaki 0.8m SN8157 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -402,8 +402,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn8163_1983-1984_0.375m/01H8JNP2SYBZT3X1GA180B4YHR",
-      "3857": "s3://linz-basemaps/3857/waikato_sn8163_1983-1984_0.375m/01H8JNP2SWMB2QRY6X61GN18VA",
+      "2193": "s3://linz-basemaps/2193/waikato_sn8163_1983-1984_0.375m/01H8JNP2SYBZT3X1GA180B4YHR/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn8163_1983-1984_0.375m/01H8JNP2SWMB2QRY6X61GN18VA/",
       "name": "waikato-sn8163-1983-1984-0.375m",
       "title": "Waikato 0.375m SN8163 (1983-1984)",
       "category": "Scanned Aerial Imagery",
@@ -411,8 +411,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn8166_1983_0.75m/01H8JNTDJHQC0YYYPQHS2F1NWA",
-      "3857": "s3://linz-basemaps/3857/waikato_sn8166_1983_0.75m/01H8JNYHHCEJWMQQR55053Q55K",
+      "2193": "s3://linz-basemaps/2193/waikato_sn8166_1983_0.75m/01H8JNTDJHQC0YYYPQHS2F1NWA/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn8166_1983_0.75m/01H8JNYHHCEJWMQQR55053Q55K/",
       "name": "waikato-sn8166-1983-0.75m",
       "title": "Waikato 0.75m SN8166 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -420,8 +420,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn8171_1983_0.375m/01H8JPK1EHAPMZWJNV7CRDQF8P",
-      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn8171_1983_0.375m/01H8JPMVEF18P883GQ1VTSE4Q0",
+      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn8171_1983_0.375m/01H8JPK1EHAPMZWJNV7CRDQF8P/",
+      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn8171_1983_0.375m/01H8JPMVEF18P883GQ1VTSE4Q0/",
       "name": "wellington-manawatu-whanganui-sn8171-1983-0.375m",
       "title": "Wellington / Manawatū-Whanganui 0.375m SN8171 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -429,8 +429,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8180_1983_0.75m/01H8JM4JGPBEJPE1X2BVFPR353",
-      "3857": "s3://linz-basemaps/3857/otago_sn8180_1983_0.75m/01H8JK184G1NCE8ZK1M6KNH9B3",
+      "2193": "s3://linz-basemaps/2193/otago_sn8180_1983_0.75m/01H8JM4JGPBEJPE1X2BVFPR353/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8180_1983_0.75m/01H8JK184G1NCE8ZK1M6KNH9B3/",
       "name": "otago-sn8180-1983-0.75m",
       "title": "Otago 0.75m SN8180 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -438,8 +438,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn8200_1983_0.375m/01H8JH81FZSMC3255DB1F2Y8J6",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn8200_1983_0.375m/01H8JH81GPM3C8GEX1D9HMDBA2",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn8200_1983_0.375m/01H8JH81FZSMC3255DB1F2Y8J6/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn8200_1983_0.375m/01H8JH81GPM3C8GEX1D9HMDBA2/",
       "name": "marlborough-sn8200-1983-0.375m",
       "title": "Marlborough 0.375m SN8200 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -447,8 +447,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_sn8209_1983_0.8m/01H8JN41FFRTCP66KSN934F4Y1",
-      "3857": "s3://linz-basemaps/3857/tasman_sn8209_1983_0.8m/01H8JN3W071MF9YEMMNJCRG7CS",
+      "2193": "s3://linz-basemaps/2193/tasman_sn8209_1983_0.8m/01H8JN41FFRTCP66KSN934F4Y1/",
+      "3857": "s3://linz-basemaps/3857/tasman_sn8209_1983_0.8m/01H8JN3W071MF9YEMMNJCRG7CS/",
       "name": "tasman-sn8209-1983-0.8m",
       "title": "Tasman 0.8m SN8209 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -456,8 +456,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8215_1983-1984_0.8m/01H8JK4G4ARGY7PBNHNEZAXYSK",
-      "3857": "s3://linz-basemaps/3857/otago_sn8215_1983-1984_0.8m/01H8JKZ90XEY62C2B9N2BWJDSQ",
+      "2193": "s3://linz-basemaps/2193/otago_sn8215_1983-1984_0.8m/01H8JK4G4ARGY7PBNHNEZAXYSK/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8215_1983-1984_0.8m/01H8JKZ90XEY62C2B9N2BWJDSQ/",
       "name": "otago-sn8215-1983-1984-0.8m",
       "title": "Otago 0.8m SN8215 (1983-1984)",
       "category": "Scanned Aerial Imagery",
@@ -465,8 +465,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8240_1983_0.75m/01H8J8RDS8Z603AJSEY5Y525AJ",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8240_1983_0.75m/01H8J8RC1E8RT597NQA3FCDJZ5",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8240_1983_0.75m/01H8J8RDS8Z603AJSEY5Y525AJ/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8240_1983_0.75m/01H8J8RC1E8RT597NQA3FCDJZ5/",
       "name": "bay-of-plenty-sn8240-1983-0.75m",
       "title": "Bay of Plenty 0.75m SN8240 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -474,8 +474,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8261_1983_0.75m/01H8JBHMZHS0XJB5RZVEZ1JAYY",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8261_1983_0.75m/01H8JBHMRZ54T418VV44PVNGSC",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8261_1983_0.75m/01H8JBHMZHS0XJB5RZVEZ1JAYY/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8261_1983_0.75m/01H8JBHMRZ54T418VV44PVNGSC/",
       "name": "canterbury-sn8261-1983-0.75m",
       "title": "Canterbury 0.75m SN8261 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -483,8 +483,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_waikato_sn8260_1983_0.75m/01H8JBNY5KSE63QJD65AZB08G5",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_waikato_sn8260_1983_0.75m/01H8JBP6KZTJF747759825FVZF",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_waikato_sn8260_1983_0.75m/01H8JBNY5KSE63QJD65AZB08G5/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_waikato_sn8260_1983_0.75m/01H8JBP6KZTJF747759825FVZF/",
       "name": "hawkes-bay-waikato-sn8260-1983-0.75m",
       "title": "Hawkes Bay / Waikato 0.75m SN8260 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -492,8 +492,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_sn8262_1983_0.375m/01H8JHC3NXE1K4CCZFH3FH3BSR",
-      "3857": "s3://linz-basemaps/3857/marlborough_sn8262_1983_0.375m/01H8JHF046XWBVSSJ7WECJ08SG",
+      "2193": "s3://linz-basemaps/2193/marlborough_sn8262_1983_0.375m/01H8JHC3NXE1K4CCZFH3FH3BSR/",
+      "3857": "s3://linz-basemaps/3857/marlborough_sn8262_1983_0.375m/01H8JHF046XWBVSSJ7WECJ08SG/",
       "name": "marlborough-sn8262-1983-0.375m",
       "title": "Marlborough 0.375m SN8262 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -501,8 +501,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_snc8294_1983_0.375m/01H8JJ1K46R4W7X0V69KGRCV6V",
-      "3857": "s3://linz-basemaps/3857/marlborough_snc8294_1983_0.375m/01H8JJ1K4MSDCCACGE3T97PEQ0",
+      "2193": "s3://linz-basemaps/2193/marlborough_snc8294_1983_0.375m/01H8JJ1K46R4W7X0V69KGRCV6V/",
+      "3857": "s3://linz-basemaps/3857/marlborough_snc8294_1983_0.375m/01H8JJ1K4MSDCCACGE3T97PEQ0/",
       "name": "marlborough-snc8294-1983-0.375m",
       "title": "Marlborough 0.375m SNC8294 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -510,8 +510,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_snc8309_1983_0.4m/01H8JBQ5DQTYBGE95RN86Z9JFA",
-      "3857": "s3://linz-basemaps/3857/gisborne_snc8309_1983_0.4m/01H8JBPW86YVK5HDAQZZPTZQ4M",
+      "2193": "s3://linz-basemaps/2193/gisborne_snc8309_1983_0.4m/01H8JBQ5DQTYBGE95RN86Z9JFA/",
+      "3857": "s3://linz-basemaps/3857/gisborne_snc8309_1983_0.4m/01H8JBPW86YVK5HDAQZZPTZQ4M/",
       "name": "gisborne-snc8309-1983-0.4m",
       "title": "Gisborne 0.4m SNC8309 (1983)",
       "category": "Scanned Aerial Imagery",
@@ -519,8 +519,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8286_1984_0.8m/01H8JK4JS7S71JY44EV7922QGS",
-      "3857": "s3://linz-basemaps/3857/otago_sn8286_1984_0.8m/01H8JK4JS3FWJEV55TR2C5HHNJ",
+      "2193": "s3://linz-basemaps/2193/otago_sn8286_1984_0.8m/01H8JK4JS7S71JY44EV7922QGS/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8286_1984_0.8m/01H8JK4JS3FWJEV55TR2C5HHNJ/",
       "name": "otago-sn8286-1984-0.8m",
       "title": "Otago 0.8m SN8286 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -528,8 +528,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8298_1984_0.375m/01H8JMRFQSZ38X16N163HR64FJ",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8298_1984_0.375m/01H8JMRJK8W815QVTYE5X7TFT2",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8298_1984_0.375m/01H8JMRFQSZ38X16N163HR64FJ/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8298_1984_0.375m/01H8JMRJK8W815QVTYE5X7TFT2/",
       "name": "taranaki-sn8298-1984-0.375m",
       "title": "Taranaki 0.375m SN8298 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -537,8 +537,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn8297_1984_0.4m/01H8JNZAPXS0PRQXNRERS9D6AM",
-      "3857": "s3://linz-basemaps/3857/waikato_sn8297_1984_0.4m/01H8JNZD91HYZJFK1TMXZVBKJS",
+      "2193": "s3://linz-basemaps/2193/waikato_sn8297_1984_0.4m/01H8JNZAPXS0PRQXNRERS9D6AM/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn8297_1984_0.4m/01H8JNZD91HYZJFK1TMXZVBKJS/",
       "name": "waikato-sn8297-1984-0.4m",
       "title": "Waikato 0.4m SN8297 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -546,8 +546,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8303_1984_0.375m/01H8JDCMV0P03ZF0NCJY719C66",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8303_1984_0.375m/01H8JDC2VS4K2NXVPM6SKRQ9N9",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8303_1984_0.375m/01H8JDCMV0P03ZF0NCJY719C66/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8303_1984_0.375m/01H8JDC2VS4K2NXVPM6SKRQ9N9/",
       "name": "manawatu-whanganui-sn8303-1984-0.375m",
       "title": "Manawatū-Whanganui 0.375m SN8303 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -555,8 +555,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn8312_1984-1985_0.375m/01H8JQFTZTDCV4Z93T54XYKE07",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn8312_1984-1985_0.375m/01H8JQFTZSXXM2GN66C21GZAH3",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn8312_1984-1985_0.375m/01H8JQFTZTDCV4Z93T54XYKE07/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn8312_1984-1985_0.375m/01H8JQFTZSXXM2GN66C21GZAH3/",
       "name": "west-coast-sn8312-1984-1985-0.375m",
       "title": "West Coast 0.375m SN8312 (1984-1985)",
       "category": "Scanned Aerial Imagery",
@@ -564,8 +564,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8316_1984_0.4m/01H8JEE1FCF7NGVTV01XTD2XE0",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8316_1984_0.4m/01H8JE9M5SR7Z1PSH9JGFCN48V",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_sn8316_1984_0.4m/01H8JEE1FCF7NGVTV01XTD2XE0/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_sn8316_1984_0.4m/01H8JE9M5SR7Z1PSH9JGFCN48V/",
       "name": "manawatu-whanganui-sn8316-1984-0.4m",
       "title": "Manawatū-Whanganui 0.4m SN8316 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -573,8 +573,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn8317_1984_0.75m/01H8JMRAQYEV3NR5K4WA8KENSW",
-      "3857": "s3://linz-basemaps/3857/southland_sn8317_1984_0.75m/01H8JMXHY7GNWPSF9BK4PFAQ2Y",
+      "2193": "s3://linz-basemaps/2193/southland_sn8317_1984_0.75m/01H8JMRAQYEV3NR5K4WA8KENSW/",
+      "3857": "s3://linz-basemaps/3857/southland_sn8317_1984_0.75m/01H8JMXHY7GNWPSF9BK4PFAQ2Y/",
       "name": "southland-sn8317-1984-0.75m",
       "title": "Southland 0.75m SN8317 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -582,8 +582,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_otago_sn8321_1984-1985_0.375m/01H8JQE08V3W8VDRQYWWR7HWKK",
-      "3857": "s3://linz-basemaps/3857/west-coast_otago_sn8321_1984-1985_0.375m/01H8JQE08VG4ZEZPTP43H0EY6Z",
+      "2193": "s3://linz-basemaps/2193/west-coast_otago_sn8321_1984-1985_0.375m/01H8JQE08V3W8VDRQYWWR7HWKK/",
+      "3857": "s3://linz-basemaps/3857/west-coast_otago_sn8321_1984-1985_0.375m/01H8JQE08VG4ZEZPTP43H0EY6Z/",
       "name": "west-coast-otago-sn8321-1984-1985-0.375m",
       "title": "West Coast / Otago 0.375m SN8321 (1984-1985)",
       "category": "Scanned Aerial Imagery",
@@ -591,8 +591,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_sn8328_1984-1986_0.8m/01H8JJKQR9XYDCQBVGW7J36NQH",
-      "3857": "s3://linz-basemaps/3857/northland_sn8328_1984-1986_0.8m/01H8JJKQRBZ1B7QMFX121GSFVA",
+      "2193": "s3://linz-basemaps/2193/northland_sn8328_1984-1986_0.8m/01H8JJKQR9XYDCQBVGW7J36NQH/",
+      "3857": "s3://linz-basemaps/3857/northland_sn8328_1984-1986_0.8m/01H8JJKQRBZ1B7QMFX121GSFVA/",
       "name": "northland-sn8328-1984-1986-0.8m",
       "title": "Northland 0.8m SN8328 (1984-1986)",
       "category": "Scanned Aerial Imagery",
@@ -600,8 +600,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_otago_sn8337_1984_0.75m/01H8JAC7YY2QVJZ9ZB71B5T30D",
-      "3857": "s3://linz-basemaps/3857/canterbury_otago_sn8337_1984_0.75m/01H8JADH3GEXXY3QR7D8W4EGFA",
+      "2193": "s3://linz-basemaps/2193/canterbury_otago_sn8337_1984_0.75m/01H8JAC7YY2QVJZ9ZB71B5T30D/",
+      "3857": "s3://linz-basemaps/3857/canterbury_otago_sn8337_1984_0.75m/01H8JADH3GEXXY3QR7D8W4EGFA/",
       "name": "canterbury-otago-sn8337-1984-0.75m",
       "title": "Canterbury / Otago 0.75m SN8337 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -609,8 +609,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8349_1984-1985_0.375m/01H8JMTV1SBDTCXAMAN93XZX0P",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8349_1984-1985_0.375m/01H8JMTVFCBCAVR1E8C9JYYATM",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8349_1984-1985_0.375m/01H8JMTV1SBDTCXAMAN93XZX0P/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8349_1984-1985_0.375m/01H8JMTVFCBCAVR1E8C9JYYATM/",
       "name": "taranaki-sn8349-1984-1985-0.375m",
       "title": "Taranaki 0.375m SN8349 (1984-1985)",
       "category": "Scanned Aerial Imagery",
@@ -618,8 +618,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8389_1984_0.375m/01H8JBHNGP0ZSG0KNAJ7KGH5QW",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8389_1984_0.375m/01H8JBHNP6T2JMTWR8H2Y0CF5R",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8389_1984_0.375m/01H8JBHNGP0ZSG0KNAJ7KGH5QW/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8389_1984_0.375m/01H8JBHNP6T2JMTWR8H2Y0CF5R/",
       "name": "canterbury-sn8389-1984-0.375m",
       "title": "Canterbury 0.375m SN8389 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -627,8 +627,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_tasman_snc8423_1984_0.375m/01H8JJ90E6NY1RBQ8QF7X2EQRB",
-      "3857": "s3://linz-basemaps/3857/marlborough_tasman_snc8423_1984_0.375m/01H8JJBKHYZYP5VP3SV14HMT2G",
+      "2193": "s3://linz-basemaps/2193/marlborough_tasman_snc8423_1984_0.375m/01H8JJ90E6NY1RBQ8QF7X2EQRB/",
+      "3857": "s3://linz-basemaps/3857/marlborough_tasman_snc8423_1984_0.375m/01H8JJBKHYZYP5VP3SV14HMT2G/",
       "name": "marlborough-tasman-snc8423-1984-0.375m",
       "title": "Marlborough / Tasman 0.375m SNC8423 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -636,8 +636,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn8408_1984_0.375m/01H8JMB5K4356R712GX4HD8R1N",
-      "3857": "s3://linz-basemaps/3857/southland_sn8408_1984_0.375m/01H8JMCFQWBQ094H9T27N4X9HG",
+      "2193": "s3://linz-basemaps/2193/southland_sn8408_1984_0.375m/01H8JMB5K4356R712GX4HD8R1N/",
+      "3857": "s3://linz-basemaps/3857/southland_sn8408_1984_0.375m/01H8JMCFQWBQ094H9T27N4X9HG/",
       "name": "southland-sn8408-1984-0.375m",
       "title": "Southland 0.375m SN8408 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -645,8 +645,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_west-coast_sn8409_1984-1985_0.375m/01H8JN9RAKA36BEPMVR8WQMH7W",
-      "3857": "s3://linz-basemaps/3857/tasman_west-coast_sn8409_1984-1985_0.375m/01H8JN9RBAG9B25E5J8MDAZE82",
+      "2193": "s3://linz-basemaps/2193/tasman_west-coast_sn8409_1984-1985_0.375m/01H8JN9RAKA36BEPMVR8WQMH7W/",
+      "3857": "s3://linz-basemaps/3857/tasman_west-coast_sn8409_1984-1985_0.375m/01H8JN9RBAG9B25E5J8MDAZE82/",
       "name": "tasman-west-coast-sn8409-1984-1985-0.375m",
       "title": "Tasman / West Coast 0.375m SN8409 (1984-1985)",
       "category": "Scanned Aerial Imagery",
@@ -654,8 +654,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_tasman_sn8415_1984_0.375m/01H8JJ73R2M08BME04C0K304WX",
-      "3857": "s3://linz-basemaps/3857/marlborough_tasman_sn8415_1984_0.375m/01H8JJCWKVMYD04XF6WAPWQCFQ",
+      "2193": "s3://linz-basemaps/2193/marlborough_tasman_sn8415_1984_0.375m/01H8JJ73R2M08BME04C0K304WX/",
+      "3857": "s3://linz-basemaps/3857/marlborough_tasman_sn8415_1984_0.375m/01H8JJCWKVMYD04XF6WAPWQCFQ/",
       "name": "marlborough-tasman-sn8415-1984-0.375m",
       "title": "Marlborough / Tasman 0.375m SN8415 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -663,8 +663,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn8418_1984-1985_0.375m/01H8JBKVAKXH3N8ZYXM92FJ5T7",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn8418_1984-1985_0.375m/01H8JBMQWQJHPDNM8Z8D3FJ3FP",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn8418_1984-1985_0.375m/01H8JBKVAKXH3N8ZYXM92FJ5T7/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn8418_1984-1985_0.375m/01H8JBMQWQJHPDNM8Z8D3FJ3FP/",
       "name": "gisborne-sn8418-1984-1985-0.375m",
       "title": "Gisborne 0.375m SN8418 (1984-1985)",
       "category": "Scanned Aerial Imagery",
@@ -672,8 +672,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/01H8J8R980P2CG305088NFPW8P",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/01H8J8RANGZD43A4B7KWC9DG4Z",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/01H8J8R980P2CG305088NFPW8P/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/01H8J8RANGZD43A4B7KWC9DG4Z/",
       "name": "bay-of-plenty-hawkes-bay-sn8419-1984-0.75m",
       "title": "Bay of Plenty / Hawkes Bay 0.75m SN8419 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -681,8 +681,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8422_1984-1985_0.375m/01H8JMVYEQNWWPVB8VDYD3MD6X",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8422_1984-1985_0.375m/01H8JMVYFYH2C0FFJHN1078538",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8422_1984-1985_0.375m/01H8JMVYEQNWWPVB8VDYD3MD6X/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8422_1984-1985_0.375m/01H8JMVYFYH2C0FFJHN1078538/",
       "name": "taranaki-sn8422-1984-1985-0.375m",
       "title": "Taranaki 0.375m SN8422 (1984-1985)",
       "category": "Scanned Aerial Imagery",
@@ -690,8 +690,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_southland_west-coast_sn8426_1984-1985_0.75m/01H8JKP0SS6Y2PG6W20MB31V0X",
-      "3857": "s3://linz-basemaps/3857/otago_southland_west-coast_sn8426_1984-1985_0.75m/01H8JKP0S9SMM3Z8D540RJTNME",
+      "2193": "s3://linz-basemaps/2193/otago_southland_west-coast_sn8426_1984-1985_0.75m/01H8JKP0SS6Y2PG6W20MB31V0X/",
+      "3857": "s3://linz-basemaps/3857/otago_southland_west-coast_sn8426_1984-1985_0.75m/01H8JKP0S9SMM3Z8D540RJTNME/",
       "name": "otago-southland-west-coast-sn8426-1984-1985-0.75m",
       "title": "Otago / Southland / West Coast 0.75m SN8426 (1984-1985)",
       "category": "Scanned Aerial Imagery",
@@ -699,8 +699,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/01H8JG9BFVAQK5P689CDRZJ80R",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/01H8JG9BFDNPF1ZPYS43FWSJEB",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/01H8JG9BFVAQK5P689CDRZJ80R/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/01H8JG9BFDNPF1ZPYS43FWSJEB/",
       "name": "manawatu-whanganui-waikato-sn8440-1984-1985-0.375m",
       "title": "Manawatū-Whanganui / Waikato 0.375m SN8440 (1984-1985)",
       "category": "Scanned Aerial Imagery",
@@ -708,8 +708,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8436_1984_0.64m/01H8JK6KMBVH8XCC5PYQX76Z6Y",
-      "3857": "s3://linz-basemaps/3857/otago_sn8436_1984_0.64m/01H8JK6NFQV9DVCDXG4B08JG9R",
+      "2193": "s3://linz-basemaps/2193/otago_sn8436_1984_0.64m/01H8JK6KMBVH8XCC5PYQX76Z6Y/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8436_1984_0.64m/01H8JK6NFQV9DVCDXG4B08JG9R/",
       "name": "otago-sn8436-1984-0.64m",
       "title": "Otago 0.64m SN8436 (1984)",
       "category": "Scanned Aerial Imagery",
@@ -717,8 +717,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8453_1985_0.75m/01H8JBHN4FKSAEHPH9XARAKSF1",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8453_1985_0.75m/01H8JBHN77AYTMD9SE0FDMZ5GY",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8453_1985_0.75m/01H8JBHN4FKSAEHPH9XARAKSF1/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8453_1985_0.75m/01H8JBHN77AYTMD9SE0FDMZ5GY/",
       "name": "canterbury-sn8453-1985-0.75m",
       "title": "Canterbury 0.75m SN8453 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -726,8 +726,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/marlborough_tasman_canterbury_sn8452_1985_0.75m/01H8JJ4DD3HYEHEQH2PAAM3DBJ",
-      "3857": "s3://linz-basemaps/3857/marlborough_tasman_canterbury_sn8452_1985_0.75m/01H8JJ4F7HV3E6AQSFEM3Q3G7P",
+      "2193": "s3://linz-basemaps/2193/marlborough_tasman_canterbury_sn8452_1985_0.75m/01H8JJ4DD3HYEHEQH2PAAM3DBJ/",
+      "3857": "s3://linz-basemaps/3857/marlborough_tasman_canterbury_sn8452_1985_0.75m/01H8JJ4F7HV3E6AQSFEM3Q3G7P/",
       "name": "marlborough-tasman-canterbury-sn8452-1985-0.75m",
       "title": "Marlborough / Tasman / Canterbury 0.75m SN8452 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -735,8 +735,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_manawatu-whanganui_sn8463_1985_0.375m/01H8JMTM3WEXBHDAXD67E9MNWG",
-      "3857": "s3://linz-basemaps/3857/taranaki_manawatu-whanganui_sn8463_1985_0.375m/01H8JMSBHWPBD4MENZNZPDF7FM",
+      "2193": "s3://linz-basemaps/2193/taranaki_manawatu-whanganui_sn8463_1985_0.375m/01H8JMTM3WEXBHDAXD67E9MNWG/",
+      "3857": "s3://linz-basemaps/3857/taranaki_manawatu-whanganui_sn8463_1985_0.375m/01H8JMSBHWPBD4MENZNZPDF7FM/",
       "name": "taranaki-manawatu-whanganui-sn8463-1985-0.375m",
       "title": "Taranaki / Manawatū-Whanganui 0.375m SN8463 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -744,8 +744,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8479_1985_0.375m/01H8JK6MM3JASK9BPHAACX6PQN",
-      "3857": "s3://linz-basemaps/3857/otago_sn8479_1985_0.375m/01H8JK6MK9XB5VPA7AK31XBKE2",
+      "2193": "s3://linz-basemaps/2193/otago_sn8479_1985_0.375m/01H8JK6MM3JASK9BPHAACX6PQN/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8479_1985_0.375m/01H8JK6MK9XB5VPA7AK31XBKE2/",
       "name": "otago-sn8479-1985-0.375m",
       "title": "Otago 0.375m SN8479 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -753,8 +753,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8502_1985_0.375m/01H8JMWE95N807VF844JTSZCCE",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8502_1985_0.375m/01H8JMWE98DPG3BW79CPAEJ3KT",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8502_1985_0.375m/01H8JMWE95N807VF844JTSZCCE/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8502_1985_0.375m/01H8JMWE98DPG3BW79CPAEJ3KT/",
       "name": "taranaki-sn8502-1985-0.375m",
       "title": "Taranaki 0.375m SN8502 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -762,8 +762,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn6656_1985-1987_0.6m/01H8JNP2SJEDAEND31C3SB82Y8",
-      "3857": "s3://linz-basemaps/3857/waikato_sn6656_1985-1987_0.6m/01H8JNP1Z1VAQ8BHQ8GFHRGGXY",
+      "2193": "s3://linz-basemaps/2193/waikato_sn6656_1985-1987_0.6m/01H8JNP2SJEDAEND31C3SB82Y8/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn6656_1985-1987_0.6m/01H8JNP1Z1VAQ8BHQ8GFHRGGXY/",
       "name": "waikato-sn6656-1985-1987-0.6m",
       "title": "Waikato 0.6m SN6656 (1985-1987)",
       "category": "Scanned Aerial Imagery",
@@ -771,8 +771,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/tasman_sn8531_1985-1986_0.375m/01H8JN6Y6K2Y3R0Q58MEG8E7HG",
-      "3857": "s3://linz-basemaps/3857/tasman_sn8531_1985-1986_0.375m/01H8JN6Y5KNVZXEP6K1S5RS0F5",
+      "2193": "s3://linz-basemaps/2193/tasman_sn8531_1985-1986_0.375m/01H8JN6Y6K2Y3R0Q58MEG8E7HG/",
+      "3857": "s3://linz-basemaps/3857/tasman_sn8531_1985-1986_0.375m/01H8JN6Y5KNVZXEP6K1S5RS0F5/",
       "name": "tasman-sn8531-1985-1986-0.375m",
       "title": "Tasman 0.375m SN8531 (1985-1986)",
       "category": "Scanned Aerial Imagery",
@@ -780,8 +780,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_marlborough_sn8533_1985-1986_0.375m/01H8JA7AZNY3BE62P7VCH88DKV",
-      "3857": "s3://linz-basemaps/3857/canterbury_marlborough_sn8533_1985-1986_0.375m/01H8JA7B0DDJ0D7K9A9D4ZRYA6",
+      "2193": "s3://linz-basemaps/2193/canterbury_marlborough_sn8533_1985-1986_0.375m/01H8JA7AZNY3BE62P7VCH88DKV/",
+      "3857": "s3://linz-basemaps/3857/canterbury_marlborough_sn8533_1985-1986_0.375m/01H8JA7B0DDJ0D7K9A9D4ZRYA6/",
       "name": "canterbury-marlborough-sn8533-1985-1986-0.375m",
       "title": "Canterbury / Marlborough 0.375m SN8533 (1985-1986)",
       "category": "Scanned Aerial Imagery",
@@ -789,8 +789,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8532_1985_0.375m/01H8JBHQ2G8HX3HPTDMATCFM9E",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8532_1985_0.375m/01H8JBHPXEX5W1WG8CVH48VJZ9",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8532_1985_0.375m/01H8JBHQ2G8HX3HPTDMATCFM9E/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8532_1985_0.375m/01H8JBHPXEX5W1WG8CVH48VJZ9/",
       "name": "canterbury-sn8532-1985-0.375m",
       "title": "Canterbury 0.375m SN8532 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -798,8 +798,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn8534_1985-1986_0.375m/01H8JQW0Z9PNE2QBKCREKS2AWK",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn8534_1985-1986_0.375m/01H8JQVZ0ERE8C5YA0MCPFDY99",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn8534_1985-1986_0.375m/01H8JQW0Z9PNE2QBKCREKS2AWK/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn8534_1985-1986_0.375m/01H8JQVZ0ERE8C5YA0MCPFDY99/",
       "name": "west-coast-sn8534-1985-1986-0.375m",
       "title": "West Coast 0.375m SN8534 (1985-1986)",
       "category": "Scanned Aerial Imagery",
@@ -807,8 +807,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn8538_1985_0.375m/01H8JBNY3YHJN1AZCZ422SKQGG",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn8538_1985_0.375m/01H8JBJZ5GEVZYR73KDZFAZVYQ",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn8538_1985_0.375m/01H8JBNY3YHJN1AZCZ422SKQGG/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn8538_1985_0.375m/01H8JBJZ5GEVZYR73KDZFAZVYQ/",
       "name": "gisborne-sn8538-1985-0.375m",
       "title": "Gisborne 0.375m SN8538 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -816,8 +816,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/northland_snc8573_1985_0.3m/01H8JJX1T63VBXTGD2QA6PF317",
-      "3857": "s3://linz-basemaps/3857/northland_snc8573_1985_0.3m/01H8JJX1T9XJX0JMXPR5XVWWR3",
+      "2193": "s3://linz-basemaps/2193/northland_snc8573_1985_0.3m/01H8JJX1T63VBXTGD2QA6PF317/",
+      "3857": "s3://linz-basemaps/3857/northland_snc8573_1985_0.3m/01H8JJX1T9XJX0JMXPR5XVWWR3/",
       "name": "northland-snc8573-1985-0.3m",
       "title": "Northland 0.3m SNC8573 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -825,8 +825,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8540_1985-1986_0.375m/01H8J8RDMECK36AQFNKESQPEKG",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8540_1985-1986_0.375m/01H8J8REJC2NHK3RXHBFDN01TX",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8540_1985-1986_0.375m/01H8J8RDMECK36AQFNKESQPEKG/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8540_1985-1986_0.375m/01H8J8REJC2NHK3RXHBFDN01TX/",
       "name": "bay-of-plenty-sn8540-1985-1986-0.375m",
       "title": "Bay of Plenty 0.375m SN8540 (1985-1986)",
       "category": "Scanned Aerial Imagery",
@@ -834,8 +834,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn8542_1985_0.375m/01H8JKYDE3NA50AWVTTTN9R03D",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn8542_1985_0.375m/01H8JKYDEPJPAFG6TVW2J8F26V",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn8542_1985_0.375m/01H8JKYDE3NA50AWVTTTN9R03D/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn8542_1985_0.375m/01H8JKYDEPJPAFG6TVW2J8F26V/",
       "name": "southland-otago-sn8542-1985-0.375m",
       "title": "Southland / Otago 0.375m SN8542 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -843,8 +843,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn8541_1985_0.375m/01H8JM95ZD5692X12KSDE0CY3N",
-      "3857": "s3://linz-basemaps/3857/southland_sn8541_1985_0.375m/01H8JM95ZGSFQ8RJPMJ206JZK5",
+      "2193": "s3://linz-basemaps/2193/southland_sn8541_1985_0.375m/01H8JM95ZD5692X12KSDE0CY3N/",
+      "3857": "s3://linz-basemaps/3857/southland_sn8541_1985_0.375m/01H8JM95ZGSFQ8RJPMJ206JZK5/",
       "name": "southland-sn8541-1985-0.375m",
       "title": "Southland 0.375m SN8541 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -852,8 +852,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8549_1985_0.375m/01H8JG8D1K07560HVP17ZXSXTE",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8549_1985_0.375m/01H8JG8D19RGGBDYAKW9G3VFBB",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8549_1985_0.375m/01H8JG8D1K07560HVP17ZXSXTE/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8549_1985_0.375m/01H8JG8D19RGGBDYAKW9G3VFBB/",
       "name": "manawatu-whanganui-taranaki-sn8549-1985-0.375m",
       "title": "Manawatū-Whanganui / Taranaki 0.375m SN8549 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -861,8 +861,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8569_1985-1986_0.8m/01H8JBHPBR494DT2ZTZS599BS5",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8569_1985-1986_0.8m/01H8JBHRAFNQGF1AMHXFZ9H74P",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8569_1985-1986_0.8m/01H8JBHPBR494DT2ZTZS599BS5/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8569_1985-1986_0.8m/01H8JBHRAFNQGF1AMHXFZ9H74P/",
       "name": "canterbury-sn8569-1985-1986-0.8m",
       "title": "Canterbury 0.8m SN8569 (1985-1986)",
       "category": "Scanned Aerial Imagery",
@@ -870,8 +870,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_otago_sn8568_1985-1987_0.75m/01H8JAJVB2C2VV9Z157GDWH162",
-      "3857": "s3://linz-basemaps/3857/canterbury_otago_sn8568_1985-1987_0.75m/01H8JAG92BRXKP81GEVDZG14KW",
+      "2193": "s3://linz-basemaps/2193/canterbury_otago_sn8568_1985-1987_0.75m/01H8JAJVB2C2VV9Z157GDWH162/",
+      "3857": "s3://linz-basemaps/3857/canterbury_otago_sn8568_1985-1987_0.75m/01H8JAG92BRXKP81GEVDZG14KW/",
       "name": "canterbury-otago-sn8568-1985-1987-0.75m",
       "title": "Canterbury / Otago 0.75m SN8568 (1985-1987)",
       "category": "Scanned Aerial Imagery",
@@ -879,8 +879,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn8565_1985-1987_0.8m/01H8JM0PQN5BS9N5EZX1R4Y4TC",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn8565_1985-1987_0.8m/01H8JKYDEQRERJWP9TKNV3BWME",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn8565_1985-1987_0.8m/01H8JM0PQN5BS9N5EZX1R4Y4TC/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn8565_1985-1987_0.8m/01H8JKYDEQRERJWP9TKNV3BWME/",
       "name": "southland-otago-sn8565-1985-1987-0.8m",
       "title": "Southland / Otago 0.8m SN8565 (1985-1987)",
       "category": "Scanned Aerial Imagery",
@@ -888,8 +888,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_gisborne_sn8564_1985_0.375m/01H8J8R807NE0G76Y8QNFR7X98",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_gisborne_sn8564_1985_0.375m/01H8J8R7T8Z03959Z4VZRFGZPV",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_gisborne_sn8564_1985_0.375m/01H8J8R807NE0G76Y8QNFR7X98/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_gisborne_sn8564_1985_0.375m/01H8J8R7T8Z03959Z4VZRFGZPV/",
       "name": "bay-of-plenty-gisborne-sn8564-1985-0.375m",
       "title": "Bay of Plenty / Gisborne 0.375m SN8564 (1985)",
       "category": "Scanned Aerial Imagery",
@@ -897,8 +897,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8584_1986_0.75m/01H8JBHSF3SAKBGWKT88N3KHFP",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8584_1986_0.75m/01H8JBHSD8AVY4ERM51V06BVGZ",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8584_1986_0.75m/01H8JBHSF3SAKBGWKT88N3KHFP/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8584_1986_0.75m/01H8JBHSD8AVY4ERM51V06BVGZ/",
       "name": "canterbury-sn8584-1986-0.75m",
       "title": "Canterbury 0.75m SN8584 (1986)",
       "category": "Scanned Aerial Imagery",
@@ -906,8 +906,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_canterbury_sn8585_1986-1987_0.75m/01H8JR0PPQ845A49V9DHHVY3WV",
-      "3857": "s3://linz-basemaps/3857/west-coast_canterbury_sn8585_1986-1987_0.75m/01H8JQGZCQ746Q8GB61MEA2YMY",
+      "2193": "s3://linz-basemaps/2193/west-coast_canterbury_sn8585_1986-1987_0.75m/01H8JR0PPQ845A49V9DHHVY3WV/",
+      "3857": "s3://linz-basemaps/3857/west-coast_canterbury_sn8585_1986-1987_0.75m/01H8JQGZCQ746Q8GB61MEA2YMY/",
       "name": "west-coast-canterbury-sn8585-1986-1987-0.75m",
       "title": "West Coast / Canterbury 0.75m SN8585 (1986-1987)",
       "category": "Scanned Aerial Imagery",
@@ -915,8 +915,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_west-coast_sn8595_1986-1987_0.96m/01H8JBMB6KJ8C6AAHSEZ5RVRC8",
-      "3857": "s3://linz-basemaps/3857/canterbury_west-coast_sn8595_1986-1987_0.96m/01H8JBKR6W92Q8Y7P5WAC5ZXM6",
+      "2193": "s3://linz-basemaps/2193/canterbury_west-coast_sn8595_1986-1987_0.96m/01H8JBMB6KJ8C6AAHSEZ5RVRC8/",
+      "3857": "s3://linz-basemaps/3857/canterbury_west-coast_sn8595_1986-1987_0.96m/01H8JBKR6W92Q8Y7P5WAC5ZXM6/",
       "name": "canterbury-west-coast-sn8595-1986-1987-0.96m",
       "title": "Canterbury / West Coast 0.96m SN8595 (1986-1987)",
       "category": "Scanned Aerial Imagery",
@@ -924,8 +924,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc8650_1986_0.375m/01H8JG3AAJ1J6FX57XQ8Y8BR1Q",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc8650_1986_0.375m/01H8JG4FBX9EYNTED3FC4R055A",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc8650_1986_0.375m/01H8JG3AAJ1J6FX57XQ8Y8BR1Q/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc8650_1986_0.375m/01H8JG4FBX9EYNTED3FC4R055A/",
       "name": "manawatu-whanganui-snc8650-1986-0.375m",
       "title": "Manawatū-Whanganui 0.375m SNC8650 (1986)",
       "category": "Scanned Aerial Imagery",
@@ -933,8 +933,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8626_1986_0.4m/01H8J8RG6M35RK4Z6QT20C5MWC",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8626_1986_0.4m/01H8J8RG8878Q4W97J37A49SJS",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8626_1986_0.4m/01H8J8RG6M35RK4Z6QT20C5MWC/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8626_1986_0.4m/01H8J8RG8878Q4W97J37A49SJS/",
       "name": "bay-of-plenty-sn8626-1986-0.4m",
       "title": "Bay of Plenty 0.4m SN8626 (1986)",
       "category": "Scanned Aerial Imagery",
@@ -942,8 +942,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn8675_1986_0.375m/01H8JBMB8PT8R97BWH7S9ZNC7Z",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn8675_1986_0.375m/01H8JBNA282DTDKXRG7F2GQR9G",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn8675_1986_0.375m/01H8JBMB8PT8R97BWH7S9ZNC7Z/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn8675_1986_0.375m/01H8JBNA282DTDKXRG7F2GQR9G/",
       "name": "hawkes-bay-sn8675-1986-0.375m",
       "title": "Hawkes Bay 0.375m SN8675 (1986)",
       "category": "Scanned Aerial Imagery",
@@ -951,8 +951,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/01H8JG98DTM7NKR76E6RQ6YE7V",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/01H8JG97G7QTEYTM0HZRYRE90M",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/01H8JG98DTM7NKR76E6RQ6YE7V/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/01H8JG97G7QTEYTM0HZRYRE90M/",
       "name": "manawatu-whanganui-taranaki-sn8686-1986-1987-0.375m",
       "title": "Manawatū-Whanganui / Taranaki 0.375m SN8686 (1986-1987)",
       "category": "Scanned Aerial Imagery",
@@ -960,8 +960,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn8687_1986-1987_0.375m/01H8JP0JM344JNKZJDYHW664MS",
-      "3857": "s3://linz-basemaps/3857/waikato_sn8687_1986-1987_0.375m/01H8JP0JMJZ1Q19PWHBZPCDXH1",
+      "2193": "s3://linz-basemaps/2193/waikato_sn8687_1986-1987_0.375m/01H8JP0JM344JNKZJDYHW664MS/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn8687_1986-1987_0.375m/01H8JP0JMJZ1Q19PWHBZPCDXH1/",
       "name": "waikato-sn8687-1986-1987-0.375m",
       "title": "Waikato 0.375m SN8687 (1986-1987)",
       "category": "Scanned Aerial Imagery",
@@ -969,8 +969,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/waikato_snc8697_1986_0.375m/01H8JPDBRYDDFB0JPF0C2SDM73",
-      "3857": "s3://linz-basemaps/3857/waikato_snc8697_1986_0.375m/01H8JPE28YHVDRN3C5Z1KEDY2D",
+      "2193": "s3://linz-basemaps/2193/waikato_snc8697_1986_0.375m/01H8JPDBRYDDFB0JPF0C2SDM73/",
+      "3857": "s3://linz-basemaps/3857/waikato_snc8697_1986_0.375m/01H8JPE28YHVDRN3C5Z1KEDY2D/",
       "name": "waikato-snc8697-1986-0.375m",
       "title": "Waikato 0.375m SNC8697 (1986)",
       "category": "Scanned Aerial Imagery",
@@ -978,8 +978,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn8721_1987_0.375m/01H8JQKF0JRGS8KCPF68R160J3",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn8721_1987_0.375m/01H8JQKF1JKDQJ1TP7TN2TFYCG",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn8721_1987_0.375m/01H8JQKF0JRGS8KCPF68R160J3/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn8721_1987_0.375m/01H8JQKF1JKDQJ1TP7TN2TFYCG/",
       "name": "west-coast-sn8721-1987-0.375m",
       "title": "West Coast 0.375m SN8721 (1987)",
       "category": "Scanned Aerial Imagery",
@@ -987,8 +987,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8720_1987_0.375m/01H8JBHXZ7T8N132VAMAJ0KZPJ",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8720_1987_0.375m/01H8JBHX0C71GFM6A23845YBXK",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8720_1987_0.375m/01H8JBHXZ7T8N132VAMAJ0KZPJ/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8720_1987_0.375m/01H8JBHX0C71GFM6A23845YBXK/",
       "name": "canterbury-sn8720-1987-0.375m",
       "title": "Canterbury 0.375m SN8720 (1987)",
       "category": "Scanned Aerial Imagery",
@@ -996,8 +996,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/otago_sn8733_1987_0.375m/01H8JKB7660GZ58R761D1YRBV4",
-      "3857": "s3://linz-basemaps/3857/otago_sn8733_1987_0.375m/01H8JKCA1S044XJ0K1Q94M76DY",
+      "2193": "s3://linz-basemaps/2193/otago_sn8733_1987_0.375m/01H8JKB7660GZ58R761D1YRBV4/",
+      "3857": "s3://linz-basemaps/3857/otago_sn8733_1987_0.375m/01H8JKCA1S044XJ0K1Q94M76DY/",
       "name": "otago-sn8733-1987-0.375m",
       "title": "Otago 0.375m SN8733 (1987)",
       "category": "Scanned Aerial Imagery",
@@ -1005,8 +1005,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8732_1987_0.15m/01H8J8RHQZJSVZA7TJGKHZE0DQ",
-      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8732_1987_0.15m/01H8J8RHN5QZAJ04R4FM2VQ78X",
+      "2193": "s3://linz-basemaps/2193/bay-of-plenty_sn8732_1987_0.15m/01H8J8RHQZJSVZA7TJGKHZE0DQ/",
+      "3857": "s3://linz-basemaps/3857/bay-of-plenty_sn8732_1987_0.15m/01H8J8RHN5QZAJ04R4FM2VQ78X/",
       "name": "bay-of-plenty-sn8732-1987-0.15m",
       "title": "Bay of Plenty 0.15m SN8732 (1987)",
       "category": "Scanned Aerial Imagery",
@@ -1014,8 +1014,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/auckland_waikato_sn8772_1987-1988_0.375m/01H8J8R64E4FPBHR3NR913XPDJ",
-      "3857": "s3://linz-basemaps/3857/auckland_waikato_sn8772_1987-1988_0.375m/01H8J8R67E85JMKT8V72CB4CYB",
+      "2193": "s3://linz-basemaps/2193/auckland_waikato_sn8772_1987-1988_0.375m/01H8J8R64E4FPBHR3NR913XPDJ/",
+      "3857": "s3://linz-basemaps/3857/auckland_waikato_sn8772_1987-1988_0.375m/01H8J8R67E85JMKT8V72CB4CYB/",
       "name": "auckland-waikato-sn8772-1987-1988-0.375m",
       "title": "Auckland / Waikato 0.375m SN8772 (1987-1988)",
       "category": "Scanned Aerial Imagery",
@@ -1023,8 +1023,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/canterbury_sn8777_1987_0.375m/01H8JBHZ0NC4TTW162FPKE4T5B",
-      "3857": "s3://linz-basemaps/3857/canterbury_sn8777_1987_0.375m/01H8JBHZ8AVFXS2QCJ2P6P6DQQ",
+      "2193": "s3://linz-basemaps/2193/canterbury_sn8777_1987_0.375m/01H8JBHZ0NC4TTW162FPKE4T5B/",
+      "3857": "s3://linz-basemaps/3857/canterbury_sn8777_1987_0.375m/01H8JBHZ8AVFXS2QCJ2P6P6DQQ/",
       "name": "canterbury-sn8777-1987-0.375m",
       "title": "Canterbury 0.375m SN8777 (1987)",
       "category": "Scanned Aerial Imagery",
@@ -1032,8 +1032,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/wellington_sn8790_1987-1988_0.375m/01H8JPJM6Q04M4Y45Q1XNW0BWK",
-      "3857": "s3://linz-basemaps/3857/wellington_sn8790_1987-1988_0.375m/01H8JPJ6EXWAXJ64YMESWMMP65",
+      "2193": "s3://linz-basemaps/2193/wellington_sn8790_1987-1988_0.375m/01H8JPJM6Q04M4Y45Q1XNW0BWK/",
+      "3857": "s3://linz-basemaps/3857/wellington_sn8790_1987-1988_0.375m/01H8JPJ6EXWAXJ64YMESWMMP65/",
       "name": "wellington-sn8790-1987-1988-0.375m",
       "title": "Wellington 0.375m SN8790 (1987-1988)",
       "category": "Scanned Aerial Imagery",
@@ -1041,8 +1041,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc8912_1987_0.375m/01H8JBP1T9J9V7Z8KQ00CWKR66",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc8912_1987_0.375m/01H8JBP1SY9HKM1NWZJDF0R8NB",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_snc8912_1987_0.375m/01H8JBP1T9J9V7Z8KQ00CWKR66/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_snc8912_1987_0.375m/01H8JBP1SY9HKM1NWZJDF0R8NB/",
       "name": "hawkes-bay-snc8912-1987-0.375m",
       "title": "Hawkes Bay 0.375m SNC8912 (1987)",
       "category": "Scanned Aerial Imagery",
@@ -1050,8 +1050,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc8914_1988_0.375m/01H8JG2MP81PQ6HXQNPGY0X1AS",
-      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc8914_1988_0.375m/01H8JG2MPKDEK3VJW32W5Y8HWD",
+      "2193": "s3://linz-basemaps/2193/manawatu-whanganui_snc8914_1988_0.375m/01H8JG2MP81PQ6HXQNPGY0X1AS/",
+      "3857": "s3://linz-basemaps/3857/manawatu-whanganui_snc8914_1988_0.375m/01H8JG2MPKDEK3VJW32W5Y8HWD/",
       "name": "manawatu-whanganui-snc8914-1988-0.375m",
       "title": "Manawatū-Whanganui 0.375m SNC8914 (1988)",
       "category": "Scanned Aerial Imagery",
@@ -1059,8 +1059,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_snc8923_1988_0.375m/01H8JN0QTR7B6Y9YRXRREC19X8",
-      "3857": "s3://linz-basemaps/3857/taranaki_snc8923_1988_0.375m/01H8JN0QVEAY2AF2NMGSVECCDM",
+      "2193": "s3://linz-basemaps/2193/taranaki_snc8923_1988_0.375m/01H8JN0QTR7B6Y9YRXRREC19X8/",
+      "3857": "s3://linz-basemaps/3857/taranaki_snc8923_1988_0.375m/01H8JN0QVEAY2AF2NMGSVECCDM/",
       "name": "taranaki-snc8923-1988-0.375m",
       "title": "Taranaki 0.375m SNC8923 (1988)",
       "category": "Scanned Aerial Imagery",
@@ -1068,8 +1068,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8771_1988_0.375m/01H8JMXFE1J73CA2X9X235Q65J",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8771_1988_0.375m/01H8JMXEPYF52SXSD9E9X9GRY2",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8771_1988_0.375m/01H8JMXFE1J73CA2X9X235Q65J/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8771_1988_0.375m/01H8JMXEPYF52SXSD9E9X9GRY2/",
       "name": "taranaki-sn8771-1988-0.375m",
       "title": "Taranaki 0.375m SN8771 (1988)",
       "category": "Scanned Aerial Imagery",
@@ -1077,8 +1077,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/gisborne_sn8941_1988_0.15m/01H8JBKJ08QZFFKDXGHGY0NQXR",
-      "3857": "s3://linz-basemaps/3857/gisborne_sn8941_1988_0.15m/01H8JBKDWSGNWMWKD6S0WK6SEW",
+      "2193": "s3://linz-basemaps/2193/gisborne_sn8941_1988_0.15m/01H8JBKJ08QZFFKDXGHGY0NQXR/",
+      "3857": "s3://linz-basemaps/3857/gisborne_sn8941_1988_0.15m/01H8JBKDWSGNWMWKD6S0WK6SEW/",
       "name": "gisborne-sn8941-1988-0.15m",
       "title": "Gisborne 0.15m SN8941 (1988)",
       "category": "Scanned Aerial Imagery",
@@ -1086,8 +1086,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn8985_1988_0.4m/01H8JBPSXPS58QAVBF1MWGZVCD",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn8985_1988_0.4m/01H8JBPK1ZW6GQ1683GG16GANF",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn8985_1988_0.4m/01H8JBPSXPS58QAVBF1MWGZVCD/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn8985_1988_0.4m/01H8JBPK1ZW6GQ1683GG16GANF/",
       "name": "hawkes-bay-sn8985-1988-0.4m",
       "title": "Hawkes Bay 0.4m SN8985 (1988)",
       "category": "Scanned Aerial Imagery",
@@ -1095,8 +1095,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn8996_1988_0.75m/01H8JMBG23B9S1GBY8WCA8D6KH",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn8996_1988_0.75m/01H8JKYQ1QY3PWCFTX47PMN0YT",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn8996_1988_0.75m/01H8JMBG23B9S1GBY8WCA8D6KH/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn8996_1988_0.75m/01H8JKYQ1QY3PWCFTX47PMN0YT/",
       "name": "southland-otago-sn8996-1988-0.75m",
       "title": "Southland / Otago 0.75m SN8996 (1988)",
       "category": "Scanned Aerial Imagery",
@@ -1104,8 +1104,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn7786_1989_0.48m/01H8JBM09ZBGC0ZFQQTTNPM9F8",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn7786_1989_0.48m/01H8JBPW7Y14X7D1Y4GCT6TCB9",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn7786_1989_0.48m/01H8JBM09ZBGC0ZFQQTTNPM9F8/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn7786_1989_0.48m/01H8JBPW7Y14X7D1Y4GCT6TCB9/",
       "name": "hawkes-bay-sn7786-1989-0.48m",
       "title": "Hawkes Bay 0.48m SN7786 (1989)",
       "category": "Scanned Aerial Imagery",
@@ -1113,8 +1113,8 @@
       "maxZoom": 32
     },
     {
-      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9037_1989_0.75m/01H8JBK25GAHVCR7ED1Q66KCTC",
-      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9037_1989_0.75m/01H8JBQKB4QQT956KJ1R736ETR",
+      "2193": "s3://linz-basemaps/2193/hawkes-bay_sn9037_1989_0.75m/01H8JBK25GAHVCR7ED1Q66KCTC/",
+      "3857": "s3://linz-basemaps/3857/hawkes-bay_sn9037_1989_0.75m/01H8JBQKB4QQT956KJ1R736ETR/",
       "name": "hawkes-bay-sn9037-1989-0.75m",
       "title": "Hawkes Bay 0.75m SN9037 (1989)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/invercargill-urban-2016-0.05m.json
+++ b/config/tileset/southland/imagery/invercargill-urban-2016-0.05m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-05m/01F6P1A2VKHHFQW764DRW93G4Y",
-      "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-05m/01ED82DPKVVWA818DY9QQ9GS0J",
+      "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-05m/01F6P1A2VKHHFQW764DRW93G4Y/",
+      "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-05m/01ED82DPKVVWA818DY9QQ9GS0J/",
       "name": "invercargill-urban-2016-0.05m",
       "title": "Invercargill 0.05m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/southland/imagery/invercargill-urban-2016-0.1m.json
+++ b/config/tileset/southland/imagery/invercargill-urban-2016-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-1m/01F6P1A7YH7JXE247G85F25WG6",
-      "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-1m/01ED82E60KN099T9A8V11KCSK0",
+      "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-1m/01F6P1A7YH7JXE247G85F25WG6/",
+      "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-1m/01ED82E60KN099T9A8V11KCSK0/",
       "name": "invercargill-urban-2016-0.1m",
       "title": "Invercargill 0.1m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/southland/imagery/southland-otago-sn5693-1980-0.75m.json
+++ b/config/tileset/southland/imagery/southland-otago-sn5693-1980-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn5693_1980_0.75m/01H8JKPGW320P7CTWMB4GBWA8Q",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn5693_1980_0.75m/01H8JKPGW1V632KZX58G63PY3R",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn5693_1980_0.75m/01H8JKPGW320P7CTWMB4GBWA8Q/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn5693_1980_0.75m/01H8JKPGW1V632KZX58G63PY3R/",
       "name": "southland-otago-sn5693-1980-0.75m",
       "title": "Southland / Otago 0.75m SN5693 (1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-otago-sn8542-1985-0.375m.json
+++ b/config/tileset/southland/imagery/southland-otago-sn8542-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn8542_1985_0.375m/01H8JKYDE3NA50AWVTTTN9R03D",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn8542_1985_0.375m/01H8JKYDEPJPAFG6TVW2J8F26V",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn8542_1985_0.375m/01H8JKYDE3NA50AWVTTTN9R03D/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn8542_1985_0.375m/01H8JKYDEPJPAFG6TVW2J8F26V/",
       "name": "southland-otago-sn8542-1985-0.375m",
       "title": "Southland / Otago 0.375m SN8542 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-otago-sn8565-1985-1987-0.8m.json
+++ b/config/tileset/southland/imagery/southland-otago-sn8565-1985-1987-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn8565_1985-1987_0.8m/01H8JM0PQN5BS9N5EZX1R4Y4TC",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn8565_1985-1987_0.8m/01H8JKYDEQRERJWP9TKNV3BWME",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn8565_1985-1987_0.8m/01H8JM0PQN5BS9N5EZX1R4Y4TC/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn8565_1985-1987_0.8m/01H8JKYDEQRERJWP9TKNV3BWME/",
       "name": "southland-otago-sn8565-1985-1987-0.8m",
       "title": "Southland / Otago 0.8m SN8565 (1985-1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-otago-sn8996-1988-0.75m.json
+++ b/config/tileset/southland/imagery/southland-otago-sn8996-1988-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn8996_1988_0.75m/01H8JMBG23B9S1GBY8WCA8D6KH",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn8996_1988_0.75m/01H8JKYQ1QY3PWCFTX47PMN0YT",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn8996_1988_0.75m/01H8JMBG23B9S1GBY8WCA8D6KH/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn8996_1988_0.75m/01H8JKYQ1QY3PWCFTX47PMN0YT/",
       "name": "southland-otago-sn8996-1988-0.75m",
       "title": "Southland / Otago 0.75m SN8996 (1988)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-otago-sn9613-1997-0.75m.json
+++ b/config/tileset/southland/imagery/southland-otago-sn9613-1997-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_sn9613_1997_0.75m/01H8JKZED3BMX7H3H982A46542",
-      "3857": "s3://linz-basemaps/3857/southland_otago_sn9613_1997_0.75m/01H8JKZED3SXF3XE4HM3ER9B4Q",
+      "2193": "s3://linz-basemaps/2193/southland_otago_sn9613_1997_0.75m/01H8JKZED3BMX7H3H982A46542/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_sn9613_1997_0.75m/01H8JKZED3SXF3XE4HM3ER9B4Q/",
       "name": "southland-otago-sn9613-1997-0.75m",
       "title": "Southland / Otago 0.75m SN9613 (1997)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-otago-snc12731-2002-0.75m.json
+++ b/config/tileset/southland/imagery/southland-otago-snc12731-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_snc12731_2002_0.75m/01H8JM01HJNA5J3P29WH13ZMRP",
-      "3857": "s3://linz-basemaps/3857/southland_otago_snc12731_2002_0.75m/01H8JM01F9KPMJ7B5YKJJK0NJJ",
+      "2193": "s3://linz-basemaps/2193/southland_otago_snc12731_2002_0.75m/01H8JM01HJNA5J3P29WH13ZMRP/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_snc12731_2002_0.75m/01H8JM01F9KPMJ7B5YKJJK0NJJ/",
       "name": "southland-otago-snc12731-2002-0.75m",
       "title": "Southland / Otago 0.75m SNC12731 (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-otago-snc30012-2003-0.75m.json
+++ b/config/tileset/southland/imagery/southland-otago-snc30012-2003-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_otago_snc30012_2003_0.75m/01H8JM6SQBD1ST5Z50KDE5FQJ2",
-      "3857": "s3://linz-basemaps/3857/southland_otago_snc30012_2003_0.75m/01H8JM6SQY8E4ZX321XJ6KK8PB",
+      "2193": "s3://linz-basemaps/2193/southland_otago_snc30012_2003_0.75m/01H8JM6SQBD1ST5Z50KDE5FQJ2/",
+      "3857": "s3://linz-basemaps/3857/southland_otago_snc30012_2003_0.75m/01H8JM6SQY8E4ZX321XJ6KK8PB/",
       "name": "southland-otago-snc30012-2003-0.75m",
       "title": "Southland / Otago 0.75m SNC30012 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-sn12545a-1998-0.75m.json
+++ b/config/tileset/southland/imagery/southland-sn12545a-1998-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn12545a_1998_0.75m/01H8JM6SQCZW0P3NZ0A47WPFT9",
-      "3857": "s3://linz-basemaps/3857/southland_sn12545a_1998_0.75m/01H8JM6SJWSGXE5VKANA3XMB0R",
+      "2193": "s3://linz-basemaps/2193/southland_sn12545a_1998_0.75m/01H8JM6SQCZW0P3NZ0A47WPFT9/",
+      "3857": "s3://linz-basemaps/3857/southland_sn12545a_1998_0.75m/01H8JM6SJWSGXE5VKANA3XMB0R/",
       "name": "southland-sn12545a-1998-0.75m",
       "title": "Southland 0.75m SN12545A (1998)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-sn8038-1982-0.75m.json
+++ b/config/tileset/southland/imagery/southland-sn8038-1982-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn8038_1982_0.75m/01H8JM7RXPPF8XBMREZFZC5M1W",
-      "3857": "s3://linz-basemaps/3857/southland_sn8038_1982_0.75m/01H8JM7RXPXBJWVCAE32080MP2",
+      "2193": "s3://linz-basemaps/2193/southland_sn8038_1982_0.75m/01H8JM7RXPPF8XBMREZFZC5M1W/",
+      "3857": "s3://linz-basemaps/3857/southland_sn8038_1982_0.75m/01H8JM7RXPXBJWVCAE32080MP2/",
       "name": "southland-sn8038-1982-0.75m",
       "title": "Southland 0.75m SN8038 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-sn8317-1984-0.75m.json
+++ b/config/tileset/southland/imagery/southland-sn8317-1984-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn8317_1984_0.75m/01H8JMRAQYEV3NR5K4WA8KENSW",
-      "3857": "s3://linz-basemaps/3857/southland_sn8317_1984_0.75m/01H8JMXHY7GNWPSF9BK4PFAQ2Y",
+      "2193": "s3://linz-basemaps/2193/southland_sn8317_1984_0.75m/01H8JMRAQYEV3NR5K4WA8KENSW/",
+      "3857": "s3://linz-basemaps/3857/southland_sn8317_1984_0.75m/01H8JMXHY7GNWPSF9BK4PFAQ2Y/",
       "name": "southland-sn8317-1984-0.75m",
       "title": "Southland 0.75m SN8317 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-sn8408-1984-0.375m.json
+++ b/config/tileset/southland/imagery/southland-sn8408-1984-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn8408_1984_0.375m/01H8JMB5K4356R712GX4HD8R1N",
-      "3857": "s3://linz-basemaps/3857/southland_sn8408_1984_0.375m/01H8JMCFQWBQ094H9T27N4X9HG",
+      "2193": "s3://linz-basemaps/2193/southland_sn8408_1984_0.375m/01H8JMB5K4356R712GX4HD8R1N/",
+      "3857": "s3://linz-basemaps/3857/southland_sn8408_1984_0.375m/01H8JMCFQWBQ094H9T27N4X9HG/",
       "name": "southland-sn8408-1984-0.375m",
       "title": "Southland 0.375m SN8408 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-sn8541-1985-0.375m.json
+++ b/config/tileset/southland/imagery/southland-sn8541-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn8541_1985_0.375m/01H8JM95ZD5692X12KSDE0CY3N",
-      "3857": "s3://linz-basemaps/3857/southland_sn8541_1985_0.375m/01H8JM95ZGSFQ8RJPMJ206JZK5",
+      "2193": "s3://linz-basemaps/2193/southland_sn8541_1985_0.375m/01H8JM95ZD5692X12KSDE0CY3N/",
+      "3857": "s3://linz-basemaps/3857/southland_sn8541_1985_0.375m/01H8JM95ZGSFQ8RJPMJ206JZK5/",
       "name": "southland-sn8541-1985-0.375m",
       "title": "Southland 0.375m SN8541 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-sn9066-1990-1991-0.75m.json
+++ b/config/tileset/southland/imagery/southland-sn9066-1990-1991-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn9066_1990-1991_0.75m/01H8JM95ZK08TXGDN9VE4F4F9J",
-      "3857": "s3://linz-basemaps/3857/southland_sn9066_1990-1991_0.75m/01H8JM95Z48FWE603P9FK2XNM4",
+      "2193": "s3://linz-basemaps/2193/southland_sn9066_1990-1991_0.75m/01H8JM95ZK08TXGDN9VE4F4F9J/",
+      "3857": "s3://linz-basemaps/3857/southland_sn9066_1990-1991_0.75m/01H8JM95Z48FWE603P9FK2XNM4/",
       "name": "southland-sn9066-1990-1991-0.75m",
       "title": "Southland 0.75m SN9066 (1990-1991)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-sn9067-1990-0.75m.json
+++ b/config/tileset/southland/imagery/southland-sn9067-1990-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn9067_1990_0.75m/01H8JMABZ33MKEDMK9B75T9AN7",
-      "3857": "s3://linz-basemaps/3857/southland_sn9067_1990_0.75m/01H8JMAAW1QS4B1Q7W63WBPE06",
+      "2193": "s3://linz-basemaps/2193/southland_sn9067_1990_0.75m/01H8JMABZ33MKEDMK9B75T9AN7/",
+      "3857": "s3://linz-basemaps/3857/southland_sn9067_1990_0.75m/01H8JMAAW1QS4B1Q7W63WBPE06/",
       "name": "southland-sn9067-1990-0.75m",
       "title": "Southland 0.75m SN9067 (1990)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-sn9421-1995-0.25m.json
+++ b/config/tileset/southland/imagery/southland-sn9421-1995-0.25m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_sn9421_1995_0.25m/01H8JMB9V2FWNW6XD9ZGFJD3Q3",
-      "3857": "s3://linz-basemaps/3857/southland_sn9421_1995_0.25m/01H8JMB9K8N2W6K9W7RWR3W2E5",
+      "2193": "s3://linz-basemaps/2193/southland_sn9421_1995_0.25m/01H8JMB9V2FWNW6XD9ZGFJD3Q3/",
+      "3857": "s3://linz-basemaps/3857/southland_sn9421_1995_0.25m/01H8JMB9K8N2W6K9W7RWR3W2E5/",
       "name": "southland-sn9421-1995-0.25m",
       "title": "Southland 0.25m SN9421 (1995)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-snc30005a-2002-0.75m.json
+++ b/config/tileset/southland/imagery/southland-snc30005a-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_snc30005a_2002_0.75m/01H8JMB9NPBEC3168KZ24DK6QW",
-      "3857": "s3://linz-basemaps/3857/southland_snc30005a_2002_0.75m/01H8JMB9R6J1GNCT2D0MB8VYX6",
+      "2193": "s3://linz-basemaps/2193/southland_snc30005a_2002_0.75m/01H8JMB9NPBEC3168KZ24DK6QW/",
+      "3857": "s3://linz-basemaps/3857/southland_snc30005a_2002_0.75m/01H8JMB9R6J1GNCT2D0MB8VYX6/",
       "name": "southland-snc30005a-2002-0.75m",
       "title": "Southland 0.75m SNC30005a (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-snc30005b-2003-0.75m.json
+++ b/config/tileset/southland/imagery/southland-snc30005b-2003-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_snc30005b_2003_0.75m/01H8JMC4N3FNSWWRXE3YDT0A81",
-      "3857": "s3://linz-basemaps/3857/southland_snc30005b_2003_0.75m/01H8JMC506FM3GSXAYPKRWBGDS",
+      "2193": "s3://linz-basemaps/2193/southland_snc30005b_2003_0.75m/01H8JMC4N3FNSWWRXE3YDT0A81/",
+      "3857": "s3://linz-basemaps/3857/southland_snc30005b_2003_0.75m/01H8JMC506FM3GSXAYPKRWBGDS/",
       "name": "southland-snc30005b-2003-0.75m",
       "title": "Southland 0.75m SNC30005b (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/southland/imagery/southland-snc30011-2003-0.75m.json
+++ b/config/tileset/southland/imagery/southland-snc30011-2003-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/southland_snc30011_2003_0.75m/01H8JMCJ3Y9BG3EFV7YC8NCRG1",
-      "3857": "s3://linz-basemaps/3857/southland_snc30011_2003_0.75m/01H8JMCJ3C1X3WY25CYZVATT53",
+      "2193": "s3://linz-basemaps/2193/southland_snc30011_2003_0.75m/01H8JMCJ3Y9BG3EFV7YC8NCRG1/",
+      "3857": "s3://linz-basemaps/3857/southland_snc30011_2003_0.75m/01H8JMCJ3C1X3WY25CYZVATT53/",
       "name": "southland-snc30011-2003-0.75m",
       "title": "Southland 0.75m SNC30011 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/new-plymouth-urban-2017-0.1m.json
+++ b/config/tileset/taranaki/imagery/new-plymouth-urban-2017-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/new-plymouth_urban_2017_0-10m/01F6P1FPAFD6D8SRHZX3GFJFWY",
-      "3857": "s3://linz-basemaps/3857/new-plymouth_urban_2017_0-10m/01ED82VQR8M1STH3EPMF3E8KFQ",
+      "2193": "s3://linz-basemaps/2193/new-plymouth_urban_2017_0-10m/01F6P1FPAFD6D8SRHZX3GFJFWY/",
+      "3857": "s3://linz-basemaps/3857/new-plymouth_urban_2017_0-10m/01ED82VQR8M1STH3EPMF3E8KFQ/",
       "name": "new-plymouth-urban-2017-0.1m",
       "title": "New Plymouth 0.10m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/taranaki/imagery/taranaki-manawatu-whanganui-sn8463-1985-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-manawatu-whanganui-sn8463-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_manawatu-whanganui_sn8463_1985_0.375m/01H8JMTM3WEXBHDAXD67E9MNWG",
-      "3857": "s3://linz-basemaps/3857/taranaki_manawatu-whanganui_sn8463_1985_0.375m/01H8JMSBHWPBD4MENZNZPDF7FM",
+      "2193": "s3://linz-basemaps/2193/taranaki_manawatu-whanganui_sn8463_1985_0.375m/01H8JMTM3WEXBHDAXD67E9MNWG/",
+      "3857": "s3://linz-basemaps/3857/taranaki_manawatu-whanganui_sn8463_1985_0.375m/01H8JMSBHWPBD4MENZNZPDF7FM/",
       "name": "taranaki-manawatu-whanganui-sn8463-1985-0.375m",
       "title": "Taranaki / Manawatū-Whanganui 0.375m SN8463 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-rural-2016-2017-0.3m.json
+++ b/config/tileset/taranaki/imagery/taranaki-rural-2016-2017-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_rural_2016-17_0-3m/01F6P1SZXEN3X5SDKT7XRQHEGY",
-      "3857": "s3://linz-basemaps/3857/taranaki_rural_2016-17_0-3m/01ED83B7TAK5SBKVYFJZMTE9AV",
+      "2193": "s3://linz-basemaps/2193/taranaki_rural_2016-17_0-3m/01F6P1SZXEN3X5SDKT7XRQHEGY/",
+      "3857": "s3://linz-basemaps/3857/taranaki_rural_2016-17_0-3m/01ED83B7TAK5SBKVYFJZMTE9AV/",
       "name": "taranaki-rural-2016-2017-0.3m",
       "title": "Taranaki 0.3m Rural Aerial Photos (2016-2018)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/taranaki/imagery/taranaki-sn25016-2000-0.75m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn25016-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn25016_2000_0.75m/01H8JMK0GTXMZWWZ6CCSNCBG3P",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn25016_2000_0.75m/01H8JMK0H32K24G228YH2RZW75",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn25016_2000_0.75m/01H8JMK0GTXMZWWZ6CCSNCBG3P/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn25016_2000_0.75m/01H8JMK0H32K24G228YH2RZW75/",
       "name": "taranaki-sn25016-2000-0.75m",
       "title": "Taranaki 0.75m SN25016 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-sn5804-1981-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn5804-1981-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn5804_1981_0.375m/01H8JMN29GP081PT3YN6R5D26D",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn5804_1981_0.375m/01H8JMN280VKE9154YRPJ0CBVW",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn5804_1981_0.375m/01H8JMN29GP081PT3YN6R5D26D/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn5804_1981_0.375m/01H8JMN280VKE9154YRPJ0CBVW/",
       "name": "taranaki-sn5804-1981-0.375m",
       "title": "Taranaki 0.375m SN5804 (1981)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-sn8003-1982-0.75m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn8003-1982-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8003_1982_0.75m/01H8JMP5874HHRXDSRVTVQ26XC",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8003_1982_0.75m/01H8JMNXQ4T9DZR0127C0RVYAK",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8003_1982_0.75m/01H8JMP5874HHRXDSRVTVQ26XC/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8003_1982_0.75m/01H8JMNXQ4T9DZR0127C0RVYAK/",
       "name": "taranaki-sn8003-1982-0.75m",
       "title": "Taranaki 0.75m SN8003 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-sn8008-1982-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn8008-1982-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8008_1982_0.375m/01H8JMQSK2TF1Y6V4GNTZ21R5W",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8008_1982_0.375m/01H8JMS0B3DQ31CMCRRHGC2WPJ",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8008_1982_0.375m/01H8JMQSK2TF1Y6V4GNTZ21R5W/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8008_1982_0.375m/01H8JMS0B3DQ31CMCRRHGC2WPJ/",
       "name": "taranaki-sn8008-1982-0.375m",
       "title": "Taranaki 0.375m SN8008 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-sn8298-1984-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn8298-1984-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8298_1984_0.375m/01H8JMRFQSZ38X16N163HR64FJ",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8298_1984_0.375m/01H8JMRJK8W815QVTYE5X7TFT2",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8298_1984_0.375m/01H8JMRFQSZ38X16N163HR64FJ/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8298_1984_0.375m/01H8JMRJK8W815QVTYE5X7TFT2/",
       "name": "taranaki-sn8298-1984-0.375m",
       "title": "Taranaki 0.375m SN8298 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-sn8349-1984-1985-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn8349-1984-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8349_1984-1985_0.375m/01H8JMTV1SBDTCXAMAN93XZX0P",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8349_1984-1985_0.375m/01H8JMTVFCBCAVR1E8C9JYYATM",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8349_1984-1985_0.375m/01H8JMTV1SBDTCXAMAN93XZX0P/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8349_1984-1985_0.375m/01H8JMTVFCBCAVR1E8C9JYYATM/",
       "name": "taranaki-sn8349-1984-1985-0.375m",
       "title": "Taranaki 0.375m SN8349 (1984-1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-sn8422-1984-1985-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn8422-1984-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8422_1984-1985_0.375m/01H8JMVYEQNWWPVB8VDYD3MD6X",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8422_1984-1985_0.375m/01H8JMVYFYH2C0FFJHN1078538",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8422_1984-1985_0.375m/01H8JMVYEQNWWPVB8VDYD3MD6X/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8422_1984-1985_0.375m/01H8JMVYFYH2C0FFJHN1078538/",
       "name": "taranaki-sn8422-1984-1985-0.375m",
       "title": "Taranaki 0.375m SN8422 (1984-1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-sn8502-1985-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn8502-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8502_1985_0.375m/01H8JMWE95N807VF844JTSZCCE",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8502_1985_0.375m/01H8JMWE98DPG3BW79CPAEJ3KT",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8502_1985_0.375m/01H8JMWE95N807VF844JTSZCCE/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8502_1985_0.375m/01H8JMWE98DPG3BW79CPAEJ3KT/",
       "name": "taranaki-sn8502-1985-0.375m",
       "title": "Taranaki 0.375m SN8502 (1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-sn8771-1988-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-sn8771-1988-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_sn8771_1988_0.375m/01H8JMXFE1J73CA2X9X235Q65J",
-      "3857": "s3://linz-basemaps/3857/taranaki_sn8771_1988_0.375m/01H8JMXEPYF52SXSD9E9X9GRY2",
+      "2193": "s3://linz-basemaps/2193/taranaki_sn8771_1988_0.375m/01H8JMXFE1J73CA2X9X235Q65J/",
+      "3857": "s3://linz-basemaps/3857/taranaki_sn8771_1988_0.375m/01H8JMXEPYF52SXSD9E9X9GRY2/",
       "name": "taranaki-sn8771-1988-0.375m",
       "title": "Taranaki 0.375m SN8771 (1988)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-snc25044-2001-0.75m.json
+++ b/config/tileset/taranaki/imagery/taranaki-snc25044-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_snc25044_2001_0.75m/01H8JN1FH0DCS9CADVJNXSVTGH",
-      "3857": "s3://linz-basemaps/3857/taranaki_snc25044_2001_0.75m/01H8JN1FJHXM99TQ6KZ8FYFDY6",
+      "2193": "s3://linz-basemaps/2193/taranaki_snc25044_2001_0.75m/01H8JN1FH0DCS9CADVJNXSVTGH/",
+      "3857": "s3://linz-basemaps/3857/taranaki_snc25044_2001_0.75m/01H8JN1FJHXM99TQ6KZ8FYFDY6/",
       "name": "taranaki-snc25044-2001-0.75m",
       "title": "Taranaki 0.75m SNC25044 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-snc30004-2002-0.75m.json
+++ b/config/tileset/taranaki/imagery/taranaki-snc30004-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_snc30004_2002_0.75m/01H8JN1FK2ASF438EQA5F0DDB8",
-      "3857": "s3://linz-basemaps/3857/taranaki_snc30004_2002_0.75m/01H8JN1FH0M30F8NB7YSV4R4BG",
+      "2193": "s3://linz-basemaps/2193/taranaki_snc30004_2002_0.75m/01H8JN1FK2ASF438EQA5F0DDB8/",
+      "3857": "s3://linz-basemaps/3857/taranaki_snc30004_2002_0.75m/01H8JN1FH0M30F8NB7YSV4R4BG/",
       "name": "taranaki-snc30004-2002-0.75m",
       "title": "Taranaki 0.75m SNC30004 (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/taranaki/imagery/taranaki-snc8923-1988-0.375m.json
+++ b/config/tileset/taranaki/imagery/taranaki-snc8923-1988-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/taranaki_snc8923_1988_0.375m/01H8JN0QTR7B6Y9YRXRREC19X8",
-      "3857": "s3://linz-basemaps/3857/taranaki_snc8923_1988_0.375m/01H8JN0QVEAY2AF2NMGSVECCDM",
+      "2193": "s3://linz-basemaps/2193/taranaki_snc8923_1988_0.375m/01H8JN0QTR7B6Y9YRXRREC19X8/",
+      "3857": "s3://linz-basemaps/3857/taranaki_snc8923_1988_0.375m/01H8JN0QVEAY2AF2NMGSVECCDM/",
       "name": "taranaki-snc8923-1988-0.375m",
       "title": "Taranaki 0.375m SNC8923 (1988)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-marlborough-nelson-sn25020-2000-0.75m.json
+++ b/config/tileset/tasman/imagery/tasman-marlborough-nelson-sn25020-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_marlborough_nelson_sn25020_2000_0.75m/01H8JN1Y33RDQDQGEDRQJGY8SF",
-      "3857": "s3://linz-basemaps/3857/tasman_marlborough_nelson_sn25020_2000_0.75m/01H8JN1Y3AHNJSGDEHQAHG85KR",
+      "2193": "s3://linz-basemaps/2193/tasman_marlborough_nelson_sn25020_2000_0.75m/01H8JN1Y33RDQDQGEDRQJGY8SF/",
+      "3857": "s3://linz-basemaps/3857/tasman_marlborough_nelson_sn25020_2000_0.75m/01H8JN1Y3AHNJSGDEHQAHG85KR/",
       "name": "tasman-marlborough-nelson-sn25020-2000-0.75m",
       "title": "Tasman / Marlborough / Nelson 0.75m SN25020 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-rural-2001-2002-1m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2001-2002-1m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z",
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA/",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z/",
       "name": "tasman-rural-2001-2002-1m",
       "title": "Tasman 1m Rural Aerial Photos (2001-2002)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/tasman/imagery/tasman-rural-2009-2010-0.5m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2009-2010-0.5m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2009-2010_0-50m_RGBA/01F6P1TWRFSGJ65V9Z0YXX4DHY",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2009-2010_0-50m_RGBA/01ED83CJ5ZT8SAGQKFT9MM59XR",
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2009-2010_0-50m_RGBA/01F6P1TWRFSGJ65V9Z0YXX4DHY/",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2009-2010_0-50m_RGBA/01ED83CJ5ZT8SAGQKFT9MM59XR/",
       "name": "tasman-rural-2009-2010-0.5m",
       "title": "Tasman 0.5m Rural Aerial Photos (2009-2010)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/tasman/imagery/tasman-rural-2015-2016-0.3m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2015-2016-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2015-16_0-3m/01F6P1V269CD5Z3Z5EC0Q8P7V6",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2015-16_0-3m/01ED83CXGMGPXTF67SETE7YBWP",
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2015-16_0-3m/01F6P1V269CD5Z3Z5EC0Q8P7V6/",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2015-16_0-3m/01ED83CXGMGPXTF67SETE7YBWP/",
       "name": "tasman-rural-2015-2016-0.3m",
       "title": "Tasman 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/tasman/imagery/tasman-rural-2016-2017-0.3m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2016-2017-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_rural_2016-17_0-3m/01F6P1V84P2HJ1YB0D5X1CSWJH",
-      "3857": "s3://linz-basemaps/3857/tasman_rural_2016-17_0-3m/01ED83DC7MCMBCRNN45E07HCHH",
+      "2193": "s3://linz-basemaps/2193/tasman_rural_2016-17_0-3m/01F6P1V84P2HJ1YB0D5X1CSWJH/",
+      "3857": "s3://linz-basemaps/3857/tasman_rural_2016-17_0-3m/01ED83DC7MCMBCRNN45E07HCHH/",
       "name": "tasman-rural-2016-2017-0.3m",
       "title": "Tasman 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/tasman/imagery/tasman-sn8209-1983-0.8m.json
+++ b/config/tileset/tasman/imagery/tasman-sn8209-1983-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_sn8209_1983_0.8m/01H8JN41FFRTCP66KSN934F4Y1",
-      "3857": "s3://linz-basemaps/3857/tasman_sn8209_1983_0.8m/01H8JN3W071MF9YEMMNJCRG7CS",
+      "2193": "s3://linz-basemaps/2193/tasman_sn8209_1983_0.8m/01H8JN41FFRTCP66KSN934F4Y1/",
+      "3857": "s3://linz-basemaps/3857/tasman_sn8209_1983_0.8m/01H8JN3W071MF9YEMMNJCRG7CS/",
       "name": "tasman-sn8209-1983-0.8m",
       "title": "Tasman 0.8m SN8209 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-sn8531-1985-1986-0.375m.json
+++ b/config/tileset/tasman/imagery/tasman-sn8531-1985-1986-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_sn8531_1985-1986_0.375m/01H8JN6Y6K2Y3R0Q58MEG8E7HG",
-      "3857": "s3://linz-basemaps/3857/tasman_sn8531_1985-1986_0.375m/01H8JN6Y5KNVZXEP6K1S5RS0F5",
+      "2193": "s3://linz-basemaps/2193/tasman_sn8531_1985-1986_0.375m/01H8JN6Y6K2Y3R0Q58MEG8E7HG/",
+      "3857": "s3://linz-basemaps/3857/tasman_sn8531_1985-1986_0.375m/01H8JN6Y5KNVZXEP6K1S5RS0F5/",
       "name": "tasman-sn8531-1985-1986-0.375m",
       "title": "Tasman 0.375m SN8531 (1985-1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-sn8821-1991-0.6m.json
+++ b/config/tileset/tasman/imagery/tasman-sn8821-1991-0.6m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_sn8821_1991_0.6m/01H8JN762SRRR460R4K3Z2SRCY",
-      "3857": "s3://linz-basemaps/3857/tasman_sn8821_1991_0.6m/01H8JN763E6QWSZD0DCWJZWQ5N",
+      "2193": "s3://linz-basemaps/2193/tasman_sn8821_1991_0.6m/01H8JN762SRRR460R4K3Z2SRCY/",
+      "3857": "s3://linz-basemaps/3857/tasman_sn8821_1991_0.6m/01H8JN763E6QWSZD0DCWJZWQ5N/",
       "name": "tasman-sn8821-1991-0.6m",
       "title": "Tasman 0.6m SN8821 (1991)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-snc25049-2000-0.75m.json
+++ b/config/tileset/tasman/imagery/tasman-snc25049-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_snc25049_2000_0.75m/01H8JN8G6DSJXF71833N0YG5QS",
-      "3857": "s3://linz-basemaps/3857/tasman_snc25049_2000_0.75m/01H8JN7ET3W1A8HWPY1814DZQA",
+      "2193": "s3://linz-basemaps/2193/tasman_snc25049_2000_0.75m/01H8JN8G6DSJXF71833N0YG5QS/",
+      "3857": "s3://linz-basemaps/3857/tasman_snc25049_2000_0.75m/01H8JN7ET3W1A8HWPY1814DZQA/",
       "name": "tasman-snc25049-2000-0.75m",
       "title": "Tasman 0.75m SNC25049 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-snc30002-2002-0.75m.json
+++ b/config/tileset/tasman/imagery/tasman-snc30002-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_snc30002_2002_0.75m/01H8JN7WN6Q04XGEPR1PFVPC69",
-      "3857": "s3://linz-basemaps/3857/tasman_snc30002_2002_0.75m/01H8JN7WNVQYWQ74FE2XQ393BQ",
+      "2193": "s3://linz-basemaps/2193/tasman_snc30002_2002_0.75m/01H8JN7WN6Q04XGEPR1PFVPC69/",
+      "3857": "s3://linz-basemaps/3857/tasman_snc30002_2002_0.75m/01H8JN7WNVQYWQ74FE2XQ393BQ/",
       "name": "tasman-snc30002-2002-0.75m",
       "title": "Tasman 0.75m SNC30002 (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-snc5676-1980-1981-0.64m.json
+++ b/config/tileset/tasman/imagery/tasman-snc5676-1980-1981-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_snc5676_1980-1981_0.64m/01H8JN7X10TWV4MTYV18WV2KRQ",
-      "3857": "s3://linz-basemaps/3857/tasman_snc5676_1980-1981_0.64m/01H8JN7X0KC125E9H3SGSA029S",
+      "2193": "s3://linz-basemaps/2193/tasman_snc5676_1980-1981_0.64m/01H8JN7X10TWV4MTYV18WV2KRQ/",
+      "3857": "s3://linz-basemaps/3857/tasman_snc5676_1980-1981_0.64m/01H8JN7X0KC125E9H3SGSA029S/",
       "name": "tasman-snc5676-1980-1981-0.64m",
       "title": "Tasman 0.64m SNC5676 (1980-1981)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-snc8054-1982-0.25m.json
+++ b/config/tileset/tasman/imagery/tasman-snc8054-1982-0.25m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_snc8054_1982_0.25m/01H8JN92BVP4FY9N1AB1BBJJ1D",
-      "3857": "s3://linz-basemaps/3857/tasman_snc8054_1982_0.25m/01H8JN92C99P6ZTETDPEGPGDYW",
+      "2193": "s3://linz-basemaps/2193/tasman_snc8054_1982_0.25m/01H8JN92BVP4FY9N1AB1BBJJ1D/",
+      "3857": "s3://linz-basemaps/3857/tasman_snc8054_1982_0.25m/01H8JN92C99P6ZTETDPEGPGDYW/",
       "name": "tasman-snc8054-1982-0.25m",
       "title": "Tasman 0.25m SNC8054 (1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-urban-2017-0.075m.json
+++ b/config/tileset/tasman/imagery/tasman-urban-2017-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_urban_2017_0-075m/01F6P1VT8BV5T0DPVSG1VEJX0Y",
-      "3857": "s3://linz-basemaps/3857/tasman_urban_2017_0-075m/01ED83ENCYFX7KFVKH0S7SK92W",
+      "2193": "s3://linz-basemaps/2193/tasman_urban_2017_0-075m/01F6P1VT8BV5T0DPVSG1VEJX0Y/",
+      "3857": "s3://linz-basemaps/3857/tasman_urban_2017_0-075m/01ED83ENCYFX7KFVKH0S7SK92W/",
       "name": "tasman-urban-2017-0.075m",
       "title": "Tasman 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/tasman/imagery/tasman-urban-2017-0.1m.json
+++ b/config/tileset/tasman/imagery/tasman-urban-2017-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_urban_2017_0-1m/01F6P1VW99KC0PEBYPDAZ3RNKK",
-      "3857": "s3://linz-basemaps/3857/tasman_urban_2017_0-1m/01ED83F2SBS02QP80KSQ3GRR92",
+      "2193": "s3://linz-basemaps/2193/tasman_urban_2017_0-1m/01F6P1VW99KC0PEBYPDAZ3RNKK/",
+      "3857": "s3://linz-basemaps/3857/tasman_urban_2017_0-1m/01ED83F2SBS02QP80KSQ3GRR92/",
       "name": "tasman-urban-2017-0.1m",
       "title": "Tasman 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/tasman/imagery/tasman-urban-2020-0.1m.json
+++ b/config/tileset/tasman/imagery/tasman-urban-2020-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_urban_2020_0-1m_RGB/01FDQV9ZW9ETAQB2VJG26WGHP3",
-      "3857": "s3://linz-basemaps/3857/tasman_urban_2020_0-1m_RGB/01FDQVCGEJA1YQJBT14AVZ3TJC",
+      "2193": "s3://linz-basemaps/2193/tasman_urban_2020_0-1m_RGB/01FDQV9ZW9ETAQB2VJG26WGHP3/",
+      "3857": "s3://linz-basemaps/3857/tasman_urban_2020_0-1m_RGB/01FDQVCGEJA1YQJBT14AVZ3TJC/",
       "name": "tasman-urban-2020-0.1m",
       "title": "Tasman 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/tasman/imagery/tasman-urban-2020-2021-0.075m.json
+++ b/config/tileset/tasman/imagery/tasman-urban-2020-2021-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_urban_2020-2021_0-075m_RGB/01FDTG4HYDSJ0E4SNV54E3CCJM",
-      "3857": "s3://linz-basemaps/3857/tasman_urban_2020-2021_0-075m_RGB/01FDTG1HG7S4HBR2BQPTE7ZRWJ",
+      "2193": "s3://linz-basemaps/2193/tasman_urban_2020-2021_0-075m_RGB/01FDTG4HYDSJ0E4SNV54E3CCJM/",
+      "3857": "s3://linz-basemaps/3857/tasman_urban_2020-2021_0-075m_RGB/01FDTG1HG7S4HBR2BQPTE7ZRWJ/",
       "name": "tasman-urban-2020-2021-0.075m",
       "title": "Tasman 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/tasman/imagery/tasman-west-coast-sn8409-1984-1985-0.375m.json
+++ b/config/tileset/tasman/imagery/tasman-west-coast-sn8409-1984-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_west-coast_sn8409_1984-1985_0.375m/01H8JN9RAKA36BEPMVR8WQMH7W",
-      "3857": "s3://linz-basemaps/3857/tasman_west-coast_sn8409_1984-1985_0.375m/01H8JN9RBAG9B25E5J8MDAZE82",
+      "2193": "s3://linz-basemaps/2193/tasman_west-coast_sn8409_1984-1985_0.375m/01H8JN9RAKA36BEPMVR8WQMH7W/",
+      "3857": "s3://linz-basemaps/3857/tasman_west-coast_sn8409_1984-1985_0.375m/01H8JN9RBAG9B25E5J8MDAZE82/",
       "name": "tasman-west-coast-sn8409-1984-1985-0.375m",
       "title": "Tasman / West Coast 0.375m SN8409 (1984-1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/tasman/imagery/tasman-west-coast-snc50452-2004-2005-0.64m.json
+++ b/config/tileset/tasman/imagery/tasman-west-coast-snc50452-2004-2005-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/tasman_west-coast_snc50452_2004-2005_0.64m/01H8JN9V262AGSEMFFNZXWM5GZ",
-      "3857": "s3://linz-basemaps/3857/tasman_west-coast_snc50452_2004-2005_0.64m/01H8JN9V27EZRXPQ4XG644Y7GJ",
+      "2193": "s3://linz-basemaps/2193/tasman_west-coast_snc50452_2004-2005_0.64m/01H8JN9V262AGSEMFFNZXWM5GZ/",
+      "3857": "s3://linz-basemaps/3857/tasman_west-coast_snc50452_2004-2005_0.64m/01H8JN9V27EZRXPQ4XG644Y7GJ/",
       "name": "tasman-west-coast-snc50452-2004-2005-0.64m",
       "title": "Tasman / West Coast 0.64m SNC50452 (2004-2005)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/texture.relifshade.json
+++ b/config/tileset/texture.relifshade.json
@@ -5,13 +5,13 @@
   "background": "00000000",
   "layers": [
     {
-      "3857": "s3://linz-basemaps/3857/geographx_nz_dem_2012_8-0m/01FM8DEN1XG1QGNT229A4T3KZ6",
+      "3857": "s3://linz-basemaps/3857/geographx_nz_dem_2012_8-0m/01FM8DEN1XG1QGNT229A4T3KZ6/",
       "name": "geographx_nz_dem_2012_8-0m",
       "title": "New Zealand 8m DEM Hillshade (2012)",
       "category": "Elevation"
     },
     {
-      "3857": "s3://linz-basemaps/3857/geographx_nz_texture_shade_2012_8-0m/01FMK5CJHR30YG9A0JDNVXYCKN",
+      "3857": "s3://linz-basemaps/3857/geographx_nz_texture_shade_2012_8-0m/01FMK5CJHR30YG9A0JDNVXYCKN/",
       "name": "geographx_nz_texture_shade_2012_8-0m",
       "title": "New Zealand 8m DEM Texture Shade (2012)",
       "category": "Elevation"

--- a/config/tileset/textureshade.json
+++ b/config/tileset/textureshade.json
@@ -5,7 +5,7 @@
   "background": "00000000",
   "layers": [
     {
-      "3857": "s3://linz-basemaps/3857/geographx_nz_texture_shade_2012_8-0m/01FMK5CJHR30YG9A0JDNVXYCKN",
+      "3857": "s3://linz-basemaps/3857/geographx_nz_texture_shade_2012_8-0m/01FMK5CJHR30YG9A0JDNVXYCKN/",
       "name": "geographx_nz_texture_shade_2012_8-0m",
       "title": "New Zealand 8m DEM Texture Shade (2012)",
       "category": "Elevation"

--- a/config/tileset/waikato/imagery/hamilton-urban-2016-2017-0.1m.json
+++ b/config/tileset/waikato/imagery/hamilton-urban-2016-2017-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hamilton_urban_2016-17_0-1m/01F6P16P7FMHSDAWX2VM3PKAHS",
-      "3857": "s3://linz-basemaps/3857/hamilton_urban_2016-17_0-1m/01EDAN1CYCXAEMG21PB6VCD0KX",
+      "2193": "s3://linz-basemaps/2193/hamilton_urban_2016-17_0-1m/01F6P16P7FMHSDAWX2VM3PKAHS/",
+      "3857": "s3://linz-basemaps/3857/hamilton_urban_2016-17_0-1m/01EDAN1CYCXAEMG21PB6VCD0KX/",
       "name": "hamilton-urban-2016-2017-0.1m",
       "title": "Hamilton 0.1m Urban Aerial Photos (2016-2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/waikato/imagery/hamilton-urban-2019-0.1m.json
+++ b/config/tileset/waikato/imagery/hamilton-urban-2019-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hamilton_urban_2019_0-1m/01F6P16V72XPFJK2X5V68YYM0X",
-      "3857": "s3://linz-basemaps/3857/hamilton_urban_2019_0-1m/01ED8284FFT9RYZ0F7XTKD64D4",
+      "2193": "s3://linz-basemaps/2193/hamilton_urban_2019_0-1m/01F6P16V72XPFJK2X5V68YYM0X/",
+      "3857": "s3://linz-basemaps/3857/hamilton_urban_2019_0-1m/01ED8284FFT9RYZ0F7XTKD64D4/",
       "name": "hamilton-urban-2019-0.1m",
       "title": "Hamilton 0.1m Urban Aerial Photos (2019)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/waikato/imagery/hamilton-urban-2020-2021-0.05m.json
+++ b/config/tileset/waikato/imagery/hamilton-urban-2020-2021-0.05m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hamilton_urban_2020-2021_0-05m_RGB/01GASE5J7NJSZRVD92X9J655TQ",
-      "3857": "s3://linz-basemaps/3857/hamilton_urban_2020-2021_0-05m_RGB/01GASE6HES5VTVKV66G5S82KV3",
+      "2193": "s3://linz-basemaps/2193/hamilton_urban_2020-2021_0-05m_RGB/01GASE5J7NJSZRVD92X9J655TQ/",
+      "3857": "s3://linz-basemaps/3857/hamilton_urban_2020-2021_0-05m_RGB/01GASE6HES5VTVKV66G5S82KV3/",
       "name": "hamilton-urban-2020-2021-0.05m",
       "title": "Hamilton 0.05m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/waikato/imagery/thames-coromandel-urban-2015-0.05m.json
+++ b/config/tileset/waikato/imagery/thames-coromandel-urban-2015-0.05m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/thames-coromandel_urban_2015_0-05m/01F6P1WD2YV0SQ3WE62RZ0RJY5",
-      "3857": "s3://linz-basemaps/3857/thames-coromandel_urban_2015_0-05m/01ED83GB3JEMR4D72PFD8JVCV6",
+      "2193": "s3://linz-basemaps/2193/thames-coromandel_urban_2015_0-05m/01F6P1WD2YV0SQ3WE62RZ0RJY5/",
+      "3857": "s3://linz-basemaps/3857/thames-coromandel_urban_2015_0-05m/01ED83GB3JEMR4D72PFD8JVCV6/",
       "name": "thames-coromandel-urban-2015-0.05m",
       "title": "Thames-Coromandel 0.05m Urban Aerial Photos (2015)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/waikato/imagery/waikato-2021-2022-0.05m.json
+++ b/config/tileset/waikato/imagery/waikato-2021-2022-0.05m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_2021-2022_0.05m/01H29E3DXNNYKJZFHBEX1NZRVF",
-      "3857": "s3://linz-basemaps/3857/waikato_2021-2022_0.05m/01H29E3QQR0YKW4CB96JZ9BHZA",
+      "2193": "s3://linz-basemaps/2193/waikato_2021-2022_0.05m/01H29E3DXNNYKJZFHBEX1NZRVF/",
+      "3857": "s3://linz-basemaps/3857/waikato_2021-2022_0.05m/01H29E3QQR0YKW4CB96JZ9BHZA/",
       "name": "waikato-2021-2022-0.05m",
       "title": "Waikato District 0.05m Urban Aerial Photos (2021-2022)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/waikato/imagery/waikato-auckland-sn9919-2000-0.75m.json
+++ b/config/tileset/waikato/imagery/waikato-auckland-sn9919-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_auckland_sn9919_2000_0.75m/01H8JNA0P0WG07ZNJMP5WZGKGN",
-      "3857": "s3://linz-basemaps/3857/waikato_auckland_sn9919_2000_0.75m/01H8JNA0NXYKNK00N7RAYHGS28",
+      "2193": "s3://linz-basemaps/2193/waikato_auckland_sn9919_2000_0.75m/01H8JNA0P0WG07ZNJMP5WZGKGN/",
+      "3857": "s3://linz-basemaps/3857/waikato_auckland_sn9919_2000_0.75m/01H8JNA0NXYKNK00N7RAYHGS28/",
       "name": "waikato-auckland-sn9919-2000-0.75m",
       "title": "Waikato / Auckland 0.75m SN9919 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-bay-of-plenty-sn12539-1999-0.75m.json
+++ b/config/tileset/waikato/imagery/waikato-bay-of-plenty-sn12539-1999-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn12539_1999_0.75m/01H8JNAW9EWM95YX3ARBYB0ZAB",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn12539_1999_0.75m/01H8JNC6TC4Y6HQYY6M5ESVFC0",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn12539_1999_0.75m/01H8JNAW9EWM95YX3ARBYB0ZAB/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn12539_1999_0.75m/01H8JNC6TC4Y6HQYY6M5ESVFC0/",
       "name": "waikato-bay-of-plenty-sn12539-1999-0.75m",
       "title": "Waikato / Bay of Plenty 0.75m SN12539 (1999)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-bay-of-plenty-sn5944-1981-1982-0.375m.json
+++ b/config/tileset/waikato/imagery/waikato-bay-of-plenty-sn5944-1981-1982-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/01H8JNCZ06Q4CYAFHF15JKQSA2",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/01H8JND6KBAM9BP4Q26E6F6Z0Y",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/01H8JNCZ06Q4CYAFHF15JKQSA2/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/01H8JND6KBAM9BP4Q26E6F6Z0Y/",
       "name": "waikato-bay-of-plenty-sn5944-1981-1982-0.375m",
       "title": "Waikato / Bay of Plenty 0.375m SN5944 (1981-1982)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-bay-of-plenty-sn5945-1981-1984-0.4m.json
+++ b/config/tileset/waikato/imagery/waikato-bay-of-plenty-sn5945-1981-1984-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/01H8JND5ZRWHW67DRJQSK926HA",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/01H8JND7FE1N1B9QY5R71Y00GV",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/01H8JND5ZRWHW67DRJQSK926HA/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/01H8JND7FE1N1B9QY5R71Y00GV/",
       "name": "waikato-bay-of-plenty-sn5945-1981-1984-0.4m",
       "title": "Waikato / Bay of Plenty 0.4m SN5945 (1981-1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-bay-of-plenty-sn9445-1995-1997-0.75m.json
+++ b/config/tileset/waikato/imagery/waikato-bay-of-plenty-sn9445-1995-1997-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/01H8JNDFZPHZ0EB8SS21FQ61PE",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/01H8JNDG10PC59K868PN88B1XX",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/01H8JNDFZPHZ0EB8SS21FQ61PE/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/01H8JNDG10PC59K868PN88B1XX/",
       "name": "waikato-bay-of-plenty-sn9445-1995-1997-0.75m",
       "title": "Waikato / Bay of Plenty 0.75m SN9445 (1995-1997)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-bay-of-plenty-snc12836-2004-0.625m.json
+++ b/config/tileset/waikato/imagery/waikato-bay-of-plenty-snc12836-2004-0.625m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_snc12836_2004_0.625m/01H8JNDK5XZ5RX8HYCW0FDA54A",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_snc12836_2004_0.625m/01H8JNDK644BE3597KE9HYD045",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_snc12836_2004_0.625m/01H8JNDK5XZ5RX8HYCW0FDA54A/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_snc12836_2004_0.625m/01H8JNDK644BE3597KE9HYD045/",
       "name": "waikato-bay-of-plenty-snc12836-2004-0.625m",
       "title": "Waikato / Bay of Plenty 0.625m SNC12836 (2004)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-bay-of-plenty-snc25060-2001-0.75m.json
+++ b/config/tileset/waikato/imagery/waikato-bay-of-plenty-snc25060-2001-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_snc25060_2001_0.75m/01H8JNHQ93AQS66ZXYHQZPHT9G",
-      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_snc25060_2001_0.75m/01H8JNHQ7KNBDNS2MMKT3ADJXS",
+      "2193": "s3://linz-basemaps/2193/waikato_bay-of-plenty_snc25060_2001_0.75m/01H8JNHQ93AQS66ZXYHQZPHT9G/",
+      "3857": "s3://linz-basemaps/3857/waikato_bay-of-plenty_snc25060_2001_0.75m/01H8JNHQ7KNBDNS2MMKT3ADJXS/",
       "name": "waikato-bay-of-plenty-snc25060-2001-0.75m",
       "title": "Waikato / Bay of Plenty 0.75m SNC25060 (2001)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-rural-2012-2013-0.5m.json
+++ b/config/tileset/waikato/imagery/waikato-rural-2012-2013-0.5m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_rural_2012-2013_0-50m_RGBA/01F6P1XPDV00F86GA8J626Y3BM",
-      "3857": "s3://linz-basemaps/3857/waikato_rural_2012-2013_0-50m_RGBA/01ED83K3YEJ0FSG0DHCFTVBEF7",
+      "2193": "s3://linz-basemaps/2193/waikato_rural_2012-2013_0-50m_RGBA/01F6P1XPDV00F86GA8J626Y3BM/",
+      "3857": "s3://linz-basemaps/3857/waikato_rural_2012-2013_0-50m_RGBA/01ED83K3YEJ0FSG0DHCFTVBEF7/",
       "name": "waikato-rural-2012-2013-0.5m",
       "title": "Waikato 0.5m Rural Aerial Photos (2012-2013)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/waikato/imagery/waikato-sn5164-1977-1979-0.375m.json
+++ b/config/tileset/waikato/imagery/waikato-sn5164-1977-1979-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn5164_1977-1979_0.375m/01H8JNNA2572YPCX5249HBK6J0",
-      "3857": "s3://linz-basemaps/3857/waikato_sn5164_1977-1979_0.375m/01H8JNNA288XCWSV32ZRBZJKH1",
+      "2193": "s3://linz-basemaps/2193/waikato_sn5164_1977-1979_0.375m/01H8JNNA2572YPCX5249HBK6J0/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn5164_1977-1979_0.375m/01H8JNNA288XCWSV32ZRBZJKH1/",
       "name": "waikato-sn5164-1977-1979-0.375m",
       "title": "Waikato 0.375m SN5164 (1977-1979)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn5479-1979-0.375m.json
+++ b/config/tileset/waikato/imagery/waikato-sn5479-1979-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn5479_1979_0.375m/01H8JNNA3025VE8MDKKK5HSBKR",
-      "3857": "s3://linz-basemaps/3857/waikato_sn5479_1979_0.375m/01H8JNNA2CQ0BG6DMFR93H3WJ3",
+      "2193": "s3://linz-basemaps/2193/waikato_sn5479_1979_0.375m/01H8JNNA3025VE8MDKKK5HSBKR/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn5479_1979_0.375m/01H8JNNA2CQ0BG6DMFR93H3WJ3/",
       "name": "waikato-sn5479-1979-0.375m",
       "title": "Waikato 0.375m SN5479 (1979)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn6656-1985-1987-0.6m.json
+++ b/config/tileset/waikato/imagery/waikato-sn6656-1985-1987-0.6m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn6656_1985-1987_0.6m/01H8JNP2SJEDAEND31C3SB82Y8",
-      "3857": "s3://linz-basemaps/3857/waikato_sn6656_1985-1987_0.6m/01H8JNP1Z1VAQ8BHQ8GFHRGGXY",
+      "2193": "s3://linz-basemaps/2193/waikato_sn6656_1985-1987_0.6m/01H8JNP2SJEDAEND31C3SB82Y8/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn6656_1985-1987_0.6m/01H8JNP1Z1VAQ8BHQ8GFHRGGXY/",
       "name": "waikato-sn6656-1985-1987-0.6m",
       "title": "Waikato 0.6m SN6656 (1985-1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn8163-1983-1984-0.375m.json
+++ b/config/tileset/waikato/imagery/waikato-sn8163-1983-1984-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn8163_1983-1984_0.375m/01H8JNP2SYBZT3X1GA180B4YHR",
-      "3857": "s3://linz-basemaps/3857/waikato_sn8163_1983-1984_0.375m/01H8JNP2SWMB2QRY6X61GN18VA",
+      "2193": "s3://linz-basemaps/2193/waikato_sn8163_1983-1984_0.375m/01H8JNP2SYBZT3X1GA180B4YHR/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn8163_1983-1984_0.375m/01H8JNP2SWMB2QRY6X61GN18VA/",
       "name": "waikato-sn8163-1983-1984-0.375m",
       "title": "Waikato 0.375m SN8163 (1983-1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn8166-1983-0.75m.json
+++ b/config/tileset/waikato/imagery/waikato-sn8166-1983-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn8166_1983_0.75m/01H8JNTDJHQC0YYYPQHS2F1NWA",
-      "3857": "s3://linz-basemaps/3857/waikato_sn8166_1983_0.75m/01H8JNYHHCEJWMQQR55053Q55K",
+      "2193": "s3://linz-basemaps/2193/waikato_sn8166_1983_0.75m/01H8JNTDJHQC0YYYPQHS2F1NWA/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn8166_1983_0.75m/01H8JNYHHCEJWMQQR55053Q55K/",
       "name": "waikato-sn8166-1983-0.75m",
       "title": "Waikato 0.75m SN8166 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn8297-1984-0.4m.json
+++ b/config/tileset/waikato/imagery/waikato-sn8297-1984-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn8297_1984_0.4m/01H8JNZAPXS0PRQXNRERS9D6AM",
-      "3857": "s3://linz-basemaps/3857/waikato_sn8297_1984_0.4m/01H8JNZD91HYZJFK1TMXZVBKJS",
+      "2193": "s3://linz-basemaps/2193/waikato_sn8297_1984_0.4m/01H8JNZAPXS0PRQXNRERS9D6AM/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn8297_1984_0.4m/01H8JNZD91HYZJFK1TMXZVBKJS/",
       "name": "waikato-sn8297-1984-0.4m",
       "title": "Waikato 0.4m SN8297 (1984)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn8687-1986-1987-0.375m.json
+++ b/config/tileset/waikato/imagery/waikato-sn8687-1986-1987-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn8687_1986-1987_0.375m/01H8JP0JM344JNKZJDYHW664MS",
-      "3857": "s3://linz-basemaps/3857/waikato_sn8687_1986-1987_0.375m/01H8JP0JMJZ1Q19PWHBZPCDXH1",
+      "2193": "s3://linz-basemaps/2193/waikato_sn8687_1986-1987_0.375m/01H8JP0JM344JNKZJDYHW664MS/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn8687_1986-1987_0.375m/01H8JP0JMJZ1Q19PWHBZPCDXH1/",
       "name": "waikato-sn8687-1986-1987-0.375m",
       "title": "Waikato 0.375m SN8687 (1986-1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn9124-1990-1991-0.48m.json
+++ b/config/tileset/waikato/imagery/waikato-sn9124-1990-1991-0.48m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9124_1990-1991_0.48m/01H8JP0KG5642BF5PFP2737HD0",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9124_1990-1991_0.48m/01H8JP0KFZ1VN0KF2HKR2G4GTP",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9124_1990-1991_0.48m/01H8JP0KG5642BF5PFP2737HD0/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9124_1990-1991_0.48m/01H8JP0KFZ1VN0KF2HKR2G4GTP/",
       "name": "waikato-sn9124-1990-1991-0.48m",
       "title": "Waikato 0.48m SN9124 (1990-1991)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn9361-1994-1995-0.75m.json
+++ b/config/tileset/waikato/imagery/waikato-sn9361-1994-1995-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9361_1994-1995_0.75m/01H8JPHWWEWBYA3F8Q8TX2TFT3",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9361_1994-1995_0.75m/01H8JPH8XQKFXDQHXH295SEZ8Q",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9361_1994-1995_0.75m/01H8JPHWWEWBYA3F8Q8TX2TFT3/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9361_1994-1995_0.75m/01H8JPH8XQKFXDQHXH295SEZ8Q/",
       "name": "waikato-sn9361-1994-1995-0.75m",
       "title": "Waikato 0.75m SN9361 (1994-1995)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn9401-1995-0.75m.json
+++ b/config/tileset/waikato/imagery/waikato-sn9401-1995-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9401_1995_0.75m/01H8JPG11WNB12VZAQHHBYWE5N",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9401_1995_0.75m/01H8JQ6GH7QX6RJP75XBJA785B",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9401_1995_0.75m/01H8JPG11WNB12VZAQHHBYWE5N/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9401_1995_0.75m/01H8JQ6GH7QX6RJP75XBJA785B/",
       "name": "waikato-sn9401-1995-0.75m",
       "title": "Waikato 0.75m SN9401 (1995)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn9584-1996-1997-0.64m.json
+++ b/config/tileset/waikato/imagery/waikato-sn9584-1996-1997-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9584_1996-1997_0.64m/01H8JPCDRV8XRVE31YHMJBV7E4",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9584_1996-1997_0.64m/01H8JPCDRRQ3N2XZY09E2JTS2X",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9584_1996-1997_0.64m/01H8JPCDRV8XRVE31YHMJBV7E4/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9584_1996-1997_0.64m/01H8JPCDRRQ3N2XZY09E2JTS2X/",
       "name": "waikato-sn9584-1996-1997-0.64m",
       "title": "Waikato 0.64m SN9584 (1996-1997)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn9615-1997-0.8m.json
+++ b/config/tileset/waikato/imagery/waikato-sn9615-1997-0.8m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9615_1997_0.8m/01H8JPCDRE2CYQJVM2R1TDH62K",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9615_1997_0.8m/01H8JPCDQRPWC1K1R0PZJC9FKT",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9615_1997_0.8m/01H8JPCDRE2CYQJVM2R1TDH62K/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9615_1997_0.8m/01H8JPCDQRPWC1K1R0PZJC9FKT/",
       "name": "waikato-sn9615-1997-0.8m",
       "title": "Waikato 0.8m SN9615 (1997)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-sn9859-1999-0.625m.json
+++ b/config/tileset/waikato/imagery/waikato-sn9859-1999-0.625m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_sn9859_1999_0.625m/01H8JPCDS96PH32JZ2ERQ5C2BH",
-      "3857": "s3://linz-basemaps/3857/waikato_sn9859_1999_0.625m/01H8JPCDV33DRXD3TGSTZK98AV",
+      "2193": "s3://linz-basemaps/2193/waikato_sn9859_1999_0.625m/01H8JPCDS96PH32JZ2ERQ5C2BH/",
+      "3857": "s3://linz-basemaps/3857/waikato_sn9859_1999_0.625m/01H8JPCDV33DRXD3TGSTZK98AV/",
       "name": "waikato-sn9859-1999-0.625m",
       "title": "Waikato 0.625m SN9859 (1999)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-snc12837-2003-0.75m.json
+++ b/config/tileset/waikato/imagery/waikato-snc12837-2003-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_snc12837_2003_0.75m/01H8JPCS6X93S52CYMFRBXTG15",
-      "3857": "s3://linz-basemaps/3857/waikato_snc12837_2003_0.75m/01H8JPCS7JJN7CPNRYZ4X5NDSE",
+      "2193": "s3://linz-basemaps/2193/waikato_snc12837_2003_0.75m/01H8JPCS6X93S52CYMFRBXTG15/",
+      "3857": "s3://linz-basemaps/3857/waikato_snc12837_2003_0.75m/01H8JPCS7JJN7CPNRYZ4X5NDSE/",
       "name": "waikato-snc12837-2003-0.75m",
       "title": "Waikato 0.75m SNC12837 (2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-snc5876-1981-0.375m.json
+++ b/config/tileset/waikato/imagery/waikato-snc5876-1981-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_snc5876_1981_0.375m/01H8JPCV7T6W2T47A6SFG4BT00",
-      "3857": "s3://linz-basemaps/3857/waikato_snc5876_1981_0.375m/01H8JPCV626WYPG26J0P8RF1TB",
+      "2193": "s3://linz-basemaps/2193/waikato_snc5876_1981_0.375m/01H8JPCV7T6W2T47A6SFG4BT00/",
+      "3857": "s3://linz-basemaps/3857/waikato_snc5876_1981_0.375m/01H8JPCV626WYPG26J0P8RF1TB/",
       "name": "waikato-snc5876-1981-0.375m",
       "title": "Waikato 0.375m SNC5876 (1981)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-snc8697-1986-0.375m.json
+++ b/config/tileset/waikato/imagery/waikato-snc8697-1986-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_snc8697_1986_0.375m/01H8JPDBRYDDFB0JPF0C2SDM73",
-      "3857": "s3://linz-basemaps/3857/waikato_snc8697_1986_0.375m/01H8JPE28YHVDRN3C5Z1KEDY2D",
+      "2193": "s3://linz-basemaps/2193/waikato_snc8697_1986_0.375m/01H8JPDBRYDDFB0JPF0C2SDM73/",
+      "3857": "s3://linz-basemaps/3857/waikato_snc8697_1986_0.375m/01H8JPE28YHVDRN3C5Z1KEDY2D/",
       "name": "waikato-snc8697-1986-0.375m",
       "title": "Waikato 0.375m SNC8697 (1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-snc9990-2001-2003-0.6m.json
+++ b/config/tileset/waikato/imagery/waikato-snc9990-2001-2003-0.6m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_snc9990_2001-2003_0.6m/01H8JPFA86KNXMC1VWKY4TKQPF",
-      "3857": "s3://linz-basemaps/3857/waikato_snc9990_2001-2003_0.6m/01H8JPGGE02AAR5S5A8M0D7G4N",
+      "2193": "s3://linz-basemaps/2193/waikato_snc9990_2001-2003_0.6m/01H8JPFA86KNXMC1VWKY4TKQPF/",
+      "3857": "s3://linz-basemaps/3857/waikato_snc9990_2001-2003_0.6m/01H8JPGGE02AAR5S5A8M0D7G4N/",
       "name": "waikato-snc9990-2001-2003-0.6m",
       "title": "Waikato 0.6m SNC9990 (2001-2003)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/waikato/imagery/waikato-urban-2014-0.1m.json
+++ b/config/tileset/waikato/imagery/waikato-urban-2014-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/waikato_urban_2014_0-10m_RGBA/01F6P1ZQZ4X5GHHX544CJJ3NNH",
-      "3857": "s3://linz-basemaps/3857/waikato_urban_2014_0-10m_RGBA/01ED83NZS98MYTMWM4D1EVZ07T",
+      "2193": "s3://linz-basemaps/2193/waikato_urban_2014_0-10m_RGBA/01F6P1ZQZ4X5GHHX544CJJ3NNH/",
+      "3857": "s3://linz-basemaps/3857/waikato_urban_2014_0-10m_RGBA/01ED83NZS98MYTMWM4D1EVZ07T/",
       "name": "waikato-urban-2014-0.1m",
       "title": "Waikato District 0.1m Urban Aerial Photos (2014)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/wellington/imagery/hutt-city-urban-2017-0.1m.json
+++ b/config/tileset/wellington/imagery/hutt-city-urban-2017-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/hutt-city_urban_2017_0-10m/01F6P19XT96PPWHAABTAGXGV3N",
-      "3857": "s3://linz-basemaps/3857/hutt-city_urban_2017_0-10m/01ED82D0F9NBGVM9WRRT46AV1V",
+      "2193": "s3://linz-basemaps/2193/hutt-city_urban_2017_0-10m/01F6P19XT96PPWHAABTAGXGV3N/",
+      "3857": "s3://linz-basemaps/3857/hutt-city_urban_2017_0-10m/01ED82D0F9NBGVM9WRRT46AV1V/",
       "name": "hutt-city-urban-2017-0.1m",
       "title": "Hutt City 0.10m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/wellington/imagery/kapiti-coast-2017-0.10m.json
+++ b/config/tileset/wellington/imagery/kapiti-coast-2017-0.10m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/kapiti-coast_2017_0.10m/01GYDZV2MK43PJNEVXPZSHDZ4F",
-      "3857": "s3://linz-basemaps/3857/kapiti-coast_2017_0.10m/01GYDZVZ557KRJP17670MJZ1T7",
+      "2193": "s3://linz-basemaps/2193/kapiti-coast_2017_0.10m/01GYDZV2MK43PJNEVXPZSHDZ4F/",
+      "3857": "s3://linz-basemaps/3857/kapiti-coast_2017_0.10m/01GYDZVZ557KRJP17670MJZ1T7/",
       "name": "kapiti-coast-2017-0.10m",
       "title": "Kapiti Coast 0.10m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/wellington/imagery/porirua-urban-2016-0.075m.json
+++ b/config/tileset/wellington/imagery/porirua-urban-2016-0.075m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/porirua_urban_2016_0-075m/01F6P1PP0S3T9HTDTDJW7ADAEH",
-      "3857": "s3://linz-basemaps/3857/porirua_urban_2016_0-075m/01ED834RYVP97AYQVDDQ6MJECY",
+      "2193": "s3://linz-basemaps/2193/porirua_urban_2016_0-075m/01F6P1PP0S3T9HTDTDJW7ADAEH/",
+      "3857": "s3://linz-basemaps/3857/porirua_urban_2016_0-075m/01ED834RYVP97AYQVDDQ6MJECY/",
       "name": "porirua-urban-2016-0.075m",
       "title": "Porirua 0.075m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/wellington/imagery/porirua-urban-2020-0.1m.json
+++ b/config/tileset/wellington/imagery/porirua-urban-2020-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/porirua_urban_2020_0-10m_RGB/01F6P1PTH5SBS82G5VVKYHFR63",
-      "3857": "s3://linz-basemaps/3857/porirua_urban_2020_0-10m_RGB/01ESM35CSPVJD54ZMT4T5FVV29",
+      "2193": "s3://linz-basemaps/2193/porirua_urban_2020_0-10m_RGB/01F6P1PTH5SBS82G5VVKYHFR63/",
+      "3857": "s3://linz-basemaps/3857/porirua_urban_2020_0-10m_RGB/01ESM35CSPVJD54ZMT4T5FVV29/",
       "name": "porirua-urban-2020-0.1m",
       "title": "Porirua 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/wellington/imagery/upper-hutt-urban-2017-0.1m.json
+++ b/config/tileset/wellington/imagery/upper-hutt-urban-2017-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/upper-hutt_urban_2017_0-10m/01F6P1XK2AVYDJ66NY2MKSEXW1",
-      "3857": "s3://linz-basemaps/3857/upper-hutt_urban_2017_0-10m/01ED83JPKMXF5TVKFD4RP91ZRB",
+      "2193": "s3://linz-basemaps/2193/upper-hutt_urban_2017_0-10m/01F6P1XK2AVYDJ66NY2MKSEXW1/",
+      "3857": "s3://linz-basemaps/3857/upper-hutt_urban_2017_0-10m/01ED83JPKMXF5TVKFD4RP91ZRB/",
       "name": "upper-hutt-urban-2017-0.1m",
       "title": "Upper Hutt 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/wellington/imagery/wellington-2016-2017-0.3m.json
+++ b/config/tileset/wellington/imagery/wellington-2016-2017-0.3m.json
@@ -6,8 +6,8 @@
   "category": "Rural Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_2016-2017_0.3m/01GYDZV2M9EBXKZAFW97K4HHMW",
-      "3857": "s3://linz-basemaps/3857/wellington_2016-2017_0.3m/01GYDZW8JYHN2NX0JMTKDEZBY5",
+      "2193": "s3://linz-basemaps/2193/wellington_2016-2017_0.3m/01GYDZV2M9EBXKZAFW97K4HHMW/",
+      "3857": "s3://linz-basemaps/3857/wellington_2016-2017_0.3m/01GYDZW8JYHN2NX0JMTKDEZBY5/",
       "name": "wellington-2016-2017-0.3m",
       "title": "Wellington 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos",

--- a/config/tileset/wellington/imagery/wellington-manawatu-whanganui-sn5139-1977-0.375m.json
+++ b/config/tileset/wellington/imagery/wellington-manawatu-whanganui-sn5139-1977-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn5139_1977_0.375m/01H8JPH3E4XE4033B7S38ZWMZD",
-      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn5139_1977_0.375m/01H8JPH4PB1ZM3R9H5TEK8QT7X",
+      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn5139_1977_0.375m/01H8JPH3E4XE4033B7S38ZWMZD/",
+      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn5139_1977_0.375m/01H8JPH4PB1ZM3R9H5TEK8QT7X/",
       "name": "wellington-manawatu-whanganui-sn5139-1977-0.375m",
       "title": "Wellington / Manawatū-Whanganui 0.375m SN5139 (1977)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-manawatu-whanganui-sn5309-1978-1981-0.64m.json
+++ b/config/tileset/wellington/imagery/wellington-manawatu-whanganui-sn5309-1978-1981-0.64m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/01H8JPHHTXW8NPPXPV0KACK4D7",
-      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/01H8JPK1FDREW54JTW5N9DB4NH",
+      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/01H8JPHHTXW8NPPXPV0KACK4D7/",
+      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/01H8JPK1FDREW54JTW5N9DB4NH/",
       "name": "wellington-manawatu-whanganui-sn5309-1978-1981-0.64m",
       "title": "Wellington / Manawatū-Whanganui 0.64m SN5309 (1978-1981)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-manawatu-whanganui-sn8171-1983-0.375m.json
+++ b/config/tileset/wellington/imagery/wellington-manawatu-whanganui-sn8171-1983-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn8171_1983_0.375m/01H8JPK1EHAPMZWJNV7CRDQF8P",
-      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn8171_1983_0.375m/01H8JPMVEF18P883GQ1VTSE4Q0",
+      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn8171_1983_0.375m/01H8JPK1EHAPMZWJNV7CRDQF8P/",
+      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn8171_1983_0.375m/01H8JPMVEF18P883GQ1VTSE4Q0/",
       "name": "wellington-manawatu-whanganui-sn8171-1983-0.375m",
       "title": "Wellington / Manawatū-Whanganui 0.375m SN8171 (1983)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-manawatu-whanganui-sn9382-1994-1995-0.75m.json
+++ b/config/tileset/wellington/imagery/wellington-manawatu-whanganui-sn9382-1994-1995-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/01H8JPK1EER9VRQ85R0ZJT9W67",
-      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/01H8JPK1EG0GVC42Q274T3ES92",
+      "2193": "s3://linz-basemaps/2193/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/01H8JPK1EER9VRQ85R0ZJT9W67/",
+      "3857": "s3://linz-basemaps/3857/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/01H8JPK1EG0GVC42Q274T3ES92/",
       "name": "wellington-manawatu-whanganui-sn9382-1994-1995-0.75m",
       "title": "Wellington / Manawatū-Whanganui 0.75m SN9382 (1994-1995)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-sn5497-1979-1980-0.4m.json
+++ b/config/tileset/wellington/imagery/wellington-sn5497-1979-1980-0.4m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_sn5497_1979-1980_0.4m/01H8JPHQ1YC7K02K9TA8F4C6DZ",
-      "3857": "s3://linz-basemaps/3857/wellington_sn5497_1979-1980_0.4m/01H8JPJDFB33PWKWJQ2KRQR7FE",
+      "2193": "s3://linz-basemaps/2193/wellington_sn5497_1979-1980_0.4m/01H8JPHQ1YC7K02K9TA8F4C6DZ/",
+      "3857": "s3://linz-basemaps/3857/wellington_sn5497_1979-1980_0.4m/01H8JPJDFB33PWKWJQ2KRQR7FE/",
       "name": "wellington-sn5497-1979-1980-0.4m",
       "title": "Wellington 0.4m SN5497 (1979-1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-sn8790-1987-1988-0.375m.json
+++ b/config/tileset/wellington/imagery/wellington-sn8790-1987-1988-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_sn8790_1987-1988_0.375m/01H8JPJM6Q04M4Y45Q1XNW0BWK",
-      "3857": "s3://linz-basemaps/3857/wellington_sn8790_1987-1988_0.375m/01H8JPJ6EXWAXJ64YMESWMMP65",
+      "2193": "s3://linz-basemaps/2193/wellington_sn8790_1987-1988_0.375m/01H8JPJM6Q04M4Y45Q1XNW0BWK/",
+      "3857": "s3://linz-basemaps/3857/wellington_sn8790_1987-1988_0.375m/01H8JPJ6EXWAXJ64YMESWMMP65/",
       "name": "wellington-sn8790-1987-1988-0.375m",
       "title": "Wellington 0.375m SN8790 (1987-1988)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-sn9448-1995-1997-0.75m.json
+++ b/config/tileset/wellington/imagery/wellington-sn9448-1995-1997-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_sn9448_1995-1997_0.75m/01H8JPJPN350V5Z6E6YQ8CJ44T",
-      "3857": "s3://linz-basemaps/3857/wellington_sn9448_1995-1997_0.75m/01H8JPJPN582A7X99QBWC69RA5",
+      "2193": "s3://linz-basemaps/2193/wellington_sn9448_1995-1997_0.75m/01H8JPJPN350V5Z6E6YQ8CJ44T/",
+      "3857": "s3://linz-basemaps/3857/wellington_sn9448_1995-1997_0.75m/01H8JPJPN582A7X99QBWC69RA5/",
       "name": "wellington-sn9448-1995-1997-0.75m",
       "title": "Wellington 0.75m SN9448 (1995-1997)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-snc25047-2000-0.75m.json
+++ b/config/tileset/wellington/imagery/wellington-snc25047-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_snc25047_2000_0.75m/01H8JPJZZQMY8KWFBSXMKKP8FS",
-      "3857": "s3://linz-basemaps/3857/wellington_snc25047_2000_0.75m/01H8JPK000T892DXZPPJSDBB42",
+      "2193": "s3://linz-basemaps/2193/wellington_snc25047_2000_0.75m/01H8JPJZZQMY8KWFBSXMKKP8FS/",
+      "3857": "s3://linz-basemaps/3857/wellington_snc25047_2000_0.75m/01H8JPK000T892DXZPPJSDBB42/",
       "name": "wellington-snc25047-2000-0.75m",
       "title": "Wellington 0.75m SNC25047 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-snc25062-2000-0.75m.json
+++ b/config/tileset/wellington/imagery/wellington-snc25062-2000-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_snc25062_2000_0.75m/01H8JRABWXZF4X2HJDSH6MJ0VC",
-      "3857": "s3://linz-basemaps/3857/wellington_snc25062_2000_0.75m/01H8JQFFC9S81YG77X4HEXBKR0",
+      "2193": "s3://linz-basemaps/2193/wellington_snc25062_2000_0.75m/01H8JRABWXZF4X2HJDSH6MJ0VC/",
+      "3857": "s3://linz-basemaps/3857/wellington_snc25062_2000_0.75m/01H8JQFFC9S81YG77X4HEXBKR0/",
       "name": "wellington-snc25062-2000-0.75m",
       "title": "Wellington 0.75m SNC25062 (2000)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-snc30010-2002-0.75m.json
+++ b/config/tileset/wellington/imagery/wellington-snc30010-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_snc30010_2002_0.75m/01H8JQDYMM0W853QVFA4GSWKMX",
-      "3857": "s3://linz-basemaps/3857/wellington_snc30010_2002_0.75m/01H8JQE8MGH8AMBD578MDX9W0M",
+      "2193": "s3://linz-basemaps/2193/wellington_snc30010_2002_0.75m/01H8JQDYMM0W853QVFA4GSWKMX/",
+      "3857": "s3://linz-basemaps/3857/wellington_snc30010_2002_0.75m/01H8JQE8MGH8AMBD578MDX9W0M/",
       "name": "wellington-snc30010-2002-0.75m",
       "title": "Wellington 0.75m SNC30010 (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/wellington/imagery/wellington-urban-2017-0.1m.json
+++ b/config/tileset/wellington/imagery/wellington-urban-2017-0.1m.json
@@ -6,8 +6,8 @@
   "category": "Urban Aerial Photos",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/wellington_urban_2017_0-10m/01F6P21F387PCQQB757VZ4E6GS",
-      "3857": "s3://linz-basemaps/3857/wellington_urban_2017_0-10m/01ED83SQ85A7B1MJ42BK13EGCQ",
+      "2193": "s3://linz-basemaps/2193/wellington_urban_2017_0-10m/01F6P21F387PCQQB757VZ4E6GS/",
+      "3857": "s3://linz-basemaps/3857/wellington_urban_2017_0-10m/01ED83SQ85A7B1MJ42BK13EGCQ/",
       "name": "wellington-urban-2017-0.1m",
       "title": "Wellington 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",

--- a/config/tileset/west-coast/imagery/west-coast-canterbury-sn8585-1986-1987-0.75m.json
+++ b/config/tileset/west-coast/imagery/west-coast-canterbury-sn8585-1986-1987-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_canterbury_sn8585_1986-1987_0.75m/01H8JR0PPQ845A49V9DHHVY3WV",
-      "3857": "s3://linz-basemaps/3857/west-coast_canterbury_sn8585_1986-1987_0.75m/01H8JQGZCQ746Q8GB61MEA2YMY",
+      "2193": "s3://linz-basemaps/2193/west-coast_canterbury_sn8585_1986-1987_0.75m/01H8JR0PPQ845A49V9DHHVY3WV/",
+      "3857": "s3://linz-basemaps/3857/west-coast_canterbury_sn8585_1986-1987_0.75m/01H8JQGZCQ746Q8GB61MEA2YMY/",
       "name": "west-coast-canterbury-sn8585-1986-1987-0.75m",
       "title": "West Coast / Canterbury 0.75m SN8585 (1986-1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-otago-sn8321-1984-1985-0.375m.json
+++ b/config/tileset/west-coast/imagery/west-coast-otago-sn8321-1984-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_otago_sn8321_1984-1985_0.375m/01H8JQE08V3W8VDRQYWWR7HWKK",
-      "3857": "s3://linz-basemaps/3857/west-coast_otago_sn8321_1984-1985_0.375m/01H8JQE08VG4ZEZPTP43H0EY6Z",
+      "2193": "s3://linz-basemaps/2193/west-coast_otago_sn8321_1984-1985_0.375m/01H8JQE08V3W8VDRQYWWR7HWKK/",
+      "3857": "s3://linz-basemaps/3857/west-coast_otago_sn8321_1984-1985_0.375m/01H8JQE08VG4ZEZPTP43H0EY6Z/",
       "name": "west-coast-otago-sn8321-1984-1985-0.375m",
       "title": "West Coast / Otago 0.375m SN8321 (1984-1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-otago-sn9065-1990-0.75m.json
+++ b/config/tileset/west-coast/imagery/west-coast-otago-sn9065-1990-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_otago_sn9065_1990_0.75m/01H8JQE93XAJR9VA4W88RXVDRW",
-      "3857": "s3://linz-basemaps/3857/west-coast_otago_sn9065_1990_0.75m/01H8JQE94ZCJ151DQ71NKM7D6C",
+      "2193": "s3://linz-basemaps/2193/west-coast_otago_sn9065_1990_0.75m/01H8JQE93XAJR9VA4W88RXVDRW/",
+      "3857": "s3://linz-basemaps/3857/west-coast_otago_sn9065_1990_0.75m/01H8JQE94ZCJ151DQ71NKM7D6C/",
       "name": "west-coast-otago-sn9065-1990-0.75m",
       "title": "West Coast / Otago 0.75m SN9065 (1990)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-sn5781-1980-0.375m.json
+++ b/config/tileset/west-coast/imagery/west-coast-sn5781-1980-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn5781_1980_0.375m/01H8JQF9H7QGBMBEKVRFAKKN0M",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn5781_1980_0.375m/01H8JQF9G5YDS4WQNP3MYRWM8X",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn5781_1980_0.375m/01H8JQF9H7QGBMBEKVRFAKKN0M/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn5781_1980_0.375m/01H8JQF9G5YDS4WQNP3MYRWM8X/",
       "name": "west-coast-sn5781-1980-0.375m",
       "title": "West Coast 0.375m SN5781 (1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-sn5817-1980-0.375m.json
+++ b/config/tileset/west-coast/imagery/west-coast-sn5817-1980-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn5817_1980_0.375m/01H8JQFDA1Y8X9XJVM0BXQDBG9",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn5817_1980_0.375m/01H8JQFDA1THJXFWWMFJ0B1YGZ",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn5817_1980_0.375m/01H8JQFDA1Y8X9XJVM0BXQDBG9/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn5817_1980_0.375m/01H8JQFDA1THJXFWWMFJ0B1YGZ/",
       "name": "west-coast-sn5817-1980-0.375m",
       "title": "West Coast 0.375m SN5817 (1980)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-sn8312-1984-1985-0.375m.json
+++ b/config/tileset/west-coast/imagery/west-coast-sn8312-1984-1985-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn8312_1984-1985_0.375m/01H8JQFTZTDCV4Z93T54XYKE07",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn8312_1984-1985_0.375m/01H8JQFTZSXXM2GN66C21GZAH3",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn8312_1984-1985_0.375m/01H8JQFTZTDCV4Z93T54XYKE07/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn8312_1984-1985_0.375m/01H8JQFTZSXXM2GN66C21GZAH3/",
       "name": "west-coast-sn8312-1984-1985-0.375m",
       "title": "West Coast 0.375m SN8312 (1984-1985)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-sn8534-1985-1986-0.375m.json
+++ b/config/tileset/west-coast/imagery/west-coast-sn8534-1985-1986-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn8534_1985-1986_0.375m/01H8JQW0Z9PNE2QBKCREKS2AWK",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn8534_1985-1986_0.375m/01H8JQVZ0ERE8C5YA0MCPFDY99",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn8534_1985-1986_0.375m/01H8JQW0Z9PNE2QBKCREKS2AWK/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn8534_1985-1986_0.375m/01H8JQVZ0ERE8C5YA0MCPFDY99/",
       "name": "west-coast-sn8534-1985-1986-0.375m",
       "title": "West Coast 0.375m SN8534 (1985-1986)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-sn8721-1987-0.375m.json
+++ b/config/tileset/west-coast/imagery/west-coast-sn8721-1987-0.375m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn8721_1987_0.375m/01H8JQKF0JRGS8KCPF68R160J3",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn8721_1987_0.375m/01H8JQKF1JKDQJ1TP7TN2TFYCG",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn8721_1987_0.375m/01H8JQKF0JRGS8KCPF68R160J3/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn8721_1987_0.375m/01H8JQKF1JKDQJ1TP7TN2TFYCG/",
       "name": "west-coast-sn8721-1987-0.375m",
       "title": "West Coast 0.375m SN8721 (1987)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-sn9493-1996-0.75m.json
+++ b/config/tileset/west-coast/imagery/west-coast-sn9493-1996-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn9493_1996_0.75m/01H8JQM3YS7GV1BYPJ11DGY4PN",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn9493_1996_0.75m/01H8JQM48NQC38PYH3RBCZN5PQ",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn9493_1996_0.75m/01H8JQM3YS7GV1BYPJ11DGY4PN/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn9493_1996_0.75m/01H8JQM48NQC38PYH3RBCZN5PQ/",
       "name": "west-coast-sn9493-1996-0.75m",
       "title": "West Coast 0.75m SN9493 (1996)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-sn9641-1997-0.75m.json
+++ b/config/tileset/west-coast/imagery/west-coast-sn9641-1997-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_sn9641_1997_0.75m/01H8JQNB71Z2QHW3NRCDGGT6SE",
-      "3857": "s3://linz-basemaps/3857/west-coast_sn9641_1997_0.75m/01H8JQNB6SY4Q8ZWTHJ9T7ANHJ",
+      "2193": "s3://linz-basemaps/2193/west-coast_sn9641_1997_0.75m/01H8JQNB71Z2QHW3NRCDGGT6SE/",
+      "3857": "s3://linz-basemaps/3857/west-coast_sn9641_1997_0.75m/01H8JQNB6SY4Q8ZWTHJ9T7ANHJ/",
       "name": "west-coast-sn9641-1997-0.75m",
       "title": "West Coast 0.75m SN9641 (1997)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/west-coast-snc30003-2002-0.75m.json
+++ b/config/tileset/west-coast/imagery/west-coast-snc30003-2002-0.75m.json
@@ -6,8 +6,8 @@
   "category": "Scanned Aerial Imagery",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/west-coast_snc30003_2002_0.75m/01H8JRKG48T0SHF8FT4GTN13G2",
-      "3857": "s3://linz-basemaps/3857/west-coast_snc30003_2002_0.75m/01H8JRA4H62PC3BW6PGTA74DKF",
+      "2193": "s3://linz-basemaps/2193/west-coast_snc30003_2002_0.75m/01H8JRKG48T0SHF8FT4GTN13G2/",
+      "3857": "s3://linz-basemaps/3857/west-coast_snc30003_2002_0.75m/01H8JRA4H62PC3BW6PGTA74DKF/",
       "name": "west-coast-snc30003-2002-0.75m",
       "title": "West Coast 0.75m SNC30003 (2002)",
       "category": "Scanned Aerial Imagery",

--- a/config/tileset/west-coast/imagery/westport-flood-2021-0.125m.json
+++ b/config/tileset/west-coast/imagery/westport-flood-2021-0.125m.json
@@ -6,8 +6,8 @@
   "category": "Event",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/2193/westport-flood_2021_0.125m/01HQS7SBSYQM47XE4GAP9Y396P",
-      "3857": "s3://linz-basemaps/3857/westport-flood_2021_0.125m/01HQS7SBDKJ1C836D52EQRM3G6",
+      "2193": "s3://linz-basemaps/2193/westport-flood_2021_0.125m/01HQS7SBSYQM47XE4GAP9Y396P/",
+      "3857": "s3://linz-basemaps/3857/westport-flood_2021_0.125m/01HQS7SBDKJ1C836D52EQRM3G6/",
       "name": "westport-flood-2021-0.125m",
       "title": "Westport Flood 0.125m Urban Aerial Photos (2021)",
       "category": "Event",


### PR DESCRIPTION
#### Motivation

All the raster imagery paths are url which is point to a folder instead of file, we should adding a trailing slash for them.

#### Modification

- add trialling slash for all rater urls.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
