### PR TITLE
fix(vector): replace missing fonts BM-1091

### DIFF
--- a/config/style/aerialhybrid.json
+++ b/config/style/aerialhybrid.json
@@ -1488,7 +1488,7 @@
         },
         "text-anchor": "left",
         "text-field": "{name}",
-        "text-font": ["Roboto Condensed Italic"],
+        "text-font": ["Roboto Light Italic"],
         "text-justify": "left",
         "text-max-width": 4,
         "text-offset": [0.5, 0],

--- a/config/style/labels.json
+++ b/config/style/labels.json
@@ -1482,7 +1482,7 @@
         },
         "text-anchor": "left",
         "text-field": "{name}",
-        "text-font": ["Roboto Condensed Italic"],
+        "text-font": ["Roboto Light Italic"],
         "text-justify": "left",
         "text-max-width": 4,
         "text-offset": [0.5, 0],


### PR DESCRIPTION
### Motivation

In both the `aerialhybrid.json` and `labels.json` stylesheets, the `landfill` layer references an unsupported font.

### Modifications

For both stylesheets, I have updated the `landfill` layer's `text-font` key-value pair:

| Before | After |
| - | - |
| `Roboto Condensed Italic` | `Roboto Light Italic` |

> Note: The `landfill` layer is also only one referencing the `Roboto Condensed Italic` font.

### Verification

Before, tiles containing a `landfill` layer element would not render because of the unsupported font.

| Before |
| - |
| ![image](https://github.com/user-attachments/assets/f2e820c8-a1fb-4d95-b057-54f1c10f013a) |

Now, such tiles render without issue.

| After |
| - |
| ![image](https://github.com/user-attachments/assets/f834bc48-46fa-4809-ade1-9694a797d24b)|

Path used for testing: `/@-41.1653803,174.9997225,z14.50?style=labels&i=topographic`