### PR TITLE
fix: gisborne-cyclone-bola-sn11485-1988-0.4m change category to event

### DIFF
--- a/config/tileset/gisborne/imagery/gisborne-cyclone-bola-sn11485-1988-0.4m.json
+++ b/config/tileset/gisborne/imagery/gisborne-cyclone-bola-sn11485-1988-0.4m.json
@@ -3,7 +3,7 @@
   "id": "ts_gisborne-cyclone-bola-sn11485-1988-0.4m",
   "title": "Gisborne Cyclone Bola 0.4m SN11485 (1988)",
   "background": "#00000000",
-  "category": "Scanned Aerial Imagery",
+  "category": "Event",
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/gisborne-cyclone-bola_sn11485_1988_0.4m/01HYM133P7MBM9GKHQ0Q4HTRQ3/",

--- a/config/tileset/gisborne/imagery/gisborne-cyclone-bola-sn11485-1988-0.4m.json
+++ b/config/tileset/gisborne/imagery/gisborne-cyclone-bola-sn11485-1988-0.4m.json
@@ -10,7 +10,7 @@
       "3857": "s3://linz-basemaps/3857/gisborne-cyclone-bola_sn11485_1988_0.4m/01HYM133NXM1YDMP18CND5SR4Q/",
       "name": "gisborne-cyclone-bola-sn11485-1988-0.4m",
       "title": "Gisborne Cyclone Bola 0.4m SN11485 (1988)",
-      "category": "Scanned Aerial Imagery",
+      "category": "Event",
       "minZoom": 0,
       "maxZoom": 32
     }


### PR DESCRIPTION
Change category of gisborne-cyclone-bola-sn11485-1988-0.4m to Event rather than Scanned Aerial Photos