### PR TITLE
ci: Upgrade the cli version to allow rgb background in the tileset config.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 env: 
-  BASEMAPS_CONTAINER_VERSION: v7.4.0-5-g310290c2
+  BASEMAPS_CONTAINER_VERSION: v7.4.0-7-g25e94af4
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 env: 
-  BASEMAPS_CONTAINER_VERSION: v7.4.0-7-g25e94af4
+  BASEMAPS_CONTAINER_VERSION: cli:v7.4.0-7-g25e94af4
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 env: 
-  BASEMAPS_CONTAINER_VERSION: cli:v7.4.0-7-g25e94af4
+  BASEMAPS_CONTAINER_VERSION: v7.4.0-7-g25e94af4
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 env: 
-  BASEMAPS_CONTAINER_VERSION: v7.3.0-2-g9396f606
+  BASEMAPS_CONTAINER_VERSION: v7.4.0-5-g310290c2
 
 jobs:
   build:


### PR DESCRIPTION
#### Motivation

Currently the tileset config background has to be defined as hex string. We are migrating them into rgb in the future. Just update the cli version to allow the bundling parser to allow both hex and rgd. https://github.com/linz/basemaps/commit/23df7debe6638946631d10d53bc809c53afa92f6

#### Modification

update cli version

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
