### PR TITLE
ci: store a 'latest' assets file in AWS S3 BM-1094

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,7 @@ jobs:
 
           echo ${ASSETS_LOCATION_PROD}
 
+          aws s3 cp assets-current.tar.co s3://linz-basemaps/assets/assets-latest.tar.co
           aws s3 cp assets-current.tar.co ${ASSETS_LOCATION_PROD}
 
           ./scripts/bmc.sh ./index.cjs bundle --config $PWD/config-current.json.gz --output $PWD/config-prod.json --assets ${ASSETS_LOCATION_PROD} --cache s3://linz-basemaps-staging/basemaps-config/cache/


### PR DESCRIPTION
### Motivation

As a Basemaps developer, having to look up the path to the most recent **`assets.tar.co`** file stored in **AWS S3** is inconvenient. It would save me time and effort if a copy of the latest assets file were stored in a fixed location with a fixed name, similar to the bundled config file (`config-latest.json.gz`).

#### Context

When I run **Basemaps** locally, it's not always the case that I can run the **`basemaps/server`** package using the **`config-latest.json.gz`** file. For example, if I make changes to the vector tile stylesheets and want to test them locally, I need to bundle the config file myself. To do so, I have to specify the `--assets` parameter to enable fonts, glyphs, and sprites. Otherwise, they will not load on the map.

#### Solution

Currently, assets files are uploaded to **AWS S3** with a hash suffix. Remembering such a hash is unrealistic. It would be ideal if there were an **`assets-latest.tar.co`** file stored within the `/assets` directory, similar to how a **`config-latest.json.gz`** file is stored within the `/config` directory.

| `s3://linz-basemaps/...` | Sorted by Last Modified |
| - | - |
| `config/`| ![][config_img] |
| `assets/`| ![][assets_img] |

### Modifications

1. Updated the **`build`** workflow so that it stores a copy of the current assets at the following location in **AWS S3**:

```
s3://linz-basemaps/assets/assets-latest.tar.co
```

[config_img]: https://github.com/user-attachments/assets/5335da73-0260-42f6-8c30-8937256d0f18
[assets_img]: https://github.com/user-attachments/assets/b6d8738a-da04-4bb3-9ae1-edb66f8e2446