### PR TITLE
fix(ci): Fix Upload asset file into production bucket.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
 
           echo ${ASSETS_LOCATION_PROD}
 
-          # aws s3 cp assets-current.tar.co ${ASSETS_LOCATION_PROD}
+          aws s3 cp assets-current.tar.co ${ASSETS_LOCATION_PROD}
 
           ./scripts/bmc.sh bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache s3://linz-basemaps-staging/basemaps-config/cache/
 


### PR DESCRIPTION
#### Motivation

Asset not been uploaded into production, we got a changed asset recently, because the ordering for the files are based on the `URL.href` instead of string path now. 

#### Modification

un-comment of the code that copy asset into production.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
