### PR TITLE
feat(elevation): add nz 8m dem as base for all elevation

### DIFF
--- a/config/tileset/elevation.json
+++ b/config/tileset/elevation.json
@@ -7,6 +7,11 @@
   "category": "Elevation",
   "layers": [
     {
+      "3857": "s3://linz-basemaps/elevation/3857/new-zealand_2012_dem_8m/01HZ0YNQPGH5RJ01S5R5T2VAPM/",
+      "title": "New Zealand 8m DEM (2012)",
+      "name": "new-zealand_2012_dem_8m"
+    },
+    {
       "minZoom": 9,
       "3857": "s3://linz-basemaps/elevation/3857/auckland-north_2016-2018_dem_1m/01HZ64YXQVSRF6JK7YMYAQ81BT/",
       "title": "Auckland North LiDAR 1m DEM (2016-2018)",


### PR DESCRIPTION
#### Motivation

the 1m dems are not full coverage of NZ, so add the 8m DEM as a baselayer for all other DEMS

#### Modification

Adds Geographx 8m DEM

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
