### PR TITLE
build: use latest v7.x.x basemaps cli version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 env: 
-  BASEMAPS_CONTAINER_VERSION: v7.4.0-7-g25e94af4
+  BASEMAPS_CONTAINER_VERSION: v7
 
 jobs:
   build:


### PR DESCRIPTION
### Motivation

the cli was linked to a specific version to fix a couple of bugs these bugs have now been reelased.
<!-- TODO: Say why you made your changes. -->

### Modifications

swap from a exact version of basemaps cli to the latest released version v7.x.x
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->