### PR TITLE
feat(style): Improve topographic vector map hillshades. BM-1140

### DIFF
--- a/config/style/topographic.json
+++ b/config/style/topographic.json
@@ -1015,10 +1015,12 @@
       "id": "hillshade",
       "layout": { "visibility": "visible" },
       "paint": {
-        "hillshade-accent-color": "#ededed",
-        "hillshade-exaggeration": 0.35,
-        "hillshade-highlight-color": "#e6e6e6",
-        "hillshade-shadow-color": "#6d6d6d"
+        "hillshade-accent-color": ["interpolate", ["linear"], ["zoom"], 0, "#64646466", 3, "#64646466", 9, "#64646455", 11, "#64646444", 14, "#64646466", 17, "#64646499"],
+        "hillshade-exaggeration": 0.4,
+        "hillshade-highlight-color": ["interpolate", ["linear"], ["zoom"], 0, "#e1e5e0cc", 3, "#e1e5e0cc", 9, "#e1e5e055", 11, "#e1e5e011", 14, "#e1e5e011", 17, "#e1e5e044"],
+        "hillshade-illumination-anchor": "map",
+        "hillshade-illumination-direction": 315,
+        "hillshade-shadow-color": ["interpolate", ["linear"], ["zoom"], 0, "#0c0c0cff", 3, "#0c0c0ccc", 9, "#0c0c0caa", 11, "#0c0c0c88", 14, "#0c0c0c66", 17, "#0c0c0c99"]
       },
       "source": "LINZ-Elevation-Hillshade",
       "type": "hillshade"


### PR DESCRIPTION
### Motivation

This change aims to improve the visibility, vibrancy and detail in the dynamic hill shade derived from the LINZ 1m DEM layer. 


### Modifications

The hill shade has been changed in the following ways:
- increased visibility at zoom level 0-7
- increased visibility at zoom level 14 and above
- locked sun angle at 315 degrees from north
- slightly increased opacity
- generally decreased highlights across all zoom levels
- minor change to hill shade shadow, highlight and accent colour

<!-- TODO: Attach screenshots if you changed the UI. -->
Examples for the change:
Before:
![image](https://github.com/user-attachments/assets/ebc441d1-0718-446c-ba88-e28a0cc90964)
After:
![image](https://github.com/user-attachments/assets/0fbce707-ebd8-40b3-9ecd-211bf7999f16)
Before:
![image](https://github.com/user-attachments/assets/adde17c8-3a3d-47c1-9c29-63154933e306)
After:
![image](https://github.com/user-attachments/assets/e579dcc2-c2b9-4e36-91a4-3965bd869f5e)
Before:
![image](https://github.com/user-attachments/assets/5a189113-f8cb-4dc0-9e74-14ab8dc51d9c)
After:
![image](https://github.com/user-attachments/assets/a38cbcb2-5935-4c7a-a599-811b276ae18e)
