### PR TITLE
config(elevation): prepare elevation-dsm tileset BM-1246

### DIFF
--- a/config/tileset/elevation.dsm.json
+++ b/config/tileset/elevation.dsm.json
@@ -7,6 +7,12 @@
   "category": "Elevation",
   "layers": [
     {
+      "2193": "s3://nz-elevation/new-zealand/new-zealand-contour/dem_8m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/new-zealand_2012_dem_8m/01HZ0YNQPGH5RJ01S5R5T2VAPM/",
+      "title": "New Zealand 8m DEM (2012)",
+      "name": "new-zealand_2012_dem_8m"
+    },
+    {
       "2193": "s3://nz-elevation/canterbury/canterbury_2010/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2010_dsm_1m/01JQN0HWF74P22K917SJRAV1SB/",
       "name": "canterbury_2010_dsm_1m",

--- a/config/tileset/elevation.dsm.json
+++ b/config/tileset/elevation.dsm.json
@@ -2,8 +2,8 @@
   "id": "ts_elevation-dsm",
   "name": "elevation-dsm",
   "type": "raster",
-  "description": "Elevation Basemap",
-  "title": "Elevation",
+  "description": "Elevation DSM Basemap",
+  "title": "Elevation DSM",
   "category": "Elevation",
   "layers": [
     {

--- a/config/tileset/elevation.dsm.json
+++ b/config/tileset/elevation.dsm.json
@@ -1,0 +1,466 @@
+{
+  "id": "ts_elevation-dsm",
+  "name": "elevation-dsm",
+  "type": "raster",
+  "description": "Elevation Basemap",
+  "title": "Elevation",
+  "category": "Elevation",
+  "layers": [
+    {
+      "2193": "s3://nz-elevation/new-zealand/new-zealand-contour/dsm_8m/2193/",
+      "title": "New Zealand 8m DSM (2012)",
+      "name": "new-zealand_2012_dsm_8m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/canterbury_2010/dsm_1m/2193/",
+      "name": "canterbury_2010_dsm_1m",
+      "title": "Canterbury LiDAR 1m DSM (2010)",
+      "minZoom": 9
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/wellington_2013-2014/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Wellington LiDAR 1m DSM (2013-2014)",
+      "name": "wellington_2013-2014_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2015-2016/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Manawatū-Whanganui LiDAR 1m DSM (2015-2016)",
+      "name": "manawatu-whanganui_2015-2016_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/auckland/auckland-south_2016-2017/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Auckland South LiDAR 1m DSM (2016-2017)",
+      "name": "auckland-south_2016-2017_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/auckland/auckland-north_2016-2018/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Auckland North LiDAR 1m DSM (2016-2018)",
+      "name": "auckland-north_2016-2018_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/manawatu-whanganui/palmerston-north_2018/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Manawatū-Whanganui - Palmerston North LiDAR 1m DSM (2018)",
+      "name": "palmerston-north_2018_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/huntly_2015-2019/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Waikato - Huntly LiDAR 1m DSM (2015-2019)",
+      "name": "huntly_2015-2019_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/thames_2017-2019/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Waikato - Thames LiDAR 1m DSM (2017-2019)",
+      "name": "thames_2017-2019_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/reporoa-and-upper-piako-river_2019/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Waikato - Reporoa and Upper Piako River LiDAR 1m DSM (2019)",
+      "name": "reporoa-and-upper-piako-river_2019_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/northland/northland_2018-2020/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Northland LiDAR 1m DSM (2018-2020)",
+      "name": "northland_2018-2020_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/wellington-city_2019-2020/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Wellington City LiDAR 1m DSM (2019-2020)",
+      "name": "wellington-city_2019-2020_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/manawatu-whanganui/whanganui-urban_2020-2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Manawatū-Whanganui - Whanganui Urban LiDAR 1m DSM (2020-2021)",
+      "name": "whanganui-urban_2020-2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/waikato_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Waikato LiDAR 1m DSM (2021)",
+      "name": "waikato_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/taranaki/taranaki_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Taranaki LiDAR 1m DSM (2021)",
+      "name": "taranaki_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/hutt-city_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Wellington - Hutt City LiDAR 1m DSM (2021)",
+      "name": "hutt-city_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/kapiti-coast_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Wellington - Kāpiti Coast LiDAR 1m DSM (2021)",
+      "name": "kapiti-coast_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/upper-hutt-city_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Wellington - Upper Hutt City LiDAR 1m DSM (2021)",
+      "name": "upper-hutt-city_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2019-2022/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Bay of Plenty LiDAR 1m DSM (2019-2022)",
+      "name": "bay-of-plenty_2019-2022_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/bay-of-plenty/tauranga_2022/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Bay of Plenty - Tauranga LiDAR 1m DSM (2022)",
+      "name": "tauranga_2022_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2022-2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Manawatū-Whanganui LiDAR 1m DSM (2022-2023)",
+      "name": "manawatu-whanganui_2022-2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/wellington/porirua_2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Wellington - Porirua LiDAR 1m DSM (2023)",
+      "name": "porirua_2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/hamilton_2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Waikato - Hamilton LiDAR 1m DSM (2023)",
+      "name": "hamilton_2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/gisborne/gisborne_2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Gisborne LiDAR 1m DSM (2023)",
+      "name": "gisborne_2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/waikato/waikato_2024/dsm_1m/2193/",
+      "name": "waikato_2024_dsm_1m",
+      "title": "Waikato LiDAR 1m DSM (2024)",
+      "minZoom": 9
+    },
+    {
+      "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2024/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Bay of Plenty LiDAR 1m DSM (2024)",
+      "name": "bay-of-plenty_2024_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/tasman_2008-2015/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Nelson and Tasman LiDAR 1m DSM (2008-2015)",
+      "name": "tasman_2008-2015_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/hurunui-rivers_2013/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Hurunui Rivers LiDAR 1m DSM (2013)",
+      "name": "hurunui-rivers_2013_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/timaru-rivers_2014/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Timaru Rivers LiDAR 1m DSM (2014)",
+      "name": "timaru-rivers_2014_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/marlborough/blenheim_2014/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Marlborough - Blenheim LiDAR 1m DSM (2014)",
+      "name": "blenheim_2014_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/richmond-and-motueka_2015/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Tasman - Richmond and Motueka LiDAR 1m DSM (2015)",
+      "name": "richmond-and-motueka_2015_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/hawarden_2015/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Hawarden LiDAR 1m DSM (2015)",
+      "name": "hawarden_2015_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/christchurch-and-selwyn_2015/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Christchurch and Selwyn LiDAR 1m DSM (2015)",
+      "name": "christchurch-and-selwyn_2015_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/mackenzie_2015/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Mackenzie LiDAR 1m DSM (2015)",
+      "name": "mackenzie_2015_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2016/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DSM (2016)",
+      "name": "abel-tasman-and-golden-bay_2016_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/otago_2016/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago LiDAR 1m DSM (2016)",
+      "name": "otago_2016_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/queenstown_2016/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago - Queenstown LiDAR 1m DSM (2016)",
+      "name": "queenstown_2016_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/kaikoura_2016-2017/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Kaikōura LiDAR 1m DSM (2016-2017)",
+      "name": "kaikoura_2016-2017_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/canterbury_2016-2017/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury LiDAR 1m DSM (2016-2017)",
+      "name": "canterbury_2016-2017_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/golden-bay_2017/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Tasman - Golden Bay LiDAR 1m DSM (2017)",
+      "name": "golden-bay_2017_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/marlborough/marlborough_2018/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Marlborough LiDAR 1m DSM (2018)",
+      "name": "marlborough_2018_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/motueka-river-valley_2018-2019/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Tasman - Motueka River Valley LiDAR 1m DSM (2018-2019)",
+      "name": "motueka-river-valley_2018-2019_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/christchurch-and-ashley-river_2018-2019/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Christchurch and Ashley River LiDAR 1m DSM (2018-2019)",
+      "name": "christchurch-and-ashley-river_2018-2019_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/canterbury_2018-2019/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury LiDAR 1m DSM (2018-2019)",
+      "name": "canterbury_2018-2019_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/balclutha_2020/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago - Balclutha LiDAR 1m DSM (2020)",
+      "name": "balclutha_2020_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/christchurch_2020-2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Christchurch LiDAR 1m DSM (2020-2021)",
+      "name": "christchurch_2020-2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/nelson/nelson_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Nelson LiDAR 1m DSM (2021)",
+      "name": "nelson_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/central-otago_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago - Central Otago LiDAR 1m DSM (2021)",
+      "name": "central-otago_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/coastal-catchments_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago - Coastal Catchments LiDAR 1m DSM (2021)",
+      "name": "coastal-catchments_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/dunedin-and-mosgiel_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago - Dunedin and Mosgiel LiDAR 1m DSM (2021)",
+      "name": "dunedin-and-mosgiel_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/queenstown_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago - Queenstown LiDAR 1m DSM (2021)",
+      "name": "queenstown_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/southland/stewart-island-rakiura-oban_2021/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Stewart Island / Rakiura - Oban LiDAR 1m DSM (2021)",
+      "name": "stewart-island-rakiura-oban_2021_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/tasman_2020-2022/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Tasman LiDAR 1m DSM (2020-2022)",
+      "name": "tasman_2020-2022_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/marlborough/marlborough_2020-2022/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Marlborough LiDAR 1m DSM (2020-2022)",
+      "name": "marlborough_2020-2022_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/west-coast/west-coast_2020-2022/dsm_1m/2193/",
+      "name": "west-coast_2020-2022_dsm_1m",
+      "title": "West Coast LiDAR 1m DSM (2020-2024) - Draft",
+      "minZoom": 9
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/tasman-bay_2022/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Tasman - Tasman Bay LiDAR 1m DSM (2022)",
+      "name": "tasman-bay_2022_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/nelson/top-of-the-south-flood_2022/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Nelson and Tasman - Top of the South Flood LiDAR 1m DSM (2022)",
+      "name": "top-of-the-south-flood_2022_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/kaikoura-and-waimakariri_2022/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Kaikōura and Waimakariri LiDAR 1m DSM (2022)",
+      "name": "kaikoura-and-waimakariri_2022_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/central-otago_2022-2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago - Central Otago LiDAR 1m DSM (2022-2023)",
+      "name": "central-otago_2022-2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/otago/wanaka_2022-2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Otago - Wanaka LiDAR 1m DSM (2022-2023)",
+      "name": "wanaka_2022-2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DSM (2023)",
+      "name": "abel-tasman-and-golden-bay_2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/tasman/waimea-dam_2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Tasman - Waimea Dam LiDAR 1m DSM (2023)",
+      "name": "waimea-dam_2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/banks-peninsula_2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Banks Peninsula LiDAR 1m DSM (2023)",
+      "name": "banks-peninsula_2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/selwyn_2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Selwyn LiDAR 1m DSM (2023)",
+      "name": "selwyn_2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/waimakariri_2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury - Waimakariri LiDAR 1m DSM (2023)",
+      "name": "waimakariri_2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/southland/southland_2020-2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Southland LiDAR 1m DSM (2020-2023)",
+      "name": "southland_2020-2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/canterbury/canterbury_2020-2023/dsm_1m/2193/",
+      "minZoom": 9,
+      "title": "Canterbury LiDAR 1m DSM (2020-2023)",
+      "name": "canterbury_2020-2023_dsm_1m"
+    },
+    {
+      "2193": "s3://nz-elevation/hawkes-bay/hawkes-bay_2023/dsm_1m/2193/",
+      "name": "hawkes-bay_2023_dsm_1m",
+      "title": "Hawke's Bay LiDAR 1m DSM (2023-2024)",
+      "minZoom": 9
+    },
+    {
+      "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2024/dsm_1m/2193/",
+      "name": "manawatu-whanganui_2024_dsm_1m",
+      "title": "Manawatū-Whanganui LiDAR 1m DSM (2024)",
+      "minZoom": 9
+    },
+    {
+      "2193": "s3://nz-elevation/northland/northland_2024/dsm_1m/2193/",
+      "name": "northland_2024_dsm_1m",
+      "title": "Northland LiDAR 1m DSM (2024)",
+      "minZoom": 9
+    }
+  ],
+  "outputs": [
+    {
+      "title": "Terrain RGB",
+      "name": "terrain-rgb",
+      "pipeline": [
+        {
+          "type": "terrain-rgb"
+        }
+      ],
+      "format": ["png"],
+      "background": {
+        "r": 1,
+        "g": 134,
+        "b": 160,
+        "alpha": 1
+      },
+      "resizeKernel": {
+        "in": "nearest",
+        "out": "nearest"
+      }
+    },
+    {
+      "title": "Color ramp",
+      "name": "color-ramp",
+      "pipeline": [
+        {
+          "type": "color-ramp"
+        }
+      ],
+      "background": {
+        "r": 172,
+        "g": 204,
+        "b": 226,
+        "alpha": 1
+      }
+    }
+  ]
+}

--- a/config/tileset/elevation.dsm.json
+++ b/config/tileset/elevation.dsm.json
@@ -10,7 +10,8 @@
       "2193": "s3://nz-elevation/new-zealand/new-zealand-contour/dem_8m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/new-zealand_2012_dem_8m/01HZ0YNQPGH5RJ01S5R5T2VAPM/",
       "title": "New Zealand 8m DEM (2012)",
-      "name": "new-zealand_2012_dem_8m"
+      "name": "new-zealand_2012_dem_8m",
+      "maxZoom": 8
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2010/dsm_1m/2193/",

--- a/config/tileset/elevation.dsm.json
+++ b/config/tileset/elevation.dsm.json
@@ -11,152 +11,152 @@
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2010_dsm_1m/01JQN0HWF74P22K917SJRAV1SB/",
       "name": "canterbury_2010_dsm_1m",
       "title": "Canterbury LiDAR 1m DSM (2010)",
-      "minZoom": 9
+      "minZoom": 5
     },
     {
       "2193": "s3://nz-elevation/wellington/wellington_2013-2014/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/wellington_2013-2014_dsm_1m/01JQN0HWFQVA617NQ27GGNAKJD/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Wellington LiDAR 1m DSM (2013-2014)",
       "name": "wellington_2013-2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2015-2016/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2015-2016_dsm_1m/01JQN0HWJ4GKEZXWN56MRF8G23/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2015-2016)",
       "name": "manawatu-whanganui_2015-2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/auckland/auckland-south_2016-2017/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/auckland-south_2016-2017_dsm_1m/01JQN0HWCWT5MG7CRVKWCHJ3NY/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Auckland South LiDAR 1m DSM (2016-2017)",
       "name": "auckland-south_2016-2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/auckland/auckland-north_2016-2018/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/auckland-north_2016-2018_dsm_1m/01JQN0HWE60P7KGVRWBG78VHQ3/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Auckland North LiDAR 1m DSM (2016-2018)",
       "name": "auckland-north_2016-2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/palmerston-north_2018/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/palmerston-north_2018_dsm_1m/01JQN0HWHXH84CM4SS8CW9SFTN/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Manawatū-Whanganui - Palmerston North LiDAR 1m DSM (2018)",
       "name": "palmerston-north_2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/huntly_2015-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/huntly_2015-2019_dsm_1m/01JQN0HWHK35N16YHADQWZHTC3/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Waikato - Huntly LiDAR 1m DSM (2015-2019)",
       "name": "huntly_2015-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/thames_2017-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/thames_2017-2019_dsm_1m/01JQN0HWERF6QA34JA2W4C1TRW/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Waikato - Thames LiDAR 1m DSM (2017-2019)",
       "name": "thames_2017-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/reporoa-and-upper-piako-river_2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/reporoa-and-upper-piako-river_2019_dsm_1m/01JQN0HWFRNKM89E2NG08MJDJR/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Waikato - Reporoa and Upper Piako River LiDAR 1m DSM (2019)",
       "name": "reporoa-and-upper-piako-river_2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/northland/northland_2018-2020/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/northland_2018-2020_dsm_1m/01JQN0HWEAKEH7JAK8SJC9C1BF/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Northland LiDAR 1m DSM (2018-2020)",
       "name": "northland_2018-2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/wellington-city_2019-2020/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/wellington-city_2019-2020_dsm_1m/01JQN19CVDNGJ27QDJ79M9K6PD/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Wellington City LiDAR 1m DSM (2019-2020)",
       "name": "wellington-city_2019-2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/whanganui-urban_2020-2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/whanganui-urban_2020-2021_dsm_1m/01JQN19G8CKT9JJ7DPAM0D7QT9/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Manawatū-Whanganui - Whanganui Urban LiDAR 1m DSM (2020-2021)",
       "name": "whanganui-urban_2020-2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/waikato_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/waikato_2021_dsm_1m/01JQN19GZHVF0ZNPJ084HPR53E/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Waikato LiDAR 1m DSM (2021)",
       "name": "waikato_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/taranaki/taranaki_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/taranaki_2021_dsm_1m/01JQN19M6FSDE0BMNP8P69A0QB/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Taranaki LiDAR 1m DSM (2021)",
       "name": "taranaki_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/hutt-city_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hutt-city_2021_dsm_1m/01JQN19QFXEHR05VTHV4H19QNA/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Wellington - Hutt City LiDAR 1m DSM (2021)",
       "name": "hutt-city_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/kapiti-coast_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/kapiti-coast_2021_dsm_1m/01JQN19SSYEJ07X9S6SJVAWYCC/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Wellington - Kāpiti Coast LiDAR 1m DSM (2021)",
       "name": "kapiti-coast_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/upper-hutt-city_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/upper-hutt-city_2021_dsm_1m/01JQN19V67XXSA1HM61JN0HP4K/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Wellington - Upper Hutt City LiDAR 1m DSM (2021)",
       "name": "upper-hutt-city_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2019-2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/bay-of-plenty_2019-2022_dsm_1m/01JQN19ZC4KZZVTWRZRVPH2134/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Bay of Plenty LiDAR 1m DSM (2019-2022)",
       "name": "bay-of-plenty_2019-2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2022-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2022-2023_dsm_1m/01JQN1E9WEYXDFEWW5V9VPKAHZ/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2022-2023)",
       "name": "manawatu-whanganui_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/porirua_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/porirua_2023_dsm_1m/01JQN1EA4YR01QSNS39GYBNKYV/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Wellington - Porirua LiDAR 1m DSM (2023)",
       "name": "porirua_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/hamilton_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hamilton_2023_dsm_1m/01JQN1F6FPVY226BRZQDXM28B0/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Waikato - Hamilton LiDAR 1m DSM (2023)",
       "name": "hamilton_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/gisborne/gisborne_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/gisborne_2023_dsm_1m/01JQN1HAH2YEPB9NBHDA1BJDVD/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Gisborne LiDAR 1m DSM (2023)",
       "name": "gisborne_2023_dsm_1m"
     },
@@ -165,194 +165,194 @@
       "3857": "s3://linz-basemaps/elevation/3857/waikato_2024_dsm_1m/01JQN1HYF1JAWM5P88YE1MJ1S4/",
       "name": "waikato_2024_dsm_1m",
       "title": "Waikato LiDAR 1m DSM (2024)",
-      "minZoom": 9
+      "minZoom": 5
     },
     {
       "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2024/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/bay-of-plenty_2024_dsm_1m/01JQN1KGBYM9MJ69P451J39RSK/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Bay of Plenty LiDAR 1m DSM (2024)",
       "name": "bay-of-plenty_2024_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/hurunui-rivers_2013/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hurunui-rivers_2013_dsm_1m/01JQN1KGMBJ07CS7BCCST85XF1/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Hurunui Rivers LiDAR 1m DSM (2013)",
       "name": "hurunui-rivers_2013_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/timaru-rivers_2014/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/timaru-rivers_2014_dsm_1m/01JQN1P1C4RWV7WV6BT0YX0BFF/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Timaru Rivers LiDAR 1m DSM (2014)",
       "name": "timaru-rivers_2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/blenheim_2014/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/blenheim_2014_dsm_1m/01JQN1QXKMKCJTP24RBS0XSNE6/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Marlborough - Blenheim LiDAR 1m DSM (2014)",
       "name": "blenheim_2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/richmond-and-motueka_2015/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/richmond-and-motueka_2015_dsm_1m/01JQN1TJX3J57MP6ZKTRCYEHJJ/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Tasman - Richmond and Motueka LiDAR 1m DSM (2015)",
       "name": "richmond-and-motueka_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/hawarden_2015/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hawarden_2015_dsm_1m/01JQN20FGEAYZ61RM2277DAQJV/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Hawarden LiDAR 1m DSM (2015)",
       "name": "hawarden_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch-and-selwyn_2015/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/christchurch-and-selwyn_2015_dsm_1m/01JQN212B574AW85B0MFJ42SZK/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Christchurch and Selwyn LiDAR 1m DSM (2015)",
       "name": "christchurch-and-selwyn_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/mackenzie_2015/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/mackenzie_2015_dsm_1m/01JQN21YXK33HH05KX63T815N4/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Mackenzie LiDAR 1m DSM (2015)",
       "name": "mackenzie_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2016/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/abel-tasman-and-golden-bay_2016_dsm_1m/01JQN2308MTSBJBQB5C3E24J6C/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DSM (2016)",
       "name": "abel-tasman-and-golden-bay_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/otago_2016/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/otago_2016_dsm_1m/01JQN23F6VC30N7TB95SBRP2QM/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago LiDAR 1m DSM (2016)",
       "name": "otago_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/queenstown_2016/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/queenstown_2016_dsm_1m/01JQN23QKWB6P3EB64PPNZ8SFH/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago - Queenstown LiDAR 1m DSM (2016)",
       "name": "queenstown_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2016-2017/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2016-2017_dsm_1m/01JQN262Q5ZJXNT30DNJ7795YN/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury LiDAR 1m DSM (2016-2017)",
       "name": "canterbury_2016-2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/golden-bay_2017/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/golden-bay_2017_dsm_1m/01JQN2AGSCWTS4Q2CT268SC3HB/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Tasman - Golden Bay LiDAR 1m DSM (2017)",
       "name": "golden-bay_2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/marlborough_2018/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/marlborough_2018_dsm_1m/01JQN2B1ABX6G1QTMNRDF44WB3/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Marlborough LiDAR 1m DSM (2018)",
       "name": "marlborough_2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/motueka-river-valley_2018-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/motueka-river-valley_2018-2019_dsm_1m/01JQN2CP2ZTNBKR3CCFQDZVBCH/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Tasman - Motueka River Valley LiDAR 1m DSM (2018-2019)",
       "name": "motueka-river-valley_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch-and-ashley-river_2018-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/christchurch-and-ashley-river_2018-2019_dsm_1m/01JQN2DJN233FFY9ZW5Y322FW9/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Christchurch and Ashley River LiDAR 1m DSM (2018-2019)",
       "name": "christchurch-and-ashley-river_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2018-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2018-2019_dsm_1m/01JQN2F7S0AVG6CQB5XSX7SYJF/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury LiDAR 1m DSM (2018-2019)",
       "name": "canterbury_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/balclutha_2020/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/balclutha_2020_dsm_1m/01JQN2F9016HAV0TWYWJDG6P5B/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago - Balclutha LiDAR 1m DSM (2020)",
       "name": "balclutha_2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch_2020-2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/christchurch_2020-2021_dsm_1m/01JQN2H6X1MEM1D2H4SBZYWG29/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Christchurch LiDAR 1m DSM (2020-2021)",
       "name": "christchurch_2020-2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/nelson/nelson_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/nelson_2021_dsm_1m/01JQN2HB3FQNS6PXNFTXJXVSPZ/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Nelson LiDAR 1m DSM (2021)",
       "name": "nelson_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/central-otago_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/central-otago_2021_dsm_1m/01JQN2J3GNJ5ZT4X0TQBAVAW2R/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago - Central Otago LiDAR 1m DSM (2021)",
       "name": "central-otago_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/coastal-catchments_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/coastal-catchments_2021_dsm_1m/01JQN2JJCHBGHPMBC94HYR3KNR/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago - Coastal Catchments LiDAR 1m DSM (2021)",
       "name": "coastal-catchments_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/dunedin-and-mosgiel_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/dunedin-and-mosgiel_2021_dsm_1m/01JQN2K5SN5M1XS138400AAWRM/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago - Dunedin and Mosgiel LiDAR 1m DSM (2021)",
       "name": "dunedin-and-mosgiel_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/queenstown_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/queenstown_2021_dsm_1m/01JQN2NYZD1SW8TPKJCA380A14/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago - Queenstown LiDAR 1m DSM (2021)",
       "name": "queenstown_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/southland/stewart-island-rakiura-oban_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/stewart-island-rakiura-oban_2021_dsm_1m/01JQN2PNFNJ8M4TMTMVX8B412E/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Stewart Island / Rakiura - Oban LiDAR 1m DSM (2021)",
       "name": "stewart-island-rakiura-oban_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/tasman_2020-2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/tasman_2020-2022_dsm_1m/01JQN2QJKC1MJQ57S4VFMTGF9F/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Tasman LiDAR 1m DSM (2020-2022)",
       "name": "tasman_2020-2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/marlborough_2020-2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/marlborough_2020-2022_dsm_1m/01JQN2RTAS51N8KWTTARRA0KC8/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Marlborough LiDAR 1m DSM (2020-2022)",
       "name": "marlborough_2020-2022_dsm_1m"
     },
@@ -361,89 +361,89 @@
       "3857": "s3://linz-basemaps/elevation/3857/west-coast_2020-2022_dsm_1m/01JQN2SFHQA0K3KAF3X8YYWJ87/",
       "name": "west-coast_2020-2022_dsm_1m",
       "title": "West Coast LiDAR 1m DSM (2020-2024) - Draft",
-      "minZoom": 9
+      "minZoom": 5
     },
     {
       "2193": "s3://nz-elevation/tasman/tasman-bay_2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/tasman-bay_2022_dsm_1m/01JQN2SGZ49XKX1B1DG3RG4X6M/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Tasman - Tasman Bay LiDAR 1m DSM (2022)",
       "name": "tasman-bay_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/nelson/top-of-the-south-flood_2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/top-of-the-south-flood_2022_dsm_1m/01JQN2SJSFV2JABW19FDB9X01J/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Nelson and Tasman - Top of the South Flood LiDAR 1m DSM (2022)",
       "name": "top-of-the-south-flood_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/kaikoura-and-waimakariri_2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/kaikoura-and-waimakariri_2022_dsm_1m/01JQN2V1ME1BQ8QKRA7H16TS1E/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Kaikōura and Waimakariri LiDAR 1m DSM (2022)",
       "name": "kaikoura-and-waimakariri_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/central-otago_2022-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/central-otago_2022-2023_dsm_1m/01JQN2XAAARKJQNHZD133S30XY/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago - Central Otago LiDAR 1m DSM (2022-2023)",
       "name": "central-otago_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/wanaka_2022-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/wanaka_2022-2023_dsm_1m/01JQN2ZE0TS4XDDEENJH12Z2SB/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Otago - Wanaka LiDAR 1m DSM (2022-2023)",
       "name": "wanaka_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/abel-tasman-and-golden-bay_2023_dsm_1m/01JQN33CXVTSJ8DA94YKXSKWYD/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DSM (2023)",
       "name": "abel-tasman-and-golden-bay_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/waimea-dam_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/waimea-dam_2023_dsm_1m/01JQN33K07HNGVVXJJS9RSPY1A/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Tasman - Waimea Dam LiDAR 1m DSM (2023)",
       "name": "waimea-dam_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/banks-peninsula_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/banks-peninsula_2023_dsm_1m/01JQN356PAVN6S6NS54VBK1DW8/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Banks Peninsula LiDAR 1m DSM (2023)",
       "name": "banks-peninsula_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/selwyn_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/selwyn_2023_dsm_1m/01JQN35QE0VNK99E2YT2P3ZGPG/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Selwyn LiDAR 1m DSM (2023)",
       "name": "selwyn_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/waimakariri_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/waimakariri_2023_dsm_1m/01JQN38JJ0W9JEBJNYNM38V3HR/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury - Waimakariri LiDAR 1m DSM (2023)",
       "name": "waimakariri_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/southland/southland_2020-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/southland_2020-2023_dsm_1m/01JQN38N6SGSGC95PSKEZKBFJN/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Southland LiDAR 1m DSM (2020-2023)",
       "name": "southland_2020-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2020-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2020-2023_dsm_1m/01JQN3D2K1M5DNSJ6EEDBJ5D2X/",
-      "minZoom": 9,
+      "minZoom": 5,
       "title": "Canterbury LiDAR 1m DSM (2020-2023)",
       "name": "canterbury_2020-2023_dsm_1m"
     },
@@ -452,21 +452,21 @@
       "3857": "s3://linz-basemaps/elevation/3857/hawkes-bay_2023_dsm_1m/01JQN3FZT3X11GAKB45T2XQ6Q6/",
       "name": "hawkes-bay_2023_dsm_1m",
       "title": "Hawke's Bay LiDAR 1m DSM (2023-2024)",
-      "minZoom": 9
+      "minZoom": 5
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2024/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2024_dsm_1m/01JQN3FASTV70PYS2PW309T7X7/",
       "name": "manawatu-whanganui_2024_dsm_1m",
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2024)",
-      "minZoom": 9
+      "minZoom": 5
     },
     {
       "2193": "s3://nz-elevation/northland/northland_2024/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/northland_2024_dsm_1m/01JQN3MVFCYHEAFCQSRDTG4HET/",
       "name": "northland_2024_dsm_1m",
       "title": "Northland LiDAR 1m DSM (2024)",
-      "minZoom": 9
+      "minZoom": 5
     }
   ],
   "outputs": [

--- a/config/tileset/elevation.dsm.json
+++ b/config/tileset/elevation.dsm.json
@@ -7,11 +7,6 @@
   "category": "Elevation",
   "layers": [
     {
-      "2193": "s3://nz-elevation/new-zealand/new-zealand-contour/dsm_8m/2193/",
-      "title": "New Zealand 8m DSM (2012)",
-      "name": "new-zealand_2012_dsm_8m"
-    },
-    {
       "2193": "s3://nz-elevation/canterbury/canterbury_2010/dsm_1m/2193/",
       "name": "canterbury_2010_dsm_1m",
       "title": "Canterbury LiDAR 1m DSM (2010)",
@@ -120,12 +115,6 @@
       "name": "bay-of-plenty_2019-2022_dsm_1m"
     },
     {
-      "2193": "s3://nz-elevation/bay-of-plenty/tauranga_2022/dsm_1m/2193/",
-      "minZoom": 9,
-      "title": "Bay of Plenty - Tauranga LiDAR 1m DSM (2022)",
-      "name": "tauranga_2022_dsm_1m"
-    },
-    {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2022-2023/dsm_1m/2193/",
       "minZoom": 9,
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2022-2023)",
@@ -160,12 +149,6 @@
       "minZoom": 9,
       "title": "Bay of Plenty LiDAR 1m DSM (2024)",
       "name": "bay-of-plenty_2024_dsm_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/tasman/tasman_2008-2015/dsm_1m/2193/",
-      "minZoom": 9,
-      "title": "Nelson and Tasman LiDAR 1m DSM (2008-2015)",
-      "name": "tasman_2008-2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/hurunui-rivers_2013/dsm_1m/2193/",
@@ -226,12 +209,6 @@
       "minZoom": 9,
       "title": "Otago - Queenstown LiDAR 1m DSM (2016)",
       "name": "queenstown_2016_dsm_1m"
-    },
-    {
-      "2193": "s3://nz-elevation/canterbury/kaikoura_2016-2017/dsm_1m/2193/",
-      "minZoom": 9,
-      "title": "Canterbury - Kaikōura LiDAR 1m DSM (2016-2017)",
-      "name": "kaikoura_2016-2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2016-2017/dsm_1m/2193/",

--- a/config/tileset/elevation.dsm.json
+++ b/config/tileset/elevation.dsm.json
@@ -11,152 +11,152 @@
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2010_dsm_1m/01JQN0HWF74P22K917SJRAV1SB/",
       "name": "canterbury_2010_dsm_1m",
       "title": "Canterbury LiDAR 1m DSM (2010)",
-      "minZoom": 5
+      "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/wellington/wellington_2013-2014/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/wellington_2013-2014_dsm_1m/01JQN0HWFQVA617NQ27GGNAKJD/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Wellington LiDAR 1m DSM (2013-2014)",
       "name": "wellington_2013-2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2015-2016/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2015-2016_dsm_1m/01JQN0HWJ4GKEZXWN56MRF8G23/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2015-2016)",
       "name": "manawatu-whanganui_2015-2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/auckland/auckland-south_2016-2017/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/auckland-south_2016-2017_dsm_1m/01JQN0HWCWT5MG7CRVKWCHJ3NY/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Auckland South LiDAR 1m DSM (2016-2017)",
       "name": "auckland-south_2016-2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/auckland/auckland-north_2016-2018/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/auckland-north_2016-2018_dsm_1m/01JQN0HWE60P7KGVRWBG78VHQ3/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Auckland North LiDAR 1m DSM (2016-2018)",
       "name": "auckland-north_2016-2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/palmerston-north_2018/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/palmerston-north_2018_dsm_1m/01JQN0HWHXH84CM4SS8CW9SFTN/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Manawatū-Whanganui - Palmerston North LiDAR 1m DSM (2018)",
       "name": "palmerston-north_2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/huntly_2015-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/huntly_2015-2019_dsm_1m/01JQN0HWHK35N16YHADQWZHTC3/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Waikato - Huntly LiDAR 1m DSM (2015-2019)",
       "name": "huntly_2015-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/thames_2017-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/thames_2017-2019_dsm_1m/01JQN0HWERF6QA34JA2W4C1TRW/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Waikato - Thames LiDAR 1m DSM (2017-2019)",
       "name": "thames_2017-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/reporoa-and-upper-piako-river_2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/reporoa-and-upper-piako-river_2019_dsm_1m/01JQN0HWFRNKM89E2NG08MJDJR/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Waikato - Reporoa and Upper Piako River LiDAR 1m DSM (2019)",
       "name": "reporoa-and-upper-piako-river_2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/northland/northland_2018-2020/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/northland_2018-2020_dsm_1m/01JQN0HWEAKEH7JAK8SJC9C1BF/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Northland LiDAR 1m DSM (2018-2020)",
       "name": "northland_2018-2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/wellington-city_2019-2020/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/wellington-city_2019-2020_dsm_1m/01JQN19CVDNGJ27QDJ79M9K6PD/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Wellington City LiDAR 1m DSM (2019-2020)",
       "name": "wellington-city_2019-2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/whanganui-urban_2020-2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/whanganui-urban_2020-2021_dsm_1m/01JQN19G8CKT9JJ7DPAM0D7QT9/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Manawatū-Whanganui - Whanganui Urban LiDAR 1m DSM (2020-2021)",
       "name": "whanganui-urban_2020-2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/waikato_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/waikato_2021_dsm_1m/01JQN19GZHVF0ZNPJ084HPR53E/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Waikato LiDAR 1m DSM (2021)",
       "name": "waikato_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/taranaki/taranaki_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/taranaki_2021_dsm_1m/01JQN19M6FSDE0BMNP8P69A0QB/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Taranaki LiDAR 1m DSM (2021)",
       "name": "taranaki_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/hutt-city_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hutt-city_2021_dsm_1m/01JQN19QFXEHR05VTHV4H19QNA/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Wellington - Hutt City LiDAR 1m DSM (2021)",
       "name": "hutt-city_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/kapiti-coast_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/kapiti-coast_2021_dsm_1m/01JQN19SSYEJ07X9S6SJVAWYCC/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Wellington - Kāpiti Coast LiDAR 1m DSM (2021)",
       "name": "kapiti-coast_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/upper-hutt-city_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/upper-hutt-city_2021_dsm_1m/01JQN19V67XXSA1HM61JN0HP4K/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Wellington - Upper Hutt City LiDAR 1m DSM (2021)",
       "name": "upper-hutt-city_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2019-2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/bay-of-plenty_2019-2022_dsm_1m/01JQN19ZC4KZZVTWRZRVPH2134/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Bay of Plenty LiDAR 1m DSM (2019-2022)",
       "name": "bay-of-plenty_2019-2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2022-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2022-2023_dsm_1m/01JQN1E9WEYXDFEWW5V9VPKAHZ/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2022-2023)",
       "name": "manawatu-whanganui_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/porirua_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/porirua_2023_dsm_1m/01JQN1EA4YR01QSNS39GYBNKYV/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Wellington - Porirua LiDAR 1m DSM (2023)",
       "name": "porirua_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/hamilton_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hamilton_2023_dsm_1m/01JQN1F6FPVY226BRZQDXM28B0/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Waikato - Hamilton LiDAR 1m DSM (2023)",
       "name": "hamilton_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/gisborne/gisborne_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/gisborne_2023_dsm_1m/01JQN1HAH2YEPB9NBHDA1BJDVD/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Gisborne LiDAR 1m DSM (2023)",
       "name": "gisborne_2023_dsm_1m"
     },
@@ -165,194 +165,194 @@
       "3857": "s3://linz-basemaps/elevation/3857/waikato_2024_dsm_1m/01JQN1HYF1JAWM5P88YE1MJ1S4/",
       "name": "waikato_2024_dsm_1m",
       "title": "Waikato LiDAR 1m DSM (2024)",
-      "minZoom": 5
+      "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2024/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/bay-of-plenty_2024_dsm_1m/01JQN1KGBYM9MJ69P451J39RSK/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Bay of Plenty LiDAR 1m DSM (2024)",
       "name": "bay-of-plenty_2024_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/hurunui-rivers_2013/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hurunui-rivers_2013_dsm_1m/01JQN1KGMBJ07CS7BCCST85XF1/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Hurunui Rivers LiDAR 1m DSM (2013)",
       "name": "hurunui-rivers_2013_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/timaru-rivers_2014/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/timaru-rivers_2014_dsm_1m/01JQN1P1C4RWV7WV6BT0YX0BFF/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Timaru Rivers LiDAR 1m DSM (2014)",
       "name": "timaru-rivers_2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/blenheim_2014/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/blenheim_2014_dsm_1m/01JQN1QXKMKCJTP24RBS0XSNE6/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Marlborough - Blenheim LiDAR 1m DSM (2014)",
       "name": "blenheim_2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/richmond-and-motueka_2015/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/richmond-and-motueka_2015_dsm_1m/01JQN1TJX3J57MP6ZKTRCYEHJJ/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Tasman - Richmond and Motueka LiDAR 1m DSM (2015)",
       "name": "richmond-and-motueka_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/hawarden_2015/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/hawarden_2015_dsm_1m/01JQN20FGEAYZ61RM2277DAQJV/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Hawarden LiDAR 1m DSM (2015)",
       "name": "hawarden_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch-and-selwyn_2015/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/christchurch-and-selwyn_2015_dsm_1m/01JQN212B574AW85B0MFJ42SZK/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Christchurch and Selwyn LiDAR 1m DSM (2015)",
       "name": "christchurch-and-selwyn_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/mackenzie_2015/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/mackenzie_2015_dsm_1m/01JQN21YXK33HH05KX63T815N4/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Mackenzie LiDAR 1m DSM (2015)",
       "name": "mackenzie_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2016/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/abel-tasman-and-golden-bay_2016_dsm_1m/01JQN2308MTSBJBQB5C3E24J6C/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DSM (2016)",
       "name": "abel-tasman-and-golden-bay_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/otago_2016/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/otago_2016_dsm_1m/01JQN23F6VC30N7TB95SBRP2QM/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago LiDAR 1m DSM (2016)",
       "name": "otago_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/queenstown_2016/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/queenstown_2016_dsm_1m/01JQN23QKWB6P3EB64PPNZ8SFH/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago - Queenstown LiDAR 1m DSM (2016)",
       "name": "queenstown_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2016-2017/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2016-2017_dsm_1m/01JQN262Q5ZJXNT30DNJ7795YN/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury LiDAR 1m DSM (2016-2017)",
       "name": "canterbury_2016-2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/golden-bay_2017/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/golden-bay_2017_dsm_1m/01JQN2AGSCWTS4Q2CT268SC3HB/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Tasman - Golden Bay LiDAR 1m DSM (2017)",
       "name": "golden-bay_2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/marlborough_2018/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/marlborough_2018_dsm_1m/01JQN2B1ABX6G1QTMNRDF44WB3/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Marlborough LiDAR 1m DSM (2018)",
       "name": "marlborough_2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/motueka-river-valley_2018-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/motueka-river-valley_2018-2019_dsm_1m/01JQN2CP2ZTNBKR3CCFQDZVBCH/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Tasman - Motueka River Valley LiDAR 1m DSM (2018-2019)",
       "name": "motueka-river-valley_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch-and-ashley-river_2018-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/christchurch-and-ashley-river_2018-2019_dsm_1m/01JQN2DJN233FFY9ZW5Y322FW9/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Christchurch and Ashley River LiDAR 1m DSM (2018-2019)",
       "name": "christchurch-and-ashley-river_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2018-2019/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2018-2019_dsm_1m/01JQN2F7S0AVG6CQB5XSX7SYJF/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury LiDAR 1m DSM (2018-2019)",
       "name": "canterbury_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/balclutha_2020/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/balclutha_2020_dsm_1m/01JQN2F9016HAV0TWYWJDG6P5B/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago - Balclutha LiDAR 1m DSM (2020)",
       "name": "balclutha_2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch_2020-2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/christchurch_2020-2021_dsm_1m/01JQN2H6X1MEM1D2H4SBZYWG29/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Christchurch LiDAR 1m DSM (2020-2021)",
       "name": "christchurch_2020-2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/nelson/nelson_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/nelson_2021_dsm_1m/01JQN2HB3FQNS6PXNFTXJXVSPZ/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Nelson LiDAR 1m DSM (2021)",
       "name": "nelson_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/central-otago_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/central-otago_2021_dsm_1m/01JQN2J3GNJ5ZT4X0TQBAVAW2R/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago - Central Otago LiDAR 1m DSM (2021)",
       "name": "central-otago_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/coastal-catchments_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/coastal-catchments_2021_dsm_1m/01JQN2JJCHBGHPMBC94HYR3KNR/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago - Coastal Catchments LiDAR 1m DSM (2021)",
       "name": "coastal-catchments_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/dunedin-and-mosgiel_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/dunedin-and-mosgiel_2021_dsm_1m/01JQN2K5SN5M1XS138400AAWRM/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago - Dunedin and Mosgiel LiDAR 1m DSM (2021)",
       "name": "dunedin-and-mosgiel_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/queenstown_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/queenstown_2021_dsm_1m/01JQN2NYZD1SW8TPKJCA380A14/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago - Queenstown LiDAR 1m DSM (2021)",
       "name": "queenstown_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/southland/stewart-island-rakiura-oban_2021/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/stewart-island-rakiura-oban_2021_dsm_1m/01JQN2PNFNJ8M4TMTMVX8B412E/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Stewart Island / Rakiura - Oban LiDAR 1m DSM (2021)",
       "name": "stewart-island-rakiura-oban_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/tasman_2020-2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/tasman_2020-2022_dsm_1m/01JQN2QJKC1MJQ57S4VFMTGF9F/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Tasman LiDAR 1m DSM (2020-2022)",
       "name": "tasman_2020-2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/marlborough_2020-2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/marlborough_2020-2022_dsm_1m/01JQN2RTAS51N8KWTTARRA0KC8/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Marlborough LiDAR 1m DSM (2020-2022)",
       "name": "marlborough_2020-2022_dsm_1m"
     },
@@ -361,89 +361,89 @@
       "3857": "s3://linz-basemaps/elevation/3857/west-coast_2020-2022_dsm_1m/01JQN2SFHQA0K3KAF3X8YYWJ87/",
       "name": "west-coast_2020-2022_dsm_1m",
       "title": "West Coast LiDAR 1m DSM (2020-2024) - Draft",
-      "minZoom": 5
+      "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/tasman/tasman-bay_2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/tasman-bay_2022_dsm_1m/01JQN2SGZ49XKX1B1DG3RG4X6M/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Tasman - Tasman Bay LiDAR 1m DSM (2022)",
       "name": "tasman-bay_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/nelson/top-of-the-south-flood_2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/top-of-the-south-flood_2022_dsm_1m/01JQN2SJSFV2JABW19FDB9X01J/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Nelson and Tasman - Top of the South Flood LiDAR 1m DSM (2022)",
       "name": "top-of-the-south-flood_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/kaikoura-and-waimakariri_2022/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/kaikoura-and-waimakariri_2022_dsm_1m/01JQN2V1ME1BQ8QKRA7H16TS1E/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Kaikōura and Waimakariri LiDAR 1m DSM (2022)",
       "name": "kaikoura-and-waimakariri_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/central-otago_2022-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/central-otago_2022-2023_dsm_1m/01JQN2XAAARKJQNHZD133S30XY/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago - Central Otago LiDAR 1m DSM (2022-2023)",
       "name": "central-otago_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/wanaka_2022-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/wanaka_2022-2023_dsm_1m/01JQN2ZE0TS4XDDEENJH12Z2SB/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Otago - Wanaka LiDAR 1m DSM (2022-2023)",
       "name": "wanaka_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/abel-tasman-and-golden-bay_2023_dsm_1m/01JQN33CXVTSJ8DA94YKXSKWYD/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DSM (2023)",
       "name": "abel-tasman-and-golden-bay_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/waimea-dam_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/waimea-dam_2023_dsm_1m/01JQN33K07HNGVVXJJS9RSPY1A/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Tasman - Waimea Dam LiDAR 1m DSM (2023)",
       "name": "waimea-dam_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/banks-peninsula_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/banks-peninsula_2023_dsm_1m/01JQN356PAVN6S6NS54VBK1DW8/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Banks Peninsula LiDAR 1m DSM (2023)",
       "name": "banks-peninsula_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/selwyn_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/selwyn_2023_dsm_1m/01JQN35QE0VNK99E2YT2P3ZGPG/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Selwyn LiDAR 1m DSM (2023)",
       "name": "selwyn_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/waimakariri_2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/waimakariri_2023_dsm_1m/01JQN38JJ0W9JEBJNYNM38V3HR/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury - Waimakariri LiDAR 1m DSM (2023)",
       "name": "waimakariri_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/southland/southland_2020-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/southland_2020-2023_dsm_1m/01JQN38N6SGSGC95PSKEZKBFJN/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Southland LiDAR 1m DSM (2020-2023)",
       "name": "southland_2020-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2020-2023/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/canterbury_2020-2023_dsm_1m/01JQN3D2K1M5DNSJ6EEDBJ5D2X/",
-      "minZoom": 5,
+      "minZoom": 9,
       "title": "Canterbury LiDAR 1m DSM (2020-2023)",
       "name": "canterbury_2020-2023_dsm_1m"
     },
@@ -452,21 +452,21 @@
       "3857": "s3://linz-basemaps/elevation/3857/hawkes-bay_2023_dsm_1m/01JQN3FZT3X11GAKB45T2XQ6Q6/",
       "name": "hawkes-bay_2023_dsm_1m",
       "title": "Hawke's Bay LiDAR 1m DSM (2023-2024)",
-      "minZoom": 5
+      "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2024/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2024_dsm_1m/01JQN3FASTV70PYS2PW309T7X7/",
       "name": "manawatu-whanganui_2024_dsm_1m",
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2024)",
-      "minZoom": 5
+      "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/northland/northland_2024/dsm_1m/2193/",
       "3857": "s3://linz-basemaps/elevation/3857/northland_2024_dsm_1m/01JQN3MVFCYHEAFCQSRDTG4HET/",
       "name": "northland_2024_dsm_1m",
       "title": "Northland LiDAR 1m DSM (2024)",
-      "minZoom": 5
+      "minZoom": 9
     }
   ],
   "outputs": [

--- a/config/tileset/elevation.dsm.json
+++ b/config/tileset/elevation.dsm.json
@@ -8,396 +8,462 @@
   "layers": [
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2010/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2010_dsm_1m/01JQN0HWF74P22K917SJRAV1SB/",
       "name": "canterbury_2010_dsm_1m",
       "title": "Canterbury LiDAR 1m DSM (2010)",
       "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/wellington/wellington_2013-2014/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/wellington_2013-2014_dsm_1m/01JQN0HWFQVA617NQ27GGNAKJD/",
       "minZoom": 9,
       "title": "Wellington LiDAR 1m DSM (2013-2014)",
       "name": "wellington_2013-2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2015-2016/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2015-2016_dsm_1m/01JQN0HWJ4GKEZXWN56MRF8G23/",
       "minZoom": 9,
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2015-2016)",
       "name": "manawatu-whanganui_2015-2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/auckland/auckland-south_2016-2017/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/auckland-south_2016-2017_dsm_1m/01JQN0HWCWT5MG7CRVKWCHJ3NY/",
       "minZoom": 9,
       "title": "Auckland South LiDAR 1m DSM (2016-2017)",
       "name": "auckland-south_2016-2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/auckland/auckland-north_2016-2018/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/auckland-north_2016-2018_dsm_1m/01JQN0HWE60P7KGVRWBG78VHQ3/",
       "minZoom": 9,
       "title": "Auckland North LiDAR 1m DSM (2016-2018)",
       "name": "auckland-north_2016-2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/palmerston-north_2018/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/palmerston-north_2018_dsm_1m/01JQN0HWHXH84CM4SS8CW9SFTN/",
       "minZoom": 9,
       "title": "Manawatū-Whanganui - Palmerston North LiDAR 1m DSM (2018)",
       "name": "palmerston-north_2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/huntly_2015-2019/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/huntly_2015-2019_dsm_1m/01JQN0HWHK35N16YHADQWZHTC3/",
       "minZoom": 9,
       "title": "Waikato - Huntly LiDAR 1m DSM (2015-2019)",
       "name": "huntly_2015-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/thames_2017-2019/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/thames_2017-2019_dsm_1m/01JQN0HWERF6QA34JA2W4C1TRW/",
       "minZoom": 9,
       "title": "Waikato - Thames LiDAR 1m DSM (2017-2019)",
       "name": "thames_2017-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/reporoa-and-upper-piako-river_2019/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/reporoa-and-upper-piako-river_2019_dsm_1m/01JQN0HWFRNKM89E2NG08MJDJR/",
       "minZoom": 9,
       "title": "Waikato - Reporoa and Upper Piako River LiDAR 1m DSM (2019)",
       "name": "reporoa-and-upper-piako-river_2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/northland/northland_2018-2020/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/northland_2018-2020_dsm_1m/01JQN0HWEAKEH7JAK8SJC9C1BF/",
       "minZoom": 9,
       "title": "Northland LiDAR 1m DSM (2018-2020)",
       "name": "northland_2018-2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/wellington-city_2019-2020/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/wellington-city_2019-2020_dsm_1m/01JQN19CVDNGJ27QDJ79M9K6PD/",
       "minZoom": 9,
       "title": "Wellington City LiDAR 1m DSM (2019-2020)",
       "name": "wellington-city_2019-2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/whanganui-urban_2020-2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/whanganui-urban_2020-2021_dsm_1m/01JQN19G8CKT9JJ7DPAM0D7QT9/",
       "minZoom": 9,
       "title": "Manawatū-Whanganui - Whanganui Urban LiDAR 1m DSM (2020-2021)",
       "name": "whanganui-urban_2020-2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/waikato_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/waikato_2021_dsm_1m/01JQN19GZHVF0ZNPJ084HPR53E/",
       "minZoom": 9,
       "title": "Waikato LiDAR 1m DSM (2021)",
       "name": "waikato_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/taranaki/taranaki_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/taranaki_2021_dsm_1m/01JQN19M6FSDE0BMNP8P69A0QB/",
       "minZoom": 9,
       "title": "Taranaki LiDAR 1m DSM (2021)",
       "name": "taranaki_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/hutt-city_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hutt-city_2021_dsm_1m/01JQN19QFXEHR05VTHV4H19QNA/",
       "minZoom": 9,
       "title": "Wellington - Hutt City LiDAR 1m DSM (2021)",
       "name": "hutt-city_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/kapiti-coast_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/kapiti-coast_2021_dsm_1m/01JQN19SSYEJ07X9S6SJVAWYCC/",
       "minZoom": 9,
       "title": "Wellington - Kāpiti Coast LiDAR 1m DSM (2021)",
       "name": "kapiti-coast_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/upper-hutt-city_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/upper-hutt-city_2021_dsm_1m/01JQN19V67XXSA1HM61JN0HP4K/",
       "minZoom": 9,
       "title": "Wellington - Upper Hutt City LiDAR 1m DSM (2021)",
       "name": "upper-hutt-city_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2019-2022/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/bay-of-plenty_2019-2022_dsm_1m/01JQN19ZC4KZZVTWRZRVPH2134/",
       "minZoom": 9,
       "title": "Bay of Plenty LiDAR 1m DSM (2019-2022)",
       "name": "bay-of-plenty_2019-2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2022-2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2022-2023_dsm_1m/01JQN1E9WEYXDFEWW5V9VPKAHZ/",
       "minZoom": 9,
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2022-2023)",
       "name": "manawatu-whanganui_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/wellington/porirua_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/porirua_2023_dsm_1m/01JQN1EA4YR01QSNS39GYBNKYV/",
       "minZoom": 9,
       "title": "Wellington - Porirua LiDAR 1m DSM (2023)",
       "name": "porirua_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/hamilton_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hamilton_2023_dsm_1m/01JQN1F6FPVY226BRZQDXM28B0/",
       "minZoom": 9,
       "title": "Waikato - Hamilton LiDAR 1m DSM (2023)",
       "name": "hamilton_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/gisborne/gisborne_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/gisborne_2023_dsm_1m/01JQN1HAH2YEPB9NBHDA1BJDVD/",
       "minZoom": 9,
       "title": "Gisborne LiDAR 1m DSM (2023)",
       "name": "gisborne_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/waikato/waikato_2024/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/waikato_2024_dsm_1m/01JQN1HYF1JAWM5P88YE1MJ1S4/",
       "name": "waikato_2024_dsm_1m",
       "title": "Waikato LiDAR 1m DSM (2024)",
       "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/bay-of-plenty/bay-of-plenty_2024/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/bay-of-plenty_2024_dsm_1m/01JQN1KGBYM9MJ69P451J39RSK/",
       "minZoom": 9,
       "title": "Bay of Plenty LiDAR 1m DSM (2024)",
       "name": "bay-of-plenty_2024_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/hurunui-rivers_2013/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hurunui-rivers_2013_dsm_1m/01JQN1KGMBJ07CS7BCCST85XF1/",
       "minZoom": 9,
       "title": "Canterbury - Hurunui Rivers LiDAR 1m DSM (2013)",
       "name": "hurunui-rivers_2013_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/timaru-rivers_2014/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/timaru-rivers_2014_dsm_1m/01JQN1P1C4RWV7WV6BT0YX0BFF/",
       "minZoom": 9,
       "title": "Canterbury - Timaru Rivers LiDAR 1m DSM (2014)",
       "name": "timaru-rivers_2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/blenheim_2014/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/blenheim_2014_dsm_1m/01JQN1QXKMKCJTP24RBS0XSNE6/",
       "minZoom": 9,
       "title": "Marlborough - Blenheim LiDAR 1m DSM (2014)",
       "name": "blenheim_2014_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/richmond-and-motueka_2015/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/richmond-and-motueka_2015_dsm_1m/01JQN1TJX3J57MP6ZKTRCYEHJJ/",
       "minZoom": 9,
       "title": "Tasman - Richmond and Motueka LiDAR 1m DSM (2015)",
       "name": "richmond-and-motueka_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/hawarden_2015/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hawarden_2015_dsm_1m/01JQN20FGEAYZ61RM2277DAQJV/",
       "minZoom": 9,
       "title": "Canterbury - Hawarden LiDAR 1m DSM (2015)",
       "name": "hawarden_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch-and-selwyn_2015/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/christchurch-and-selwyn_2015_dsm_1m/01JQN212B574AW85B0MFJ42SZK/",
       "minZoom": 9,
       "title": "Canterbury - Christchurch and Selwyn LiDAR 1m DSM (2015)",
       "name": "christchurch-and-selwyn_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/mackenzie_2015/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/mackenzie_2015_dsm_1m/01JQN21YXK33HH05KX63T815N4/",
       "minZoom": 9,
       "title": "Canterbury - Mackenzie LiDAR 1m DSM (2015)",
       "name": "mackenzie_2015_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2016/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/abel-tasman-and-golden-bay_2016_dsm_1m/01JQN2308MTSBJBQB5C3E24J6C/",
       "minZoom": 9,
       "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DSM (2016)",
       "name": "abel-tasman-and-golden-bay_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/otago_2016/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/otago_2016_dsm_1m/01JQN23F6VC30N7TB95SBRP2QM/",
       "minZoom": 9,
       "title": "Otago LiDAR 1m DSM (2016)",
       "name": "otago_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/queenstown_2016/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/queenstown_2016_dsm_1m/01JQN23QKWB6P3EB64PPNZ8SFH/",
       "minZoom": 9,
       "title": "Otago - Queenstown LiDAR 1m DSM (2016)",
       "name": "queenstown_2016_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2016-2017/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2016-2017_dsm_1m/01JQN262Q5ZJXNT30DNJ7795YN/",
       "minZoom": 9,
       "title": "Canterbury LiDAR 1m DSM (2016-2017)",
       "name": "canterbury_2016-2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/golden-bay_2017/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/golden-bay_2017_dsm_1m/01JQN2AGSCWTS4Q2CT268SC3HB/",
       "minZoom": 9,
       "title": "Tasman - Golden Bay LiDAR 1m DSM (2017)",
       "name": "golden-bay_2017_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/marlborough_2018/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/marlborough_2018_dsm_1m/01JQN2B1ABX6G1QTMNRDF44WB3/",
       "minZoom": 9,
       "title": "Marlborough LiDAR 1m DSM (2018)",
       "name": "marlborough_2018_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/motueka-river-valley_2018-2019/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/motueka-river-valley_2018-2019_dsm_1m/01JQN2CP2ZTNBKR3CCFQDZVBCH/",
       "minZoom": 9,
       "title": "Tasman - Motueka River Valley LiDAR 1m DSM (2018-2019)",
       "name": "motueka-river-valley_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch-and-ashley-river_2018-2019/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/christchurch-and-ashley-river_2018-2019_dsm_1m/01JQN2DJN233FFY9ZW5Y322FW9/",
       "minZoom": 9,
       "title": "Canterbury - Christchurch and Ashley River LiDAR 1m DSM (2018-2019)",
       "name": "christchurch-and-ashley-river_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2018-2019/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2018-2019_dsm_1m/01JQN2F7S0AVG6CQB5XSX7SYJF/",
       "minZoom": 9,
       "title": "Canterbury LiDAR 1m DSM (2018-2019)",
       "name": "canterbury_2018-2019_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/balclutha_2020/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/balclutha_2020_dsm_1m/01JQN2F9016HAV0TWYWJDG6P5B/",
       "minZoom": 9,
       "title": "Otago - Balclutha LiDAR 1m DSM (2020)",
       "name": "balclutha_2020_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/christchurch_2020-2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/christchurch_2020-2021_dsm_1m/01JQN2H6X1MEM1D2H4SBZYWG29/",
       "minZoom": 9,
       "title": "Canterbury - Christchurch LiDAR 1m DSM (2020-2021)",
       "name": "christchurch_2020-2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/nelson/nelson_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/nelson_2021_dsm_1m/01JQN2HB3FQNS6PXNFTXJXVSPZ/",
       "minZoom": 9,
       "title": "Nelson LiDAR 1m DSM (2021)",
       "name": "nelson_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/central-otago_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/central-otago_2021_dsm_1m/01JQN2J3GNJ5ZT4X0TQBAVAW2R/",
       "minZoom": 9,
       "title": "Otago - Central Otago LiDAR 1m DSM (2021)",
       "name": "central-otago_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/coastal-catchments_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/coastal-catchments_2021_dsm_1m/01JQN2JJCHBGHPMBC94HYR3KNR/",
       "minZoom": 9,
       "title": "Otago - Coastal Catchments LiDAR 1m DSM (2021)",
       "name": "coastal-catchments_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/dunedin-and-mosgiel_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/dunedin-and-mosgiel_2021_dsm_1m/01JQN2K5SN5M1XS138400AAWRM/",
       "minZoom": 9,
       "title": "Otago - Dunedin and Mosgiel LiDAR 1m DSM (2021)",
       "name": "dunedin-and-mosgiel_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/queenstown_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/queenstown_2021_dsm_1m/01JQN2NYZD1SW8TPKJCA380A14/",
       "minZoom": 9,
       "title": "Otago - Queenstown LiDAR 1m DSM (2021)",
       "name": "queenstown_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/southland/stewart-island-rakiura-oban_2021/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/stewart-island-rakiura-oban_2021_dsm_1m/01JQN2PNFNJ8M4TMTMVX8B412E/",
       "minZoom": 9,
       "title": "Stewart Island / Rakiura - Oban LiDAR 1m DSM (2021)",
       "name": "stewart-island-rakiura-oban_2021_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/tasman_2020-2022/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/tasman_2020-2022_dsm_1m/01JQN2QJKC1MJQ57S4VFMTGF9F/",
       "minZoom": 9,
       "title": "Tasman LiDAR 1m DSM (2020-2022)",
       "name": "tasman_2020-2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/marlborough/marlborough_2020-2022/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/marlborough_2020-2022_dsm_1m/01JQN2RTAS51N8KWTTARRA0KC8/",
       "minZoom": 9,
       "title": "Marlborough LiDAR 1m DSM (2020-2022)",
       "name": "marlborough_2020-2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/west-coast/west-coast_2020-2022/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/west-coast_2020-2022_dsm_1m/01JQN2SFHQA0K3KAF3X8YYWJ87/",
       "name": "west-coast_2020-2022_dsm_1m",
       "title": "West Coast LiDAR 1m DSM (2020-2024) - Draft",
       "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/tasman/tasman-bay_2022/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/tasman-bay_2022_dsm_1m/01JQN2SGZ49XKX1B1DG3RG4X6M/",
       "minZoom": 9,
       "title": "Tasman - Tasman Bay LiDAR 1m DSM (2022)",
       "name": "tasman-bay_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/nelson/top-of-the-south-flood_2022/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/top-of-the-south-flood_2022_dsm_1m/01JQN2SJSFV2JABW19FDB9X01J/",
       "minZoom": 9,
       "title": "Nelson and Tasman - Top of the South Flood LiDAR 1m DSM (2022)",
       "name": "top-of-the-south-flood_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/kaikoura-and-waimakariri_2022/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/kaikoura-and-waimakariri_2022_dsm_1m/01JQN2V1ME1BQ8QKRA7H16TS1E/",
       "minZoom": 9,
       "title": "Canterbury - Kaikōura and Waimakariri LiDAR 1m DSM (2022)",
       "name": "kaikoura-and-waimakariri_2022_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/central-otago_2022-2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/central-otago_2022-2023_dsm_1m/01JQN2XAAARKJQNHZD133S30XY/",
       "minZoom": 9,
       "title": "Otago - Central Otago LiDAR 1m DSM (2022-2023)",
       "name": "central-otago_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/otago/wanaka_2022-2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/wanaka_2022-2023_dsm_1m/01JQN2ZE0TS4XDDEENJH12Z2SB/",
       "minZoom": 9,
       "title": "Otago - Wanaka LiDAR 1m DSM (2022-2023)",
       "name": "wanaka_2022-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/abel-tasman-and-golden-bay_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/abel-tasman-and-golden-bay_2023_dsm_1m/01JQN33CXVTSJ8DA94YKXSKWYD/",
       "minZoom": 9,
       "title": "Tasman - Abel Tasman and Golden Bay LiDAR 1m DSM (2023)",
       "name": "abel-tasman-and-golden-bay_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/tasman/waimea-dam_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/waimea-dam_2023_dsm_1m/01JQN33K07HNGVVXJJS9RSPY1A/",
       "minZoom": 9,
       "title": "Tasman - Waimea Dam LiDAR 1m DSM (2023)",
       "name": "waimea-dam_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/banks-peninsula_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/banks-peninsula_2023_dsm_1m/01JQN356PAVN6S6NS54VBK1DW8/",
       "minZoom": 9,
       "title": "Canterbury - Banks Peninsula LiDAR 1m DSM (2023)",
       "name": "banks-peninsula_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/selwyn_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/selwyn_2023_dsm_1m/01JQN35QE0VNK99E2YT2P3ZGPG/",
       "minZoom": 9,
       "title": "Canterbury - Selwyn LiDAR 1m DSM (2023)",
       "name": "selwyn_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/waimakariri_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/waimakariri_2023_dsm_1m/01JQN38JJ0W9JEBJNYNM38V3HR/",
       "minZoom": 9,
       "title": "Canterbury - Waimakariri LiDAR 1m DSM (2023)",
       "name": "waimakariri_2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/southland/southland_2020-2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/southland_2020-2023_dsm_1m/01JQN38N6SGSGC95PSKEZKBFJN/",
       "minZoom": 9,
       "title": "Southland LiDAR 1m DSM (2020-2023)",
       "name": "southland_2020-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/canterbury/canterbury_2020-2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/canterbury_2020-2023_dsm_1m/01JQN3D2K1M5DNSJ6EEDBJ5D2X/",
       "minZoom": 9,
       "title": "Canterbury LiDAR 1m DSM (2020-2023)",
       "name": "canterbury_2020-2023_dsm_1m"
     },
     {
       "2193": "s3://nz-elevation/hawkes-bay/hawkes-bay_2023/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/hawkes-bay_2023_dsm_1m/01JQN3FZT3X11GAKB45T2XQ6Q6/",
       "name": "hawkes-bay_2023_dsm_1m",
       "title": "Hawke's Bay LiDAR 1m DSM (2023-2024)",
       "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/manawatu-whanganui/manawatu-whanganui_2024/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/manawatu-whanganui_2024_dsm_1m/01JQN3FASTV70PYS2PW309T7X7/",
       "name": "manawatu-whanganui_2024_dsm_1m",
       "title": "Manawatū-Whanganui LiDAR 1m DSM (2024)",
       "minZoom": 9
     },
     {
       "2193": "s3://nz-elevation/northland/northland_2024/dsm_1m/2193/",
+      "3857": "s3://linz-basemaps/elevation/3857/northland_2024_dsm_1m/01JQN3MVFCYHEAFCQSRDTG4HET/",
       "name": "northland_2024_dsm_1m",
       "title": "Northland LiDAR 1m DSM (2024)",
       "minZoom": 9


### PR DESCRIPTION
### Motivation

We now have DSM elevation data available to process and serve through Basemaps as `Terrain-RGB` tiles. This work defines a tileset to collage the DSM datasets. As part of this work, we have run each dataset through the [basemaps-imagery-import-cogify] Argo workflow to re-project it into `3857`.

### Modifications

We have cloned the existing [elevation] tileset config as a new file titled `elevation.dsm.json` and made the following modifications:

1. **Metadata**

   #### Before

   ```json
   {
     "id": "ts_elevation",
     "name": "elevation",
     "type": "raster",
     "description": "Elevation Basemap",
     "title": "Elevation",
     "category": "Elevation",
     ...
   ```

   #### After

   ```json
   {
     "id": "ts_elevation-dsm",
     "name": "elevation-dsm",
     "type": "raster",
     "description": "Elevation DSM Basemap",
     "title": "Elevation DSM",
     "category": "Elevation",
     ...
   ```

2. **Layers**

   For each layer in the array:

   - **2193**: found and replaced all instances of `dem` with `dsm`
   - **3857**: added the `s3://linz-basemaps/elevation/3857/...` path generated by the corresponding [basemaps-imagery-import-cogify] Argo workflow.
   - **title**: found and replaced all instances of `DEM` with `DSM`
   - **name**: found and replaced all instances of `dem` with `dsm`

   We have kept the following layer from the existing [elevation] tileset config to serve as a backdrop from zoom levels `0-8`. Without it, the map would appear empty between those zoom levels:
   ```json
   [
     {
       "2193": "s3://nz-elevation/new-zealand/new-zealand-contour/dsm_8m/2193/",
       "title": "New Zealand 8m DSM (2012)",
       "name": "new-zealand_2012_dem_8m",
       "maxZoom": 8
     }
   ]
   ```

   We have deleted the following layers from the tileset config as they have no equivalent `dsm` dataset:

   ```json
   [
     {
       "2193": "s3://nz-elevation/bay-of-plenty/tauranga_2022/dsm_1m/2193/",
       "minZoom": 9,
       "title": "Bay of Plenty - Tauranga LiDAR 1m DSM (2022)",
       "name": "tauranga_2022_dsm_1m",
     },
     {
       "2193": "s3://nz-elevation/tasman/tasman_2008-2015/dsm_1m/2193/",
       "minZoom": 9,
       "title": "Nelson and Tasman LiDAR 1m DSM (2008-2015)",
       "name": "tasman_2008-2015_dsm_1m",
     },
     {
       "2193": "s3://nz-elevation/canterbury/kaikoura_2016-2017/dsm_1m/2193/",
       "minZoom": 9,
       "title": "Canterbury - Kaikōura LiDAR 1m DSM (2016-2017)",
       "name": "kaikoura_2016-2017_dsm_1m",
     }
   ]
   ```

### Verification

#### Import Success

All 66 [basemaps-imagery-import-cogify] Argo workflows (one for each layer) succeeded without failure. The [resulting imagery] also appears as we would expect it to in Basemaps.

| [Full View] |
| - |
| ![][full_view] |

#### Partial Coverage

Depending on where you zoom on the map, in some regions, [the map will disappear] after zoom level `8`. This is expected. Such regions just do not have any DSM coverage.

| DEM Backdrop Only | DSM Only |
| - | - |
| ![][dem_backdrop_only] | ![][dsm_only] |
| Zoom levels `0-8` | Zoom levels `9+` |

<!-- external links -->

[basemaps-imagery-import-cogify]: https://github.com/linz/topo-workflows/blob/master/workflows/basemaps/imagery-import-cogify.yml

[elevation]: https://github.com/linz/basemaps-config/blob/feat/elevation-dsm-tileset/config/tileset/elevation.json

[resulting imagery]: https://basemaps.linz.govt.nz/?i=elevation-dsm&config=TmVmbYRQjL9T2JWgyaSie193b4D1qZnBD8hjaSqPFYSsEvEYYhaGYKrcjgjmijAA5MdGnusLR6Ce5pQq7Zht5DfvKq5kc3381iERsd4dYr9MZxENs79A5ckgyb2zYe5&debug=true&debug.layer=basemaps-elevation-dsm-color-ramp

[the map will disappear]: https://basemaps.linz.govt.nz/@-39.5126503,175.4614087,z8?i=elevation-dsm&config=TmVmbYRQjL9T2JWgyaSie193b4D1qZnBD8hjaSqPFYSsEvEYYhaGYKrcjgjmijAA5MdGnusLR6Ce5pQq7Zht5DfvKq5kc3381iERsd4dYr9MZxENs79A5ckgyb2zYe5&debug=true&debug.layer=basemaps-elevation-dsm-color-ramp

[Full View]: https://basemaps.linz.govt.nz/?i=elevation-dsm&config=TmVmbYRQjL9T2JWgyaSie193b4D1qZnBD8hjaSqPFYSsEvEYYhaGYKrcjgjmijAA5MdGnusLR6Ce5pQq7Zht5DfvKq5kc3381iERsd4dYr9MZxENs79A5ckgyb2zYe5&debug=true&debug.layer=basemaps-elevation-dsm-color-ramp

<!-- external images -->

[full_view]: https://github.com/user-attachments/assets/ff6ae1aa-9543-446e-afd4-0fa73f27f29f
[dem_backdrop_only]: https://github.com/user-attachments/assets/2da5a605-3152-490c-b3d8-4d237c86a282
[dsm_only]: https://github.com/user-attachments/assets/fa20af7c-9efa-434b-80fe-3c41fdcde92b