### PR TITLE
fix: smoke test not running due to relative path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,7 @@ jobs:
           # Wait for the server to start
           timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${BASEMAPS_HOST}/v1/version)" !=  "200" ]]; do sleep 0.5; done' || false
 
-          ./scripts/bmc.sh --test /app/node_modules/@basemaps/smoke/build/
+          ./scripts/bmc.sh --test /app/node_modules/@basemaps/smoke/build/*.test.js
 
       - name: (Smoke) Stop Server
         run: docker stop bms


### PR DESCRIPTION
### Motivation

smoke test not running due to relative path and glob patterns

### Modifications

use absolute path and glob *.test.js

### Verification

tested in basemaps cli container, relative path works with `ENV NODE_MAJOR=20` but not `ENV NODE_MAJOR=24`