### PR TITLE
feat(elevation): reintroduce older datasets not fully replaced

### DIFF
--- a/config/tileset/elevation.json
+++ b/config/tileset/elevation.json
@@ -223,11 +223,25 @@
       "name": "hawarden_2015_dem_1m"
     },
     {
+      "2193": "s3://nz-elevation/canterbury/christchurch-and-selwyn_2015/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/christchurch-and-selwyn_2015_dem_1m/01HZ65BE94TVDRNGJ9PZB2BTYX/",
+      "minZoom": 9,
+      "title": "Canterbury - Christchurch and Selwyn LiDAR 1m DEM (2015)",
+      "name": "christchurch-and-selwyn_2015_dem_1m"
+    },
+    {
       "2193": "s3://nz-elevation/canterbury/mackenzie_2015/dem_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/mackenzie_2015_dem_1m/01HZ65MFCV4J3XN39ZDRH4Z22P/",
       "minZoom": 9,
       "title": "Canterbury - Mackenzie LiDAR 1m DEM (2015)",
       "name": "mackenzie_2015_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2016/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/abel-tasman-and-golden-bay_2016_dem_1m/01HZ66YRH6T1E72EDJH8E2C9WE/",
+      "minZoom": 9,
+      "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DEM (2016)",
+      "name": "abel-tasman-and-golden-bay_2016_dem_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/otago_2016/dem_1m/2193/",
@@ -277,6 +291,13 @@
       "minZoom": 9,
       "title": "Tasman - Motueka River Valley LiDAR 1m DEM (2018-2019)",
       "name": "motueka-river-valley_2018-2019_dem_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/christchurch-and-ashley-river_2018-2019/dem_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/christchurch-and-ashley-river_2018-2019_dem_1m/01HZ65B3P90PS85WF0SEY7T6KG/",
+      "minZoom": 9,
+      "title": "Canterbury - Christchurch and Ashley River LiDAR 1m DEM (2018-2019)",
+      "name": "christchurch-and-ashley-river_2018-2019_dem_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2018-2019/dem_1m/2193/",


### PR DESCRIPTION
### Motivation

These three datasets are being reintroduced as they fill minor gaps that were not reflown as part of later surveys.

### Modifications

Reintroduced 3 datasets into elevation.json

### Verification

Abel Tasman and Golden Bay 2016:
![image](https://github.com/user-attachments/assets/fb7ac79d-a94c-4f4c-9ffa-1b163609412b)

Christchurch and Ashley River 2018-2019:
![image](https://github.com/user-attachments/assets/3aab46d1-e951-4b76-b853-50cfea0202b8)

Christchurch and Selwyn 2015:
![image](https://github.com/user-attachments/assets/dfe04208-2125-45ff-93cd-9b5133d35271)
