### PR TITLE
build: upgrade visual snapshot to support new artifacts api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
           docker run --rm --network="host" -v $PWD:$PWD ${DOCKER_AWS_ENV} ${SCREENSHOT_CONTAINER} --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
       
       - name: Save snapshots
-        uses: blacha/action-visual-snapshot@main
+        uses: blacha/action-visual-snapshot@19bcf5e44c8a691f28c89219b1e0d7b9a3889c4e
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -283,7 +283,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: blacha/action-visual-snapshot@main
+        uses: blacha/action-visual-snapshot@19bcf5e44c8a691f28c89219b1e0d7b9a3889c4e
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
           docker run --rm --network="host" -v $PWD:$PWD ${DOCKER_AWS_ENV} ${SCREENSHOT_CONTAINER} --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
       
       - name: Save snapshots
-        uses: blacha/action-visual-snapshot@19bcf5e44c8a691f28c89219b1e0d7b9a3889c4e
+        uses: blacha/action-visual-snapshot@v2-next
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -283,7 +283,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: blacha/action-visual-snapshot@19bcf5e44c8a691f28c89219b1e0d7b9a3889c4e
+        uses: blacha/action-visual-snapshot@v2-next
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
           docker run --rm --network="host" -v $PWD:$PWD ${DOCKER_AWS_ENV} ${SCREENSHOT_CONTAINER} --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
       
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@v2
+        uses: blacha/action-visual-snapshot@main
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -283,7 +283,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: blacha/action-visual-snapshot@v2
+        uses: blacha/action-visual-snapshot@main
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'


### PR DESCRIPTION
### Motivation

`getsentry/action-visual-snapshot` has been deprecated and archived, it is no longer supported, github has recently removed support for the artifacts API it was using to store the images, causing all of these actions to fail.

### Modifications

Fork the github action and update it to support the newer github actions artifacts API.

this is a temporary fix with the intention to replace this github action with another more supported action in the near term.

### Verification

Checking to see if the build succeeds after this is merged.
