### PR TITLE
feat: Add 2193 version of New Zealand Contour-Interpolated 8m DEM

### DIFF
--- a/config/tileset/elevation.json
+++ b/config/tileset/elevation.json
@@ -7,6 +7,7 @@
   "category": "Elevation",
   "layers": [
     {
+      "2193": "s3://nz-elevation/new-zealand/new-zealand-contour/dem_8m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/new-zealand_2012_dem_8m/01HZ0YNQPGH5RJ01S5R5T2VAPM/",
       "title": "New Zealand 8m DEM (2012)",
       "name": "new-zealand_2012_dem_8m"


### PR DESCRIPTION
### Motivation

Adds the 2193 version of the New Zealand Contour-Interpolated 8m DEM which was missing when this configuration was originally created.

### Modifications

Add 8m DEM link to elevation.json

### Verification

Before:
![image](https://github.com/user-attachments/assets/2a02b619-a469-4439-b8a4-b97f97fc65e4)
After:
![image](https://github.com/user-attachments/assets/f3c7cdbe-54b5-4d83-aeb9-a06ca20dfcd4)