### PR TITLE
config: add a label base style BM-1066

### DIFF
--- a/config/style/label.json
+++ b/config/style/label.json
@@ -1393,7 +1393,7 @@
     "sky-horizon-blend": 0.5
   },
   "sources": {
-    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json" },
+    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json" }
   },
   "sprite": "/v1/sprites/topographic",
   "version": 8

--- a/config/style/label.json
+++ b/config/style/label.json
@@ -1,0 +1,1400 @@
+{
+  "glyphs": "/v1/fonts/{fontstack}/{range}.pbf",
+  "id": "st_label",
+  "layers": [
+    {
+      "filter": ["none", ["==", "parcel_intent", "Road"], ["==", "parcel_intent", "Hydro"]],
+      "id": "Parcels-Ln-Shadow",
+      "layout": { "visibility": "visible" },
+      "minzoom": 15,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [16, "rgba(58, 58, 58, 0.4)"],
+            [20, "rgba(70, 70, 70, 0.7)"]
+          ]
+        },
+        "line-offset": 1,
+        "line-opacity": {
+          "stops": [
+            [15, 0.4],
+            [18, 1]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [16, 0.75],
+            [24, 1.5]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "parcel_boundaries",
+      "type": "line"
+    },
+    {
+      "filter": ["none", ["==", "parcel_intent", "Road"], ["==", "parcel_intent", "Hydro"]],
+      "id": "Parcels-Ln",
+      "layout": { "visibility": "visible" },
+      "minzoom": 15,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [16, "rgba(141, 141, 141, 0.4)"],
+            [20, "rgba(196, 196, 196, 0.7)"]
+          ]
+        },
+        "line-offset": 0,
+        "line-opacity": {
+          "stops": [
+            [15, 0.4],
+            [18, 1]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [16, 0.75],
+            [24, 1.5]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "parcel_boundaries",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
+      "id": "Transport-FootTracks-Shadow",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 14,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [13, "rgba(231, 231, 231, 0.7)"],
+            [18, "rgba(231, 231, 231, 0.4)"]
+          ]
+        },
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [16, 0.75]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [14, 1],
+            [15, 1.5],
+            [19, 5]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "track"], ["==", "track_use", "foot"]],
+      "id": "Transport-FootTracks",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 14,
+      "paint": {
+        "line-color": "rgba(78, 78, 78, 0.8)",
+        "line-dasharray": {
+          "base": 1,
+          "stops": [
+            [13, [2.5, 4]],
+            [15, [2.5, 3]],
+            [16, [2.5, 3]]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [14, 1],
+            [15, 1.5],
+            [19, 3]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "track"], ["==", "track_use", "vehicle"]],
+      "id": "Transport-VehicleTracks-Shadow",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-blur": 0.75,
+        "line-color": {
+          "stops": [
+            [13, "rgba(231, 231, 231, 0.7)"],
+            [18, "rgba(231, 231, 231, 0.4)"]
+          ]
+        },
+        "line-dasharray": [8],
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [16, 0.5],
+            [18, 0]
+          ]
+        },
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [13, 1.5],
+            [15, 5],
+            [19, 18]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "track"], ["==", "track_use", "vehicle"]],
+      "id": "Transport-VehicleTracks",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(78, 78, 78, 0.8)",
+        "line-dasharray": {
+          "base": 1,
+          "stops": [
+            [14, [3, 3]],
+            [15, [3, 4]],
+            [16, [4, 6]],
+            [17, [6, 8]]
+          ]
+        },
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [13, 1],
+            [15, 2],
+            [19, 8]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "lane_count", 1], ["!=", "class", "motorway"]],
+      "id": "Transport-1Casing",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(78, 78, 78, 1)",
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [16, 0.5],
+            [18, 0]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [13, 1.5],
+            [15, 5],
+            [19, 18]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["in", "lane_count", 2, 3, 4, 5, 6, 7, 8], ["!=", "class", "motorway"]],
+      "id": "Transport-2Casing",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(78, 78, 78, 1)",
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [16, 0.5],
+            [18, 0]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [13, 2],
+            [15, 6],
+            [19, 16]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "metalled"], ["==", "lane_count", 1]],
+      "id": "Transport-1Metalled-White",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [14, 0.5],
+            [18, 0.4]
+          ]
+        },
+        "line-translate-anchor": "map",
+        "line-width": {
+          "stops": [
+            [13, 0.5],
+            [15, 3],
+            [19, 16]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "metalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
+      "id": "Transport-2Metalled-White",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [14, 0.5],
+            [18, 0.4]
+          ]
+        },
+        "line-translate-anchor": "map",
+        "line-width": {
+          "stops": [
+            [13, 1],
+            [15, 5],
+            [19, 18]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "unmetalled"]],
+      "id": "Transport-UnMetalled",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [14, 0.5],
+            [18, 0.4]
+          ]
+        },
+        "line-translate-anchor": "map",
+        "line-width": {
+          "stops": [
+            [13, 0.5],
+            [15, 3],
+            [19, 16]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "unmetalled"], ["in", "lane_count", 2, 3, 4, 5, 6, 7]],
+      "id": "Transport-2UnMetalled",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [14, 0.5],
+            [18, 0.4]
+          ]
+        },
+        "line-translate-anchor": "map",
+        "line-width": {
+          "stops": [
+            [13, 1],
+            [15, 5],
+            [19, 18]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "sealed"], ["==", "lane_count", 1], ["!=", "class", "motorway"]],
+      "id": "Transport-1Sealed",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [14, 0.5],
+            [18, 0.4]
+          ]
+        },
+        "line-translate-anchor": "map",
+        "line-width": {
+          "stops": [
+            [13, 0.5],
+            [15, 3],
+            [19, 16]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "surface", "sealed"], ["in", "lane_count", 2, 3, 4, 5, 6, 7], ["!=", "class", "motorway"]],
+      "id": "Transport-2+Sealed",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "rgba(184, 184, 184, 1)",
+        "line-gap-width": 0,
+        "line-opacity": {
+          "stops": [
+            [13, 1],
+            [14, 0.5],
+            [18, 0.4]
+          ]
+        },
+        "line-translate-anchor": "map",
+        "line-width": {
+          "stops": [
+            [13, 1],
+            [15, 5],
+            [19, 18]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 1]],
+      "id": "Transport-1HWY-Casing",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "line-color": "rgba(69, 69, 69, 1)",
+        "line-opacity": {
+          "stops": [
+            [8, 1],
+            [13, 0.75],
+            [16, 0.25]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [8, 1.5],
+            [10, 1.5],
+            [15, 4],
+            [20, 30]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
+      "id": "Transport-2HWY-Casing",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "line-color": "rgba(69, 69, 69, 1)",
+        "line-opacity": {
+          "stops": [
+            [8, 1],
+            [13, 0.75],
+            [16, 0.25]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [8, 3],
+            [10, 3],
+            [15, 6],
+            [18, 30]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
+      "id": "Transport-HWY-Casing",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "line-color": "rgba(69, 69, 69, 1)",
+        "line-opacity": {
+          "stops": [
+            [8, 1],
+            [13, 0.75],
+            [16, 0.25]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [8, 3],
+            [10, 3],
+            [15, 6],
+            [18, 30]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"], ["==", "lane_count", 1]],
+      "id": "Transport-1HWY",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [8, "rgba(232, 218, 123, 1)"],
+            [10, "rgba(210, 162, 84, 1)"]
+          ]
+        },
+        "line-opacity": {
+          "stops": [
+            [8, 1],
+            [13, 0.75],
+            [16, 0.25]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [8, 0.5],
+            [10, 0.5],
+            [14, 2],
+            [17, 14],
+            [20, 30]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 2, 3]],
+      "id": "Transport-2HWY",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "line-blur": 0,
+        "line-color": {
+          "stops": [
+            [8, "rgba(232, 218, 123, 1)"],
+            [10, "rgba(210, 162, 84, 1)"]
+          ]
+        },
+        "line-opacity": {
+          "stops": [
+            [8, 1],
+            [13, 0.75],
+            [16, 0.25]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [8, 1],
+            [10, 1],
+            [14, 3],
+            [18, 30]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"], ["in", "lane_count", 4, 5, 6, 7]],
+      "id": "Transport-HWY",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [8, "rgba(232, 218, 123, 1)"],
+            [10, "rgba(210, 162, 84, 1)"]
+          ]
+        },
+        "line-opacity": {
+          "stops": [
+            [8, 1],
+            [13, 0.75],
+            [16, 0.25]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [8, 1],
+            [10, 1],
+            [14, 3],
+            [18, 30]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"]],
+      "id": "Transport-Roads-8-Casing",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 8,
+      "minzoom": 6,
+      "paint": {
+        "line-color": "rgba(69, 69, 69, 1)",
+        "line-width": {
+          "stops": [
+            [5, 1.5],
+            [8, 4]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "motorway"]],
+      "id": "Transport-Roads-8",
+      "layout": { "visibility": "visible" },
+      "maxzoom": 8,
+      "minzoom": 6,
+      "paint": {
+        "line-color": {
+          "stops": [
+            [6, "rgba(232, 218, 123, 1)"],
+            [10, "rgba(210, 162, 84, 1)"]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [5, 0.75],
+            [8, 1.5]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": ["all", ["==", "class", "ferry"]],
+      "id": "Transport-FerryCrossing",
+      "minzoom": 11.5,
+      "paint": {
+        "line-color": "rgba(74, 110, 153, 1)",
+        "line-dasharray": [8, 10],
+        "line-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "id": "Airport-Label",
+      "layout": {
+        "icon-anchor": "bottom",
+        "icon-ignore-placement": false,
+        "icon-image": "airport_airport_pnt_fill",
+        "icon-offset": [0, 0],
+        "icon-pitch-alignment": "viewport",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1.2,
+        "icon-text-fit": "none",
+        "symbol-spacing": 250,
+        "text-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Bold Italic"],
+        "text-justify": "center",
+        "text-max-width": 5,
+        "text-padding": 2,
+        "text-pitch-alignment": "auto",
+        "text-rotation-alignment": "auto",
+        "text-size": 11,
+        "visibility": "visible"
+      },
+      "minzoom": 12,
+      "paint": {
+        "icon-opacity": 0.8,
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "aerodrome_label",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["in", "hway_num", "25A", "20A", "20B", "29A", "30A", "74A", "67A"]],
+      "id": "All-Highway-Labels-three",
+      "layout": {
+        "icon-anchor": "center",
+        "icon-image": "highway_pnt_wide",
+        "icon-keep-upright": false,
+        "icon-offset": [0, 1],
+        "icon-padding": 2,
+        "icon-pitch-alignment": "viewport",
+        "icon-rotate": 0,
+        "icon-rotation-alignment": "viewport",
+        "icon-size": {
+          "stops": [
+            [8, 1.2],
+            [12, 1.5],
+            [15, 1.7]
+          ]
+        },
+        "icon-text-fit": "none",
+        "icon-text-fit-padding": [1, 4, 3, 3],
+        "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [6, 500],
+            [13, 400]
+          ]
+        },
+        "text-field": "{hway_num}",
+        "text-font": ["Open Sans Bold"],
+        "text-justify": "center",
+        "text-keep-upright": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [8, 9],
+            [11, 10],
+            [15, 14]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "icon-translate-anchor": "map",
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-translate-anchor": "map"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "hway_num"], ["!in", "hway_num", "6,94", "2,50", "1,3", "12,15", "14,15", "6,96", "25A", "20A", "20B", "29A", "30A", "74A", "67A"], ["!=", "lane_count", 1]],
+      "id": "All-Highway-Labels-standard",
+      "layout": {
+        "icon-anchor": "center",
+        "icon-image": "highway_pnt_standard",
+        "icon-keep-upright": false,
+        "icon-offset": [0, 1],
+        "icon-padding": 2,
+        "icon-pitch-alignment": "viewport",
+        "icon-rotate": 0,
+        "icon-rotation-alignment": "viewport",
+        "icon-size": {
+          "stops": [
+            [8, 1.2],
+            [12, 1.5],
+            [15, 1.7]
+          ]
+        },
+        "icon-text-fit": "none",
+        "icon-text-fit-padding": [1, 4, 3, 3],
+        "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [6, 500],
+            [13, 400]
+          ]
+        },
+        "text-field": "{hway_num}",
+        "text-font": ["Open Sans Bold"],
+        "text-justify": "center",
+        "text-keep-upright": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [8, 9],
+            [11, 10],
+            [15, 14]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "minzoom": 8,
+      "paint": {
+        "icon-translate-anchor": "map",
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-translate-anchor": "map"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "name"]],
+      "id": "All-Road-Labels",
+      "layout": {
+        "icon-ignore-placement": false,
+        "icon-pitch-alignment": "auto",
+        "icon-text-fit": "both",
+        "symbol-placement": "line",
+        "symbol-spacing": 250,
+        "text-anchor": "center",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Bold"],
+        "text-justify": "center",
+        "text-size": {
+          "stops": [
+            [13, 8],
+            [15, 11],
+            [18, 14],
+            [19, 20],
+            [22, 28]
+          ]
+        },
+        "text-transform": "none",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": {
+          "stops": [
+            [13, 1],
+            [15, 1.2],
+            [18, 1.5],
+            [19, 2.5]
+          ]
+        },
+        "text-opacity": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "helipad"]],
+      "id": "Aeroway-Helipads",
+      "layout": {
+        "icon-image": {
+          "stops": [
+            [10, "heliport_11"],
+            [15, "heliport_15"]
+          ]
+        },
+        "text-font": ["Open Sans Regular"]
+      },
+      "maxzoom": 21,
+      "minzoom": 12,
+      "source": "LINZ Basemaps",
+      "source-layer": "aeroway",
+      "type": "symbol"
+    },
+    {
+      "id": "Housenumber",
+      "layout": {
+        "text-allow-overlap": false,
+        "text-anchor": "bottom",
+        "text-field": "{housenumber}",
+        "text-font": ["Roboto Bold Italic"],
+        "text-size": {
+          "stops": [
+            [17, 10],
+            [19, 12]
+          ]
+        }
+      },
+      "minzoom": 17,
+      "paint": {
+        "icon-color": "rgba(0, 0, 0, 1)",
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-color": "rgba(14, 14, 14, 1)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "housenumber",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all"],
+      "id": "Place-Names",
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-anchor": "center",
+        "icon-ignore-placement": false,
+        "icon-optional": false,
+        "icon-pitch-alignment": "auto",
+        "icon-text-fit": "both",
+        "symbol-avoid-edges": false,
+        "symbol-placement": "point",
+        "symbol-spacing": 1,
+        "symbol-z-order": "auto",
+        "text-allow-overlap": true,
+        "text-field": "{label}",
+        "text-font": ["Open Sans Bold"],
+        "text-ignore-placement": false,
+        "text-max-width": 100,
+        "text-optional": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-writing-mode": [],
+        "visibility": "visible"
+      },
+      "minzoom": 3,
+      "paint": {
+        "icon-color": "rgba(53, 53, 53, 1)",
+        "icon-halo-blur": 1,
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
+        "icon-halo-width": 1,
+        "icon-opacity": 1,
+        "text-color": {
+          "stops": [
+            [6, "rgba(35, 34, 34, 1)"],
+            [19, "rgba(111, 111, 111, 1)"]
+          ]
+        },
+        "text-halo-color": "rgba(255, 252, 252, 0.75)",
+        "text-halo-width": 2.5,
+        "text-translate-anchor": "viewport"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place_names",
+      "type": "symbol"
+    },
+    {
+      "id": "Place-Names-3-12",
+      "layout": {
+        "icon-ignore-placement": false,
+        "icon-rotation-alignment": "auto",
+        "text-anchor": "center",
+        "text-field": "{name}",
+        "text-font": ["Roboto Regular"],
+        "text-letter-spacing": {
+          "stops": [
+            [10, 0.08],
+            [13, 0.04],
+            [14, 0]
+          ]
+        },
+        "text-max-width": 6,
+        "text-offset": {
+          "stops": [
+            [4, [0, 1.75]],
+            [6, [0, 1.25]]
+          ]
+        },
+        "text-optional": true,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [2, 10],
+            [5, 16],
+            [8, 16],
+            [10, 17],
+            [12, 17],
+            [14, 17]
+          ]
+        },
+        "text-variable-anchor": ["top", "bottom-left"]
+      },
+      "maxzoom": 13,
+      "minzoom": 3,
+      "paint": {
+        "icon-color": {
+          "stops": [
+            [6, "rgba(53, 53, 53, 1)"],
+            [10, "rgba(53, 53, 53, 1)"]
+          ]
+        },
+        "icon-halo-blur": {
+          "stops": [
+            [13, 1],
+            [14, 0.5]
+          ]
+        },
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
+        "icon-opacity": 1,
+        "icon-translate-anchor": "viewport",
+        "text-color": "rgba(255, 252, 252, 1)",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(32, 32, 32, 1)",
+        "text-halo-width": {
+          "stops": [
+            [4, 1.5],
+            [9, 1.5]
+          ]
+        },
+        "text-opacity": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "place",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["has", "name"], ["==", "class", "track"], ["==", "track_use", "foot"]],
+      "id": "All-FootTrack-Labels",
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-anchor": "bottom",
+        "icon-ignore-placement": false,
+        "icon-image": "track_walking_pnt_fill",
+        "icon-offset": [0, -3],
+        "icon-pitch-alignment": "auto",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": {
+          "stops": [
+            [13, 1.2],
+            [20, 2]
+          ]
+        },
+        "icon-text-fit": "none",
+        "symbol-placement": "point",
+        "symbol-spacing": 100,
+        "text-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Semi Bold"],
+        "text-ignore-placement": false,
+        "text-justify": "center",
+        "text-max-width": 4,
+        "text-pitch-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-size": {
+          "stops": [
+            [13, 10],
+            [15, 12],
+            [18, 14],
+            [19, 30],
+            [22, 140]
+          ]
+        },
+        "text-transform": "none",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 0.8,
+        "text-opacity": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "grass"], ["==", "grass_type", "golf_course"]],
+      "id": "Landcover-GolfCourse-Symbol",
+      "layout": {
+        "icon-anchor": "right",
+        "icon-image": "golf_course_pnt_dual",
+        "icon-pitch-alignment": "viewport",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1.2,
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Semi Bold Italic"],
+        "text-justify": "left",
+        "text-max-width": 6,
+        "text-offset": [0.5, 0],
+        "text-size": 11,
+        "visibility": "visible"
+      },
+      "maxzoom": 20,
+      "minzoom": 12,
+      "paint": {
+        "text-color": "rgba(146, 201, 156, 1)",
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 0.8
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landcover",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "landfill"]],
+      "id": "Landuse-Landfill-Symbol",
+      "layout": {
+        "icon-anchor": "right",
+        "icon-image": "landfill_pnt",
+        "icon-size": {
+          "stops": [
+            [12, 1.2],
+            [16, 1.5]
+          ]
+        },
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-justify": "left",
+        "text-max-width": 4,
+        "text-offset": [0.5, 0],
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "minzoom": 13.5,
+      "paint": {
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(28, 25, 17, 1)",
+        "text-halo-width": 1.5
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "landuse",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "beacon"], ["==", "type", "lighthouse"]],
+      "id": "Poi-Beacon-Lighthouse",
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "icon-image": "beacon_lighthouse_land_pnt",
+        "icon-size": 1.3,
+        "text-allow-overlap": true,
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Semi Bold Italic"],
+        "text-justify": "right",
+        "text-size": 11
+      },
+      "maxzoom": 20,
+      "minzoom": 12,
+      "paint": {
+        "text-color": "rgba(255, 214, 150, 1)",
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 0.8,
+        "text-translate": [15, 0]
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["any", ["==", "class", "hut"]],
+      "id": "Poi-Hut-Label",
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": "building_pnt_hut",
+        "icon-size": 1.5,
+        "text-anchor": "left",
+        "text-field": {
+          "stops": [
+            [6, ""],
+            [15, "{name}"]
+          ]
+        },
+        "text-font": ["Open Sans Semi Bold"],
+        "text-justify": "left",
+        "text-max-width": 5,
+        "text-offset": [1, 0],
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "icon-opacity": 0.9,
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-color": "rgba(59, 55, 55, 1)",
+        "text-halo-width": 1.5
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "monument"]],
+      "id": "Poi-Monument",
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "icon-image": "monument_pnt",
+        "icon-size": {
+          "stops": [
+            [12, 1.2],
+            [16, 1.6]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-anchor": "left",
+        "text-field": "{name}",
+        "text-font": ["Open Sans Semi Bold Italic"],
+        "text-justify": "left",
+        "text-max-width": 5,
+        "text-offset": [1.5, 0],
+        "text-radial-offset": 0,
+        "text-size": 11,
+        "visibility": "visible"
+      },
+      "maxzoom": 20,
+      "minzoom": 12,
+      "paint": {
+        "icon-opacity": 0.85,
+        "text-color": "rgba(255, 214, 150, 1)",
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 0.8
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "railway"]],
+      "id": "Poi-Railway-Symbol",
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-anchor": "center",
+        "icon-image": "rail_station_train_diesel_pnt_red",
+        "icon-optional": true,
+        "icon-size": {
+          "stops": [
+            [12, 0.4],
+            [13, 1],
+            [20, 2]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-anchor": "left",
+        "text-field": {
+          "stops": [
+            [12, "{name}"],
+            [13, "{name}"]
+          ]
+        },
+        "text-font": ["Open Sans Bold Italic"],
+        "text-justify": "left",
+        "text-max-width": 5,
+        "text-offset": [1.25, 1.5],
+        "text-size": {
+          "stops": [
+            [13, 10],
+            [16, 10],
+            [17, 16],
+            [18, 19]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "text-color": "rgba(255, 255, 255, 1)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(16, 16, 16, 1)",
+        "text-halo-width": 1,
+        "text-translate": [0, -15]
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "rifle_range"]],
+      "id": "Poi-RifleRange-Label",
+      "layout": {
+        "icon-image": "rifle_range_pnt",
+        "icon-size": {
+          "stops": [
+            [12, 1.2],
+            [15, 1.5]
+          ]
+        },
+        "text-field": "",
+        "text-font": ["Open Sans Regular"],
+        "text-size": 9
+      },
+      "minzoom": 13,
+      "paint": {
+        "icon-opacity": {
+          "stops": [
+            [12, 0.25],
+            [13, 0.9]
+          ]
+        }
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "showground"]],
+      "id": "Poi-Showground-Symbol",
+      "layout": {
+        "icon-image": "showground_pnt",
+        "icon-size": {
+          "stops": [
+            [12, 1.2],
+            [16, 1.5]
+          ]
+        },
+        "text-field": "",
+        "text-font": ["Open Sans Bold Italic"],
+        "text-size": 9
+      },
+      "minzoom": 13.5,
+      "paint": {
+        "text-color": "rgba(121, 195, 128, 0.2)",
+        "text-halo-color": "rgba(255, 255, 255, 1)"
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": ["all", ["==", "class", "sports_field"]],
+      "id": "Poi-SportsField-Label",
+      "layout": {
+        "text-field": "{name}",
+        "text-font": ["Open Sans Semi Bold Italic"],
+        "text-size": 11
+      },
+      "minzoom": 13,
+      "paint": {
+        "text-color": "rgba(146, 201, 156, 1)",
+        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 1
+      },
+      "source": "LINZ Basemaps",
+      "source-layer": "poi",
+      "type": "symbol"
+    }
+  ],
+  "name": "label",
+  "sky": {
+    "atmosphere-blend": ["interpolate", ["linear"], ["zoom"], 0, 1, 10, 1, 12, 0],
+    "fog-color": "#e8e8e8",
+    "fog-ground-blend": 0.8,
+    "horizon-color": "#ecffff",
+    "horizon-fog-blend": 0.65,
+    "sky-color": "#77b5fe",
+    "sky-horizon-blend": 0.5
+  },
+  "sources": {
+    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic/EPSG:3857/tile.json" },
+  },
+  "sprite": "/v1/sprites/topographic",
+  "version": 8
+}

--- a/config/style/labels.json
+++ b/config/style/labels.json
@@ -1,6 +1,6 @@
 {
   "glyphs": "/v1/fonts/{fontstack}/{range}.pbf",
-  "id": "st_label",
+  "id": "st_labels",
   "layers": [
     {
       "filter": ["none", ["==", "parcel_intent", "Road"], ["==", "parcel_intent", "Hydro"]],
@@ -1382,7 +1382,7 @@
       "type": "symbol"
     }
   ],
-  "name": "label",
+  "name": "labels",
   "sky": {
     "atmosphere-blend": ["interpolate", ["linear"], ["zoom"], 0, 1, 10, 1, 12, 0],
     "fog-color": "#e8e8e8",


### PR DESCRIPTION
### Motivation

It would be nice to layer all the vector data ontop of all the individual aerial imagery datasets that we have.

### Modifications

Add a "labels" style which has no base layer and overlays labels and roads.

### Verification

When it is deployed we can verify it looks good across all the individual layers.