### PR TITLE
feat: show rural imagery at z12 rather than z13

### DIFF
--- a/config/tileset/aerial.json
+++ b/config/tileset/aerial.json
@@ -71,7 +71,7 @@
       "2193": "s3://linz-basemaps/2193/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XY0TVJJ4QVJ7988TCKGWS/",
       "3857": "s3://linz-basemaps/3857/nz-nearshore-islands_satellite_2010-2021_0-5m_RGB/01G00XYQ8YKAZC7P5QJ4BPCX22/",
       "name": "nz-nearshore-islands-satellite-2010-2021-0.5m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "New Zealand Nearshore Islands 0.5m Satellite Imagery (2010-2021)",
       "category": "Satellite Imagery"
     },
@@ -87,7 +87,7 @@
       "2193": "s3://linz-basemaps/2193/tasman_rural_2004-2005_1m_RGB/01F6P1TQVSC7QRF1R3JAT893ZS/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2004-2005_1m_RGB/01EE962ZB3Z6Y7GVZ28XCWJ9JB/",
       "name": "tasman-rural-2004-2005-1m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Tasman 1m Rural Aerial Photos (2004-2005)",
       "category": "Rural Aerial Photos"
     },
@@ -95,7 +95,7 @@
       "2193": "s3://linz-basemaps/2193/southland_rural_2005-2011_0-75m_RGBA/01F6P1S7DSP4N5DCBGCTZCMJ27/",
       "3857": "s3://linz-basemaps/3857/southland_rural_2005-2011_0-75m_RGBA/01ED835ZSP0MQ3W55QEMVZKNR1/",
       "name": "southland-rural-2005-2011-0.75m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Southland 0.75m Rural Aerial Photos (2005-2011)",
       "category": "Rural Aerial Photos"
     },
@@ -103,7 +103,7 @@
       "2193": "s3://linz-basemaps/2193/auckland_rural_2010-2012_0-50m_RGBA/01F66DT3ZBYZZM6R0AF9Q2989R/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2010-2012_0-50m_RGBA/01ED81BNAX2ESPMV59YPC3AQ2C/",
       "name": "auckland-rural-2010-2012-0.5m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
       "category": "Rural Aerial Photos"
     },
@@ -111,7 +111,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2012-2013_0-40m_RGBA/01F66E9294YKPYAJP7SXTVY2EM/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2012-2013_0-40m_RGBA/01ED81XK539QM497AYHM1X70JQ/",
       "name": "canterbury-rural-2012-2013-0.4m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.4m Rural Aerial Photos (2012-2013)",
       "category": "Rural Aerial Photos"
     },
@@ -119,7 +119,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2013-2014_0-40m_RGBA/01F66E9VVX07WFC1C5Y05S4JXM/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2013-2014_0-40m_RGBA/01ED81YFYF0D76RZRH9FHF7JDN/",
       "name": "canterbury-rural-2013-2014-0.4m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.4m Rural Aerial Photos (2013-2014)",
       "category": "Rural Aerial Photos"
     },
@@ -127,7 +127,7 @@
       "2193": "s3://linz-basemaps/2193/southland-central-otago_rural_2013-2014_0-40m_RGBA/01F6P1R136F2BHRHRJ961SC7CH/",
       "3857": "s3://linz-basemaps/3857/southland-central-otago_rural_2013-2014_0-40m_RGBA/01ED83886J46GSSZP6GKCCYGH1/",
       "name": "southland-central-otago-rural-2013-2014-0.4m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Southland & Central Otago 0.4m Rural Aerial Photos (2013-2014)",
       "category": "Rural Aerial Photos"
     },
@@ -135,7 +135,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2014-2015_0-30m_RGBA/01F66EATPYCJF8R9WZRRE481ZP/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2014-2015_0-30m_RGBA/01ED81ZMNH3PM5Q3E2MWRFD22B/",
       "name": "canterbury-rural-2014-2015-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.3m Rural Aerial Photos (2014-2015)",
       "category": "Rural Aerial Photos"
     },
@@ -143,7 +143,7 @@
       "2193": "s3://linz-basemaps/2193/northland_rural_2014-16_0-4m/01F6P1JB8GFYFC08W3AK9KFGJW/",
       "3857": "s3://linz-basemaps/3857/northland_rural_2014-16_0-4m/01ED82WK4A955T96RV5NWEN3R6/",
       "name": "northland-rural-2014-2016-0.4m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Northland 0.4m Rural Aerial Photos (2014-2016)",
       "category": "Rural Aerial Photos"
     },
@@ -151,7 +151,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2015-2016_0-30m_RGBA/01F66EBN9BYJA29NMW96ZJM7ZJ/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2015-2016_0-30m_RGBA/01ED82104D376HEF1ZMW8PRX5N/",
       "name": "canterbury-rural-2015-2016-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos"
     },
@@ -159,7 +159,7 @@
       "2193": "s3://linz-basemaps/2193/southland-central-otago_rural_2015-2017_0-40m_RGB/01F6P1RQRT6N94DDKGRCSYKM6R/",
       "3857": "s3://linz-basemaps/3857/southland-central-otago_rural_2015-2017_0-40m_RGB/01ED83A271YNKAW0KRH17RPMMV/",
       "name": "southland-central-otago-rural-2015-2017-0.4m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Southland & Central Otago 0.4m Rural Aerial Photos (2015-2017)",
       "category": "Rural Aerial Photos"
     },
@@ -167,7 +167,7 @@
       "2193": "s3://linz-basemaps/2193/southland_2023_0.25m/01J2CYGDFGE0JBCDGP8K37VHY6/",
       "3857": "s3://linz-basemaps/3857/southland_2023_0.25m/01J2CYGDFXH71XBHE1HXRXVEQR/",
       "name": "southland-2023-0.25m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Southland 0.25m Rural Aerial Photos (2023-2024)",
       "category": "Rural Aerial Photos"
     },
@@ -175,7 +175,7 @@
       "2193": "s3://linz-basemaps/2193/west-coast_rural_2015-16_0-3m/01F6P21PNQC7D67W5SHQF806Z3/",
       "3857": "s3://linz-basemaps/3857/west-coast_rural_2015-16_0-3m/01ED83TT0ZHKXTPFXEGFJHP2M5/",
       "name": "west-coast-rural-2015-2016-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "West Coast 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos"
     },
@@ -183,7 +183,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2016-18_0-3m/01F66ECJGT5PGYPVK9MW7TYHPZ/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2016-18_0-3m/01ED8225A94WY3GQ4CNZ9E1PZN/",
       "name": "canterbury-rural-2016-2018-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.3m Rural Aerial Photos (2017-2018)",
       "category": "Rural Aerial Photos"
     },
@@ -191,7 +191,7 @@
       "2193": "s3://linz-basemaps/2193/kaikoura-post-earthquake_rural_2016-17_0-3m/01F6P1AGSRJG1VKND6PD8BXH2Q/",
       "3857": "s3://linz-basemaps/3857/kaikoura-post-earthquake_rural_2016-17_0-3m/01ED82F0376F6FJFMTV4JAVJ53/",
       "name": "kaikoura-post-earthquake-rural-2016-2017-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Kaikōura Earthquake 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Event"
     },
@@ -199,7 +199,7 @@
       "2193": "s3://linz-basemaps/2193/wellington_rural_2021_0-3m_RGB/01FB82NZY0ASDQBKT28DSXS8XC/",
       "3857": "s3://linz-basemaps/3857/wellington_rural_2021_0-3m_RGB/01FB82QKPWEHV0FWN7KBXM6NDM/",
       "name": "wellington-rural-2021-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Wellington 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
     },
@@ -207,7 +207,7 @@
       "2193": "s3://linz-basemaps/2193/west-coast_rural_2016-17_0-3m/01F6P220GYWC836YQ4RRZGSV73/",
       "3857": "s3://linz-basemaps/3857/west-coast_rural_2016-17_0-3m/01ED83VT2T06B1FVXF9P6CCV8C/",
       "name": "west-coast-rural-2016-2017-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "West Coast 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos"
     },
@@ -215,7 +215,7 @@
       "2193": "s3://linz-basemaps/2193/marlborough_rural_2017-18_0-3m/01F6P1E05SRRSMA94E11F1EAFJ/",
       "3857": "s3://linz-basemaps/3857/marlborough_rural_2017-18_0-3m/01EDAMZ587FYSZ9NY8TP40VASS/",
       "name": "marlborough-rural-2017-2018-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Marlborough 0.3m Rural Aerial Photos (2017-2018)",
       "category": "Rural Aerial Photos"
     },
@@ -223,7 +223,7 @@
       "2193": "s3://linz-basemaps/2193/otago_rural_2017-2019_0-30m_RGB/01F6P1N3TA18Y2GYJ5B4YGGZYC/",
       "3857": "s3://linz-basemaps/3857/otago_rural_2017-2019_0-30m_RGB/01ED831MKK85M1QNCNZV0AYPYC/",
       "name": "otago-rural-2017-2019-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Otago 0.3m Rural Aerial Photos (2017-2019)",
       "category": "Rural Aerial Photos"
     },
@@ -231,7 +231,7 @@
       "2193": "s3://linz-basemaps/2193/waikato_rural_2017-19_0-3m/01F6P1YQNFECBE6S3TESNSPA2X/",
       "3857": "s3://linz-basemaps/3857/waikato_rural_2017-19_0-3m/01EDAN2JJVFCS9WZWMB9105XFH/",
       "name": "waikato-rural-2017-2019-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Waikato 0.3m Rural Aerial Photos (2016-2019)",
       "category": "Rural Aerial Photos"
     },
@@ -239,7 +239,7 @@
       "2193": "s3://linz-basemaps/2193/nelson_rural_2018-19_0-3m/01F6P1FJNXVVTS7HC3VS3FHEYX/",
       "3857": "s3://linz-basemaps/3857/nelson_rural_2018-19_0-3m/01ED82T5HM0H275QJPMDQN0JFJ/",
       "name": "nelson-rural-2018-2019-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Nelson 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
     },
@@ -247,7 +247,7 @@
       "2193": "s3://linz-basemaps/2193/tasman_rural_2018-19_0-3m/01F6P1VDEYFR0XB5XJMN9X6V1C/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2018-19_0-3m/01ED83DSMR8N1FQFVXM8JASBV2/",
       "name": "tasman-rural-2018-2019-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Tasman 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
     },
@@ -256,14 +256,14 @@
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW/",
       "name": "bay-of-plenty-rural-2016-2017-0.3m",
       "title": "Bay of Plenty 0.3m Rural Aerial Photos (2016-2017)",
-      "minZoom": 13,
+      "minZoom": 12,
       "category": "Rural Aerial Photos"
     },
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2021_0-2m/01H3E4XFK8N1JYJCM8BHDQAJPQ/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2021_0-2m/01H3E4ZG0MJ0SABSSBW2MJXVNS/",
       "name": "bay-of-plenty-rural-2021-0.2m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
     },
@@ -271,7 +271,7 @@
       "2193": "s3://linz-basemaps/2193/tasman_rural_2020_0-3m_RGB/01FBGB1QN859XRGNNWT6ZBHEN8/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2020_0-3m_RGB/01FBGB0T73562VAZBEBHZ7E84T/",
       "name": "tasman-rural-2020-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Tasman 0.3m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos"
     },
@@ -279,7 +279,7 @@
       "2193": "s3://linz-basemaps/2193/tasman_2022-2023_0.25m/01H4Q84VRY1WFXERB721NJZPED/",
       "3857": "s3://linz-basemaps/3857/tasman_2022-2023_0.25m/01H4Q85QE0ZF7E13DSGGZRR04V/",
       "name": "tasman-2022-2023-0.25m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Tasman 0.25m Rural Aerial Photos (2022-2023)",
       "category": "Rural Aerial Photos"
     },
@@ -287,7 +287,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2019_0-3m_RGB/01FJJFP25MYHH34JEV0XM9Z8Q8/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2019_0-3m_RGB/01FJJFN1H62SA0836CKX2BYE5F/",
       "name": "canterbury-rural-2019-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos"
     },
@@ -295,7 +295,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2020_0-3m_RGB/01FHRTDFP4DDQD4X1G63SDF0AX/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2020_0-3m_RGB/01FHRTF5GHTZD5SEXP3MS7E911/",
       "name": "canterbury-rural-2020-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.3m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos"
     },
@@ -303,7 +303,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2020-2021_0-2m_RGB/01FHV1ZNDNT9256J13H89BRKWT/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2020-2021_0-2m_RGB/01FHV1VPTBM52WH81ZT7XAX93W/",
       "name": "canterbury-rural-2020-2021-0.2m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.2m Rural Aerial Photos (2020-2021)",
       "category": "Rural Aerial Photos"
     },
@@ -311,7 +311,7 @@
       "2193": "s3://linz-basemaps/2193/otago_rural_2019-2021_0-3m_RGB/01FKP9RXGA4EXSFWBGKHKVTPMT/",
       "3857": "s3://linz-basemaps/3857/otago_rural_2019-2021_0-3m_RGB/01FKP9PAF9VNHC4FYGQRGHF593/",
       "name": "otago-rural-2019-2021-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Otago 0.3m Rural Aerial Photos (2019-2021)",
       "category": "Rural Aerial Photos"
     },
@@ -319,7 +319,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury-waitaki_rural_2021_0-3m_RGB/01FQ07ZVQYC3M57D8N84WFM4F5/",
       "3857": "s3://linz-basemaps/3857/canterbury-waitaki_rural_2021_0-3m_RGB/01FQ07XS8GHPFS913PGY5P9010/",
       "name": "canterbury-waitaki-rural-2021-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury - Waitaki 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
     },
@@ -327,7 +327,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury-mackenzie_rural_2021_0-3m_RGB/01FQ081YGQNSSB120WPZ3N70W0/",
       "3857": "s3://linz-basemaps/3857/canterbury-mackenzie_rural_2021_0-3m_RGB/01FQ080VWM2VAMT9G2BYPWZTKB/",
       "name": "canterbury-mackenzie-rural-2021-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury - Mackenzie 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos"
     },
@@ -335,7 +335,7 @@
       "2193": "s3://linz-basemaps/2193/tasman_rural_2022_0-3m_RGB/01G75YD43EBA980HFWVF6ZFV6B/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2022_0-3m_RGB/01G75YDG4KFEZ5BAGTPHMEAPP7/",
       "name": "tasman-rural-2022-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Tasman 0.3m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
     },
@@ -343,7 +343,7 @@
       "2193": "s3://linz-basemaps/2193/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ84DPHCND4PG6BD0W999A/",
       "3857": "s3://linz-basemaps/3857/marlborough_rural_2021-2022_0-25m_RGB/01GAMZ9988GKX5JF0F0EW2R9Q3/",
       "name": "marlborough-rural-2021-2022-0.25m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Marlborough 0.25m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
@@ -351,7 +351,7 @@
       "2193": "s3://linz-basemaps/2193/marlborough_2023_0.25m/01H6WRJWDK9VNKK6HE2PZ63AKG/",
       "3857": "s3://linz-basemaps/3857/marlborough_2023_0.25m/01H6WRKSPQD92366HB8WT35BQK/",
       "name": "marlborough-2023-0.25m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Marlborough 0.25m Rural Aerial Photos (2023) - Draft",
       "category": "Rural Aerial Photos"
     },
@@ -359,7 +359,7 @@
       "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH2Y0Q4PENH4T22PGJB521/",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH42RKHGCSHRB3EMZVZD91/",
       "name": "hawkes-bay-rural-2021-2022-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Hawke's Bay 0.3m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
@@ -367,7 +367,7 @@
       "2193": "s3://linz-basemaps/2193/taranaki_rural_2021-2022_0.25m_RGB/01GDKFTY5BPAHMSKKVC336J9Y2/",
       "3857": "s3://linz-basemaps/3857/taranaki_rural_2021-2022_0.25m_RGB/01GDKFVY7VZ7CVYGYG02FXSEMJ/",
       "name": "taranaki-rural-2021-2022-0.25m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Taranaki 0.25m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
@@ -375,7 +375,7 @@
       "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2021-2022_0.3m/01GVCD2Y9RTQ57TWG4MPTHJ84R/",
       "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2021-2022_0.3m/01GVCDBNDH2Z9JEHDHJSD1EJ79/",
       "name": "manawatu-whanganui-rural-2021-2022-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
@@ -383,7 +383,7 @@
       "2193": "s3://linz-basemaps/2193/manawatu-whanganui_2023-2024_0.2m/01J0HT395T9SHD4WPQ909PEREZ/",
       "3857": "s3://linz-basemaps/3857/manawatu-whanganui_2023-2024_0.2m/01J0HT3961293FJM2HBKN9NC79/",
       "name": "manawatu-whanganui-2023-2024-0.2m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Manawatū-Whanganui 0.2m Rural Aerial Photos (2023-2024)",
       "category": "Rural Aerial Photos"
     },
@@ -391,7 +391,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_2021-2022_0.2m/01GHW1Y474AHB191P8SRKENK7Y/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_2021-2022_0.2m/01GHW1ZWNS4N0GP9TAM09WHPBC/",
       "name": "bay-of-plenty-2021-2022-0.2m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos"
     },
@@ -399,7 +399,7 @@
       "2193": "s3://linz-basemaps/2193/canterbury_2022_0.3m/01GPEXMRQCA525WF8B0XBV5575/",
       "3857": "s3://linz-basemaps/3857/canterbury_2022_0.3m/01GPEXPBHG2XJZK0JPGKNAVD6A/",
       "name": "canterbury-2022-0.3m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Canterbury 0.3m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
     },
@@ -575,7 +575,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FVDF75ZM3KHXDYJES57AG/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FX6SQBKE27MWG6K3E86CM/",
       "name": "bay-of-plenty-urban-2020-0.1m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos"
     },
@@ -583,7 +583,7 @@
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_2023_0.1m/01H7BSV0VASQPKX47EQD4JWYDM/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_2023_0.1m/01H7BSWXXHTC8581TSPJS1QTM1/",
       "name": "bay-of-plenty-2023-0.1m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2023)",
       "category": "Urban Aerial Photos"
     },
@@ -743,7 +743,7 @@
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8/",
       "name": "auckland-rural-2020-0.075m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Auckland 0.075m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos"
     },
@@ -751,7 +751,7 @@
       "2193": "s3://linz-basemaps/2193/auckland_rural_2022_0-075m_RGB/01G6HJ9S4PGK6MTVEZWWHV56QN/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2022_0-075m_RGB/01G6HJBFJRBKJ7FQPHVRACKMNQ/",
       "name": "auckland-rural-2022-0.075m",
-      "minZoom": 13,
+      "minZoom": 12,
       "title": "Auckland 0.075m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos"
     },
@@ -841,7 +841,7 @@
       "name": "canterbury-2023-0.3m",
       "title": "Canterbury 0.3m Rural Aerial Photos (2023)",
       "category": "Rural Aerial Photos",
-      "minZoom": 13,
+      "minZoom": 12,
       "maxZoom": 14
     },
     {


### PR DESCRIPTION
### Motivation

The zoom level in the 3D view decreases as the map view moves toward the horizon, and rural imagery isn't showing very far toward the horizon at present because as soon as it drops a zoom level, we see satellite imagery instead. Dropping the minZoom for rural imagery may help, but may also make z12 in 2D mode look worse (due to lack of colour balancing between rural imagery sources).

### Modifications

Replaced all `"minZoom": 13` with `"minZoom": 12`

### Verification

To be checked using config link when Actions complete.