### PR TITLE
feat(elevation): reorder based on island then date

### DIFF
--- a/config/tileset/elevation.json
+++ b/config/tileset/elevation.json
@@ -12,6 +12,20 @@
       "name": "new-zealand_2012_dem_8m"
     },
     {
+      "2193": "s3://nz-elevation/wellington/wellington_2013-2014/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/wellington_2013-2014_dem_1m/01HZ67MBQJ8VASM6Z69PMATPHH/",
+      "minZoom": 9,
+      "title": "Wellington LiDAR 1m DEM (2013-2014)",
+      "name": "wellington_2013-2014_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2015-2016/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2015-2016_dem_1m/01HZ65XSK73Z8GBSTWJ6SKYGGV/",
+      "minZoom": 9,
+      "title": "Manawatū-Whanganui LiDAR 1m DEM (2015-2016)",
+      "name": "manawatu-whanganui_2015-2016_dem_1m"
+    },
+    {
       "2193": "s3://nz-elevation/auckland/auckland-south_2016-2017/dem_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/auckland-south_2016-2017_dem_1m/01HZ64YZW62RJVDK4331QAFTHH/",
       "minZoom": 9,
@@ -24,6 +38,97 @@
       "minZoom": 9,
       "title": "Auckland North LiDAR 1m DEM (2016-2018)",
       "name": "auckland-north_2016-2018_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/manawatu-whanganui/palmerston-north_2018/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/palmerston-north_2018_dem_1m/01HZ6645STRC0SK7W50BZ5PG0S/",
+      "minZoom": 9,
+      "title": "Manawatū-Whanganui - Palmerston North LiDAR 1m DEM (2018)",
+      "name": "palmerston-north_2018_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/huntly_2015-2019/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/huntly_2015-2019_dem_1m/01HZ67C43AKY44WM7R0YKA3ZDF/",
+      "minZoom": 9,
+      "title": "Waikato - Huntly LiDAR 1m DEM (2015-2019)",
+      "name": "huntly_2015-2019_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/thames_2017-2019/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/thames_2017-2019_dem_1m/01HZ67CB7CEZX0JYWJ38N3920E/",
+      "minZoom": 9,
+      "title": "Waikato - Thames LiDAR 1m DEM (2017-2019)",
+      "name": "thames_2017-2019_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/reporoa-and-upper-piako-river_2019/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/reporoa-and-upper-piako-river_2019_dem_1m/01HZ67C4MCA93ZQ93RH99DQ872/",
+      "minZoom": 9,
+      "title": "Waikato - Reporoa and Upper Piako River LiDAR 1m DEM (2019)",
+      "name": "reporoa-and-upper-piako-river_2019_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/northland/northland_2018-2020/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/northland_2018-2020_dem_1m/01HZ66GGG01VJJDT3WMRSFCADF/",
+      "minZoom": 9,
+      "title": "Northland LiDAR 1m DEM (2018-2020)",
+      "name": "northland_2018-2020_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/wellington-city_2019-2020/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/wellington-city_2019-2020_dem_1m/01HZ67KCCZYYV6T93H51WPTDMF/",
+      "minZoom": 9,
+      "title": "Wellington City LiDAR 1m DEM (2019-2020)",
+      "name": "wellington-city_2019-2020_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/manawatu-whanganui/whanganui-urban_2020-2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/whanganui-urban_2020-2021_dem_1m/01HZ66357NCHDTAYYW4KNEHX3N/",
+      "minZoom": 9,
+      "title": "Manawatū-Whanganui - Whanganui Urban LiDAR 1m DEM (2020-2021)",
+      "name": "whanganui-urban_2020-2021_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/hawkes-bay/hawkes-bay_2020-2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hawkes-bay_2020-2021_dem_1m/01HZ65X24J7RSQCPERN7HADX6N/",
+      "minZoom": 9,
+      "title": "Hawke's Bay LiDAR 1m DEM (2020-2021)",
+      "name": "hawkes-bay_2020-2021_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/waikato_2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/waikato_2021_dem_1m/01J546JDQCQ0H9735NHN4P903W/",
+      "minZoom": 9,
+      "title": "Waikato LiDAR 1m DEM (2021)",
+      "name": "waikato_2021_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/taranaki/taranaki_2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/taranaki_2021_dem_1m/01HZ66YA59N5Q9GKXP1ZAPHKK3/",
+      "minZoom": 9,
+      "title": "Taranaki LiDAR 1m DEM (2021)",
+      "name": "taranaki_2021_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/hutt-city_2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hutt-city_2021_dem_1m/01HZ67GF9ZANVBZW5PEM98V0T7/",
+      "minZoom": 9,
+      "title": "Wellington - Hutt City LiDAR 1m DEM (2021)",
+      "name": "hutt-city_2021_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/kapiti-coast_2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/kapiti-coast_2021_dem_1m/01HZ5W74E8B1DF2B0MDSKSTSTV/",
+      "minZoom": 9,
+      "title": "Wellington - Kāpiti Coast LiDAR 1m DEM (2021)",
+      "name": "kapiti-coast_2021_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/upper-hutt-city_2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/upper-hutt-city_2021_dem_1m/01HZ67GZ5R61GX6QTAQT5NMQ7P/",
+      "minZoom": 9,
+      "title": "Wellington - Upper Hutt City LiDAR 1m DEM (2021)",
+      "name": "upper-hutt-city_2021_dem_1m"
     },
     {
       "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2019-2022/dem_1m/2193/",
@@ -40,6 +145,62 @@
       "name": "tauranga_2022_dem_1m"
     },
     {
+      "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2022-2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2022-2023_dem_1m/01HZ66026FD0WJWVWV9V3ABQGZ/",
+      "minZoom": 9,
+      "title": "Manawatū-Whanganui LiDAR 1m DEM (2022-2023)",
+      "name": "manawatu-whanganui_2022-2023_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/porirua_2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/porirua_2023_dem_1m/01HZ67GXY4ZRC1F1F3GA5BHG8H/",
+      "minZoom": 9,
+      "title": "Wellington - Porirua LiDAR 1m DEM (2023)",
+      "name": "porirua_2023_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/hamilton_2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hamilton_2023_dem_1m/01HZ67AXVJ9N35PFNBE5HX6KFW/",
+      "minZoom": 9,
+      "title": "Waikato - Hamilton LiDAR 1m DEM (2023)",
+      "name": "hamilton_2023_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/gisborne/gisborne_2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/gisborne_2023_dem_1m/01HZ65SHA9XRZP0PRX1GMSMDD0/",
+      "minZoom": 9,
+      "title": "Gisborne LiDAR 1m DEM (2023)",
+      "name": "gisborne_2023_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/hawkes-bay/hawkes-bay_2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hawkes-bay_2023_dem_1m/01HZ65XM69XGJMGXJKQ1EHRG8D/",
+      "minZoom": 9,
+      "title": "Hawke's Bay LiDAR 1m DEM (2023) - Draft",
+      "name": "hawkes-bay_2023_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/waikato_2024/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/waikato_2024_dem_1m/01JA9CKCVM0GB17HX9Y33SH8G8/",
+      "minZoom": 9,
+      "title": "Waikato LiDAR 1m DEM (2024)",
+      "name": "waikato_2024_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2024/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/bay-of-plenty_2024_dem_1m/01JA9CJB2TTJ1YGMAFY5DS2D86/",
+      "minZoom": 9,
+      "title": "Bay of Plenty LiDAR 1m DEM (2024)",
+      "name": "bay-of-plenty_2024_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/tasman_2008-2015/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/tasman_2008-2015_dem_1m/01HZ676DYQAVNGE6XJ7FVRS8F8/",
+      "minZoom": 9,
+      "title": "Nelson and Tasman LiDAR 1m DEM (2008-2015)",
+      "name": "tasman_2008-2015_dem_1m"
+    },
+    {
       "2193": "s3://nz-elevation/canterbury/hurunui-rivers_2013/dem_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hurunui-rivers_2013_dem_1m/01HZ65DX33BAHRC5XBJMFKE0Z1/",
       "minZoom": 9,
@@ -52,6 +213,20 @@
       "minZoom": 9,
       "title": "Canterbury - Timaru Rivers LiDAR 1m DEM (2014)",
       "name": "timaru-rivers_2014_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/marlborough/blenheim_2014/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/blenheim_2014_dem_1m/01HZ666NDGVZXZ7M52VPQF1XRV/",
+      "minZoom": 9,
+      "title": "Marlborough - Blenheim LiDAR 1m DEM (2014)",
+      "name": "blenheim_2014_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/richmond-and-motueka_2015/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/richmond-and-motueka_2015_dem_1m/01HZ675GM81HZTFKGZEAREFXZC/",
+      "minZoom": 9,
+      "title": "Tasman - Richmond and Motueka LiDAR 1m DEM (2015)",
+      "name": "richmond-and-motueka_2015_dem_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/hawarden_2015/dem_1m/2193/",
@@ -68,160 +243,6 @@
       "name": "mackenzie_2015_dem_1m"
     },
     {
-      "2193": "s3://nz-elevation/canterbury/canterbury_2016-2017/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2016-2017_dem_1m/01HZ64YZT7YJN6K8BDMAMBN4RS/",
-      "minZoom": 9,
-      "title": "Canterbury LiDAR 1m DEM (2016-2017)",
-      "name": "canterbury_2016-2017_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/kaikoura_2016-2017/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/kaikoura_2016-2017_dem_1m/01HZ65GD9PHB1WR0JSTFGSMVER/",
-      "minZoom": 9,
-      "title": "Canterbury - Kaikōura LiDAR 1m DEM (2016-2017)",
-      "name": "kaikoura_2016-2017_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/canterbury_2018-2019/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2018-2019_dem_1m/01HZ65500HBTB4VS48JRK03SXD/",
-      "minZoom": 9,
-      "title": "Canterbury LiDAR 1m DEM (2018-2019)",
-      "name": "canterbury_2018-2019_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/christchurch_2020-2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/christchurch_2020-2021_dem_1m/01HZ65DFG13DXY0WGMR8M43N2P/",
-      "minZoom": 9,
-      "title": "Canterbury - Christchurch LiDAR 1m DEM (2020-2021)",
-      "name": "christchurch_2020-2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/canterbury_2020-2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2020-2023_dem_1m/01HZ656J6KSFB7KF6W8PBG8DRE/",
-      "minZoom": 9,
-      "title": "Canterbury LiDAR 1m DEM (2020-2023)",
-      "name": "canterbury_2020-2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/kaikoura-and-waimakariri_2022/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/kaikoura-and-waimakariri_2022_dem_1m/01HZ65G6BN1MF98CK9BRVG67ES/",
-      "minZoom": 9,
-      "title": "Canterbury - Kaikōura and Waimakariri LiDAR 1m DEM (2022)",
-      "name": "kaikoura-and-waimakariri_2022_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/banks-peninsula_2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/banks-peninsula_2023_dem_1m/01HZ64YZW6ZYDFY5X9NE7SMHW5/",
-      "minZoom": 9,
-      "title": "Canterbury - Banks Peninsula LiDAR 1m DEM (2023)",
-      "name": "banks-peninsula_2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/selwyn_2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/selwyn_2023_dem_1m/01HZ65NMH4R9DPKJA0HMEKH0TP/",
-      "minZoom": 9,
-      "title": "Canterbury - Selwyn LiDAR 1m DEM (2023)",
-      "name": "selwyn_2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/waimakariri_2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/waimakariri_2023_dem_1m/01HZ65QH9TEZV22HRV8TZS7R1Y/",
-      "minZoom": 9,
-      "title": "Canterbury - Waimakariri LiDAR 1m DEM (2023)",
-      "name": "waimakariri_2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/gisborne/gisborne_2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/gisborne_2023_dem_1m/01HZ65SHA9XRZP0PRX1GMSMDD0/",
-      "minZoom": 9,
-      "title": "Gisborne LiDAR 1m DEM (2023)",
-      "name": "gisborne_2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/hawkes-bay/hawkes-bay_2020-2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/hawkes-bay_2020-2021_dem_1m/01HZ65X24J7RSQCPERN7HADX6N/",
-      "minZoom": 9,
-      "title": "Hawke's Bay LiDAR 1m DEM (2020-2021)",
-      "name": "hawkes-bay_2020-2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/hawkes-bay/hawkes-bay_2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/hawkes-bay_2023_dem_1m/01HZ65XM69XGJMGXJKQ1EHRG8D/",
-      "minZoom": 9,
-      "title": "Hawke's Bay LiDAR 1m DEM (2023) - Draft",
-      "name": "hawkes-bay_2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2015-2016/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2015-2016_dem_1m/01HZ65XSK73Z8GBSTWJ6SKYGGV/",
-      "minZoom": 9,
-      "title": "Manawatū-Whanganui LiDAR 1m DEM (2015-2016)",
-      "name": "manawatu-whanganui_2015-2016_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/manawatu-whanganui/palmerston-north_2018/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/palmerston-north_2018_dem_1m/01HZ6645STRC0SK7W50BZ5PG0S/",
-      "minZoom": 9,
-      "title": "Manawatū-Whanganui - Palmerston North LiDAR 1m DEM (2018)",
-      "name": "palmerston-north_2018_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/manawatu-whanganui/whanganui-urban_2020-2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/whanganui-urban_2020-2021_dem_1m/01HZ66357NCHDTAYYW4KNEHX3N/",
-      "minZoom": 9,
-      "title": "Manawatū-Whanganui - Whanganui Urban LiDAR 1m DEM (2020-2021)",
-      "name": "whanganui-urban_2020-2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2022-2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2022-2023_dem_1m/01HZ66026FD0WJWVWV9V3ABQGZ/",
-      "minZoom": 9,
-      "title": "Manawatū-Whanganui LiDAR 1m DEM (2022-2023)",
-      "name": "manawatu-whanganui_2022-2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/marlborough/blenheim_2014/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/blenheim_2014_dem_1m/01HZ666NDGVZXZ7M52VPQF1XRV/",
-      "minZoom": 9,
-      "title": "Marlborough - Blenheim LiDAR 1m DEM (2014)",
-      "name": "blenheim_2014_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/marlborough/marlborough_2018/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/marlborough_2018_dem_1m/01HZ667FEBVQ7KVJME1FWH20NK/",
-      "minZoom": 9,
-      "title": "Marlborough LiDAR 1m DEM (2018)",
-      "name": "marlborough_2018_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/marlborough/marlborough_2020-2022/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/marlborough_2020-2022_dem_1m/01HZ66AMW595EGWGQ28C0DBBQR/",
-      "minZoom": 9,
-      "title": "Marlborough LiDAR 1m DEM (2020-2022)",
-      "name": "marlborough_2020-2022_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/nelson/nelson_2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/nelson_2021_dem_1m/01HZ66ASZZQZE5WXS8J1C68KM7/",
-      "minZoom": 9,
-      "title": "Nelson LiDAR 1m DEM (2021)",
-      "name": "nelson_2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/nelson/top-of-the-south-flood_2022/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/top-of-the-south-flood_2022_dem_1m/01HZ66DDCRHQNZFM5H6WQFAB3N/",
-      "minZoom": 9,
-      "title": "Nelson and Tasman - Top of the South Flood LiDAR 1m DEM (2022)",
-      "name": "top-of-the-south-flood_2022_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/northland/northland_2018-2020/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/northland_2018-2020_dem_1m/01HZ66GGG01VJJDT3WMRSFCADF/",
-      "minZoom": 9,
-      "title": "Northland LiDAR 1m DEM (2018-2020)",
-      "name": "northland_2018-2020_dem_1m"
-    },
-    {
       "2193": "s3://nz-elevation/otago/otago_2016/dem_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/otago_2016_dem_1m/01HZ66PY2EZ4GX639DGY276ZZ3/",
       "minZoom": 9,
@@ -236,11 +257,67 @@
       "name": "queenstown_2016_dem_1m"
     },
     {
+      "2193": "s3://nz-elevation/canterbury/kaikoura_2016-2017/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/kaikoura_2016-2017_dem_1m/01HZ65GD9PHB1WR0JSTFGSMVER/",
+      "minZoom": 9,
+      "title": "Canterbury - Kaikōura LiDAR 1m DEM (2016-2017)",
+      "name": "kaikoura_2016-2017_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/canterbury_2016-2017/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2016-2017_dem_1m/01HZ64YZT7YJN6K8BDMAMBN4RS/",
+      "minZoom": 9,
+      "title": "Canterbury LiDAR 1m DEM (2016-2017)",
+      "name": "canterbury_2016-2017_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/golden-bay_2017/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/golden-bay_2017_dem_1m/01HZ671SY2RBC3K2W8CDQQ298V/",
+      "minZoom": 9,
+      "title": "Tasman - Golden Bay LiDAR 1m DEM (2017)",
+      "name": "golden-bay_2017_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/marlborough/marlborough_2018/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/marlborough_2018_dem_1m/01HZ667FEBVQ7KVJME1FWH20NK/",
+      "minZoom": 9,
+      "title": "Marlborough LiDAR 1m DEM (2018)",
+      "name": "marlborough_2018_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/motueka-river-valley_2018-2019/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/motueka-river-valley_2018-2019_dem_1m/01HZ673XVQGY3D0YG53CC074KW/",
+      "minZoom": 9,
+      "title": "Tasman - Motueka River Valley LiDAR 1m DEM (2018-2019)",
+      "name": "motueka-river-valley_2018-2019_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/canterbury_2018-2019/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2018-2019_dem_1m/01HZ65500HBTB4VS48JRK03SXD/",
+      "minZoom": 9,
+      "title": "Canterbury LiDAR 1m DEM (2018-2019)",
+      "name": "canterbury_2018-2019_dem_1m"
+    },
+    {
       "2193": "s3://nz-elevation/otago/balclutha_2020/dem_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/balclutha_2020_dem_1m/01HZ66HSTHR2N3B3923KX8812H/",
       "minZoom": 9,
       "title": "Otago - Balclutha LiDAR 1m DEM (2020)",
       "name": "balclutha_2020_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/christchurch_2020-2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/christchurch_2020-2021_dem_1m/01HZ65DFG13DXY0WGMR8M43N2P/",
+      "minZoom": 9,
+      "title": "Canterbury - Christchurch LiDAR 1m DEM (2020-2021)",
+      "name": "christchurch_2020-2021_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/nelson/nelson_2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/nelson_2021_dem_1m/01HZ66ASZZQZE5WXS8J1C68KM7/",
+      "minZoom": 9,
+      "title": "Nelson LiDAR 1m DEM (2021)",
+      "name": "nelson_2021_dem_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/central-otago_2021/dem_1m/2193/",
@@ -271,6 +348,55 @@
       "name": "queenstown_2021_dem_1m"
     },
     {
+      "2193": "s3://nz-elevation/southland/stewart-island-rakiura-oban_2021/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/stewart-island-rakiura-oban_2021_dem_1m/01HZ66Y0NMZ6WTCYKC7PE01D8J/",
+      "minZoom": 9,
+      "title": "Stewart Island / Rakiura - Oban LiDAR 1m DEM (2021)",
+      "name": "stewart-island-rakiura-oban_2021_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/tasman_2020-2022/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/tasman_2020-2022_dem_1m/01HZ677D4DM9DQWB4ADK2M3RK8/",
+      "minZoom": 9,
+      "title": "Tasman LiDAR 1m DEM (2020-2022)",
+      "name": "tasman_2020-2022_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/marlborough/marlborough_2020-2022/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/marlborough_2020-2022_dem_1m/01HZ66AMW595EGWGQ28C0DBBQR/",
+      "minZoom": 9,
+      "title": "Marlborough LiDAR 1m DEM (2020-2022)",
+      "name": "marlborough_2020-2022_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/west-coast/west-coast_2020-2022/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/west-coast_2020-2022_dem_1m/01HZ67MBE87WF9VN3N2M4Z8S1N/",
+      "minZoom": 9,
+      "title": "West Coast LiDAR 1m DEM (2020-2022)",
+      "name": "west-coast_2020-2022_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/tasman-bay_2022/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/tasman-bay_2022_dem_1m/01HZ675SWB6MVKB2BBAYYNB53R/",
+      "minZoom": 9,
+      "title": "Tasman - Tasman Bay LiDAR 1m DEM (2022)",
+      "name": "tasman-bay_2022_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/nelson/top-of-the-south-flood_2022/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/top-of-the-south-flood_2022_dem_1m/01HZ66DDCRHQNZFM5H6WQFAB3N/",
+      "minZoom": 9,
+      "title": "Nelson and Tasman - Top of the South Flood LiDAR 1m DEM (2022)",
+      "name": "top-of-the-south-flood_2022_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/kaikoura-and-waimakariri_2022/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/kaikoura-and-waimakariri_2022_dem_1m/01HZ65G6BN1MF98CK9BRVG67ES/",
+      "minZoom": 9,
+      "title": "Canterbury - Kaikōura and Waimakariri LiDAR 1m DEM (2022)",
+      "name": "kaikoura-and-waimakariri_2022_dem_1m"
+    },
+    {
       "2193": "s3://nz-elevation/otago/central-otago_2022-2023/dem_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/central-otago_2022-2023_dem_1m/01HZ66M5EX3NW8J7569JS3TQKR/",
       "minZoom": 9,
@@ -283,69 +409,6 @@
       "minZoom": 9,
       "title": "Otago - Wanaka LiDAR 1m DEM (2022-2023)",
       "name": "wanaka_2022-2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/southland/southland_2020-2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/southland_2020-2023_dem_1m/01J9Q42DGRE9P73Y8ZRVJX2J4J/",
-      "minZoom": 9,
-      "title": "Southland LiDAR 1m DEM (2020-2023)",
-      "name": "southland_2020-2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/southland/stewart-island-rakiura-oban_2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/stewart-island-rakiura-oban_2021_dem_1m/01HZ66Y0NMZ6WTCYKC7PE01D8J/",
-      "minZoom": 9,
-      "title": "Stewart Island / Rakiura - Oban LiDAR 1m DEM (2021)",
-      "name": "stewart-island-rakiura-oban_2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/taranaki/taranaki_2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/taranaki_2021_dem_1m/01HZ66YA59N5Q9GKXP1ZAPHKK3/",
-      "minZoom": 9,
-      "title": "Taranaki LiDAR 1m DEM (2021)",
-      "name": "taranaki_2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/tasman/tasman_2008-2015/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/tasman_2008-2015_dem_1m/01HZ676DYQAVNGE6XJ7FVRS8F8/",
-      "minZoom": 9,
-      "title": "Nelson and Tasman LiDAR 1m DEM (2008-2015)",
-      "name": "tasman_2008-2015_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/tasman/richmond-and-motueka_2015/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/richmond-and-motueka_2015_dem_1m/01HZ675GM81HZTFKGZEAREFXZC/",
-      "minZoom": 9,
-      "title": "Tasman - Richmond and Motueka LiDAR 1m DEM (2015)",
-      "name": "richmond-and-motueka_2015_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/tasman/golden-bay_2017/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/golden-bay_2017_dem_1m/01HZ671SY2RBC3K2W8CDQQ298V/",
-      "minZoom": 9,
-      "title": "Tasman - Golden Bay LiDAR 1m DEM (2017)",
-      "name": "golden-bay_2017_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/tasman/motueka-river-valley_2018-2019/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/motueka-river-valley_2018-2019_dem_1m/01HZ673XVQGY3D0YG53CC074KW/",
-      "minZoom": 9,
-      "title": "Tasman - Motueka River Valley LiDAR 1m DEM (2018-2019)",
-      "name": "motueka-river-valley_2018-2019_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/tasman/tasman_2020-2022/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/tasman_2020-2022_dem_1m/01HZ677D4DM9DQWB4ADK2M3RK8/",
-      "minZoom": 9,
-      "title": "Tasman LiDAR 1m DEM (2020-2022)",
-      "name": "tasman_2020-2022_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/tasman/tasman-bay_2022/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/tasman-bay_2022_dem_1m/01HZ675SWB6MVKB2BBAYYNB53R/",
-      "minZoom": 9,
-      "title": "Tasman - Tasman Bay LiDAR 1m DEM (2022)",
-      "name": "tasman-bay_2022_dem_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2023/dem_1m/2193/",
@@ -362,88 +425,32 @@
       "name": "waimea-dam_2023_dem_1m"
     },
     {
-      "2193": "s3://nz-elevation/waikato/huntly_2015-2019/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/huntly_2015-2019_dem_1m/01HZ67C43AKY44WM7R0YKA3ZDF/",
+      "2193": "s3://nz-elevation/canterbury/banks-peninsula_2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/banks-peninsula_2023_dem_1m/01HZ64YZW6ZYDFY5X9NE7SMHW5/",
       "minZoom": 9,
-      "title": "Waikato - Huntly LiDAR 1m DEM (2015-2019)",
-      "name": "huntly_2015-2019_dem_1m"
+      "title": "Canterbury - Banks Peninsula LiDAR 1m DEM (2023)",
+      "name": "banks-peninsula_2023_dem_1m"
     },
     {
-      "2193": "s3://nz-elevation/waikato/thames_2017-2019/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/thames_2017-2019_dem_1m/01HZ67CB7CEZX0JYWJ38N3920E/",
+      "2193": "s3://nz-elevation/canterbury/selwyn_2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/selwyn_2023_dem_1m/01HZ65NMH4R9DPKJA0HMEKH0TP/",
       "minZoom": 9,
-      "title": "Waikato - Thames LiDAR 1m DEM (2017-2019)",
-      "name": "thames_2017-2019_dem_1m"
+      "title": "Canterbury - Selwyn LiDAR 1m DEM (2023)",
+      "name": "selwyn_2023_dem_1m"
     },
     {
-      "2193": "s3://nz-elevation/waikato/reporoa-and-upper-piako-river_2019/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/reporoa-and-upper-piako-river_2019_dem_1m/01HZ67C4MCA93ZQ93RH99DQ872/",
+      "2193": "s3://nz-elevation/canterbury/waimakariri_2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/waimakariri_2023_dem_1m/01HZ65QH9TEZV22HRV8TZS7R1Y/",
       "minZoom": 9,
-      "title": "Waikato - Reporoa and Upper Piako River LiDAR 1m DEM (2019)",
-      "name": "reporoa-and-upper-piako-river_2019_dem_1m"
+      "title": "Canterbury - Waimakariri LiDAR 1m DEM (2023)",
+      "name": "waimakariri_2023_dem_1m"
     },
     {
-      "2193": "s3://nz-elevation/waikato/waikato_2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/waikato_2021_dem_1m/01J546JDQCQ0H9735NHN4P903W/",
+      "2193": "s3://nz-elevation/southland/southland_2020-2023/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/southland_2020-2023_dem_1m/01J9Q42DGRE9P73Y8ZRVJX2J4J/",
       "minZoom": 9,
-      "title": "Waikato LiDAR 1m DEM (2021)",
-      "name": "waikato_2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/waikato/hamilton_2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/hamilton_2023_dem_1m/01HZ67AXVJ9N35PFNBE5HX6KFW/",
-      "minZoom": 9,
-      "title": "Waikato - Hamilton LiDAR 1m DEM (2023)",
-      "name": "hamilton_2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/wellington/wellington_2013-2014/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/wellington_2013-2014_dem_1m/01HZ67MBQJ8VASM6Z69PMATPHH/",
-      "minZoom": 9,
-      "title": "Wellington LiDAR 1m DEM (2013-2014)",
-      "name": "wellington_2013-2014_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/wellington/wellington-city_2019-2020/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/wellington-city_2019-2020_dem_1m/01HZ67KCCZYYV6T93H51WPTDMF/",
-      "minZoom": 9,
-      "title": "Wellington City LiDAR 1m DEM (2019-2020)",
-      "name": "wellington-city_2019-2020_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/wellington/hutt-city_2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/hutt-city_2021_dem_1m/01HZ67GF9ZANVBZW5PEM98V0T7/",
-      "minZoom": 9,
-      "title": "Wellington - Hutt City LiDAR 1m DEM (2021)",
-      "name": "hutt-city_2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/wellington/kapiti-coast_2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/kapiti-coast_2021_dem_1m/01HZ5W74E8B1DF2B0MDSKSTSTV/",
-      "minZoom": 9,
-      "title": "Wellington - Kāpiti Coast LiDAR 1m DEM (2021)",
-      "name": "kapiti-coast_2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/wellington/upper-hutt-city_2021/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/upper-hutt-city_2021_dem_1m/01HZ67GZ5R61GX6QTAQT5NMQ7P/",
-      "minZoom": 9,
-      "title": "Wellington - Upper Hutt City LiDAR 1m DEM (2021)",
-      "name": "upper-hutt-city_2021_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/wellington/porirua_2023/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/porirua_2023_dem_1m/01HZ67GXY4ZRC1F1F3GA5BHG8H/",
-      "minZoom": 9,
-      "title": "Wellington - Porirua LiDAR 1m DEM (2023)",
-      "name": "porirua_2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/west-coast/west-coast_2020-2022/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/west-coast_2020-2022_dem_1m/01HZ67MBE87WF9VN3N2M4Z8S1N/",
-      "minZoom": 9,
-      "title": "West Coast LiDAR 1m DEM (2020-2022)",
-      "name": "west-coast_2020-2022_dem_1m"
+      "title": "Southland LiDAR 1m DEM (2020-2023)",
+      "name": "southland_2020-2023_dem_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2020-2023/dem_1m/2193/",
@@ -451,20 +458,6 @@
       "minZoom": 9,
       "title": "Canterbury LiDAR 1m DEM (2020-2023)",
       "name": "canterbury_2020-2023_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/waikato/waikato_2024/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/waikato_2024_dem_1m/01JA9CKCVM0GB17HX9Y33SH8G8/",
-      "minZoom": 9,
-      "title": "Waikato LiDAR 1m DEM (2024)",
-      "name": "waikato_2024_dem_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2024/dem_1m/2193/",
-      "3857": "s3://linz-basemaps/elevation/3857/bay-of-plenty_2024_dem_1m/01JA9CJB2TTJ1YGMAFY5DS2D86/",
-      "minZoom": 9,
-      "title": "Bay of Plenty LiDAR 1m DEM (2024)",
-      "name": "bay-of-plenty_2024_dem_1m"
     }
   ],
   "outputs": [


### PR DESCRIPTION
### Motivation

The elevation config was originally ordered by region then date, however many regions overlap and it is difficult to work out what the order should be between regions.

### Modifications

Reordered the config by island (North/South) then date.

### Verification

Will check National 1m DEM after this is merged.