### PR TITLE
chore: set Basemaps team as CODEOWNER of tilesets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,12 @@
 * @linz/proj-basemaps-dev
-config/tileset/*/imagery/*.json @linz/proj-basemaps-dev @linz/imagery
-config/tileset/aerial.json @linz/proj-basemaps-dev @linz/imagery
-config/tileset/event.*.json @linz/proj-basemaps-dev @linz/imagery
-config/tileset/scanned.*.json @linz/proj-basemaps-dev @linz/imagery
-config/tileset/elevation.json @linz/proj-basemaps-dev @linz/elevation
-config/tileset/elevation.*.json @linz/proj-basemaps-dev @linz/elevation
-config/tileset/hillshade.json @linz/proj-basemaps-dev @linz/elevation
-config/tileset/hillshade.*.json @linz/proj-basemaps-dev @linz/elevation
+config/tileset/*/imagery/*.json @linz/proj-basemaps @linz/imagery
+config/tileset/aerial.json @linz/proj-basemaps @linz/imagery
+config/tileset/event.*.json @linz/proj-basemaps @linz/imagery
+config/tileset/scanned.*.json @linz/proj-basemaps @linz/imagery
+config/tileset/elevation.json @linz/proj-basemaps @linz/elevation
+config/tileset/elevation.*.json @linz/proj-basemaps @linz/elevation
+config/tileset/hillshade.json @linz/proj-basemaps @linz/elevation
+config/tileset/hillshade.*.json @linz/proj-basemaps @linz/elevation
+config/tileset/topo-raster.json @linz/proj-basemaps
+config/tileset/topographic-v2.json @linz/proj-basemaps
+config/tileset/topographic.json @linz/proj-basemaps


### PR DESCRIPTION
### Motivation

@JBLINZ needs to be able to sign-off on tileset changes

### Modifications

Updated CODEOWNERS file to specify Basemaps team as owner of tilesets rather than Basemaps developers.

### Verification

GitHub validates the CODEOWNERS file as valid.