### PR TITLE
feat(elevation): update Waikato 1m DEM (2021) with added tiles

### DIFF
--- a/config/tileset/elevation.json
+++ b/config/tileset/elevation.json
@@ -384,7 +384,7 @@
     },
     {
       "2193": "s3://nz-elevation/waikato/waikato_2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/waikato_2021_dem_1m/01HZ67GB12GXJDBF92Q4E2T9A2/",
+      "3857": "s3://linz-basemaps/elevation/3857/waikato_2021_dem_1m/01J546JDQCQ0H9735NHN4P903W/",
       "minZoom": 9,
       "title": "Waikato LiDAR 1m DEM (2021)",
       "name": "waikato_2021_dem_1m"


### PR DESCRIPTION
### Motivation

Waikato had updated tiles added to the Registry of Open Data on AWS, Basemaps Web Mercator layer needs to be updated to match.

### Modifications

Updated the tileset ID.

### Verification

Basemaps previews of that tileset ID: https://basemaps.linz.govt.nz/@-37.8921956,175.6933593,z9?style=01J546JDQCQ0H9735NHN4P903W&tileMatrix=WebMercatorQuad&debug&config=4CaC4znMfJBq41Lr3HetGWsVkRE8SDHmHXcfSxTG8yVxqAiFUPFxSNpB2HJZWcSnFdpxDoszHzqcSYhZiyJkoA5paKFDNQKnZCoiZhs8w9VvENBWRzyguhxkJeNU3ygJ7c6GpyNKe9jQZgy7HNXyTXJUR7vifw7W82HE9ZcfuDgHpAvANuyhX2Xhr8Koft3LypzKsVbpJdeq