### PR TITLE
fix(vector): update helipad icon-image symbol BM-1095

### DIFF
--- a/config/style/aerialhybrid.json
+++ b/config/style/aerialhybrid.json
@@ -904,15 +904,7 @@
     {
       "filter": ["all", ["==", "class", "helipad"]],
       "id": "Aeroway-Helipads",
-      "layout": {
-        "icon-image": {
-          "stops": [
-            [10, "heliport_11"],
-            [15, "heliport_15"]
-          ]
-        },
-        "text-font": ["Open Sans Regular"]
-      },
+      "layout": { "icon-image": "helipad_pnt_fill", "icon-size": 1.25, "text-font": ["Open Sans Regular"] },
       "maxzoom": 21,
       "minzoom": 12,
       "source": "LINZ Basemaps",

--- a/config/style/labels.json
+++ b/config/style/labels.json
@@ -898,15 +898,7 @@
     {
       "filter": ["all", ["==", "class", "helipad"]],
       "id": "Aeroway-Helipads",
-      "layout": {
-        "icon-image": {
-          "stops": [
-            [10, "heliport_11"],
-            [15, "heliport_15"]
-          ]
-        },
-        "text-font": ["Open Sans Regular"]
-      },
+      "layout": { "icon-image": "helipad_pnt_fill", "icon-size": 1.25, "text-font": ["Open Sans Regular"] },
       "maxzoom": 21,
       "minzoom": 12,
       "source": "LINZ Basemaps",


### PR DESCRIPTION
### Motivation

As a **Basemaps** user, when I view the [**Aerial** layer][aerial] with labels enabled, I cannot identify **helipad** locations like I can when viewing the [**Topographic** layer][topographic].

| Layer | Topographic | Aerial (Labels on) |
| - | - | - |
| Screenshot | ![][img_1] | ![][img_2] |
| Console | (No sprite file errors or warnings) |  ![][img_3] | 

#### Sprite files

When we compare the `Aeroway-Helipads` layer of the [`topographic.json` style][helipads-topo] to that of the [`labels.json` style][helipads-labels]. We can see that the two styles reference different sprite files.

- **topographic.json**

    ```json
    "icon-image": "helipad_pnt_fill"
    ```

    The [`helipad_pnt_fill`][helipad_sprite] sprite file exists within the [`sprites/topographic` directory][sprites-dir].

- **labels.json**

    ```json
    "icon-image": {
      "stops": [
        [10, "heliport_11"],
        [15, "heliport_15"]
      ]
    }
    ```

    The `heliport_11` and `heliport_15` sprite files do not exist within the [`sprites/topographic` directory][sprites-dir].

### Modifications

For both the `aerialhybrid.json` and `labels.json` styles, I have updated the `icon-image` property of the `aeroway-Helipads` layer to reference the same sprite file ([`helipad_pnt_fill`][helipad_sprite]) as the `topographic.json` style:

- **aerialhybrid.json**

    ```json
    "icon-image": "helipad_pnt_fill"
    ```

- **labels.json**

    ```json
    "icon-image": "helipad_pnt_fill"
    ```

### Verification

Using the links provided by the `github-actions` bot, when I preview both the [**Aerial Hybrid** style][aerialhybrid-preview] and the [**Labels** style][labels-preview], I can now identify **helipad** locations, respectively.

| Layer | Aerial Hybrid | Labels |
| - | - | - |
| Screenshot | ![][aerialhybrid] | ![][labels] |
| Console | (No sprite file errors or warnings) |  (No sprite file errors or warnings) | 

<!-- links and images -->

[aerial]: https://basemaps.linz.govt.nz/@-44.0002925,170.4091917,z15.75
[topographic]: https://basemaps.linz.govt.nz/@-44.0002925,170.4091917,z15.75?style=topographic&i=topographic

[img_1]: https://github.com/user-attachments/assets/cb4069dd-d9d6-4079-9870-bc9c163c7fcd
[img_2]: https://github.com/user-attachments/assets/12112435-bb5d-4e31-8cab-ce77a2ac1212
[img_3]: https://github.com/user-attachments/assets/518da1ef-1027-4531-a425-f416c1c8fb76

[helipads-topo]: https://github.com/linz/basemaps-config/blob/0343c7cbdae92bef61990307443d3f6d6f20251c/config/style/topographic.json#L4819
[helipads-labels]: https://github.com/linz/basemaps-config/blob/0343c7cbdae92bef61990307443d3f6d6f20251c/config/style/labels.json#L900

[sprites-dir]: https://github.com/linz/basemaps-config/tree/0343c7cbdae92bef61990307443d3f6d6f20251c/config/sprites/topographic
[helipad_sprite]: https://github.com/linz/basemaps-config/blob/0343c7cbdae92bef61990307443d3f6d6f20251c/config/sprites/topographic/helipad_pnt_fill.svg

[aerialhybrid]: https://github.com/user-attachments/assets/a96d934f-8374-4c66-bb79-afc77b655c2e
[labels]: https://github.com/user-attachments/assets/ed860f7c-1c84-4b14-a6d9-c15e7b5e585a

[aerialhybrid-preview]: https://basemaps.linz.govt.nz/@-44.0002925,170.4091917,z15.75?style=aerialhybrid&i=topographic&config=TmVmbYRQjL9T2JWgyaSie193b4D1qZnBD8hjaSqPFYSsEvEYYhaGYKrcnMTqEkj1J6igbx6Ybv3drKRdZJtFNwmoHxdcyF9JJVnKx8VnVgteFNSELCAdPBKw7uawhZT&debug=true

[labels-preview]: https://basemaps.linz.govt.nz/@-44.0002925,170.4091917,z15.75?style=labels&i=topographic&config=TmVmbYRQjL9T2JWgyaSie193b4D1qZnBD8hjaSqPFYSsEvEYYhaGYKrcnMTqEkj1J6igbx6Ybv3drKRdZJtFNwmoHxdcyF9JJVnKx8VnVgteFNSELCAdPBKw7uawhZT&debug=true