### PR TITLE
fix(style): Fix the topolite-v2 and labels-v2 to styles to support NZTM2000Quad TileMatrix.

### DIFF
--- a/config/style/labels-v2.json
+++ b/config/style/labels-v2.json
@@ -1719,7 +1719,7 @@
     "sky-horizon-blend": 0.5
   },
   "sources": {
-    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic-v2/EPSG:3857/tile.json" }
+    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic-v2/{tileMatrix}/tile.json" }
   },
   "sprite": "/v1/sprites/topographic",
   "version": 8

--- a/config/style/topolite-v2.json
+++ b/config/style/topolite-v2.json
@@ -2422,8 +2422,8 @@
   "metadata": { "maputnik:renderer": "mbgljs" },
   "name": "topolite-v2",
   "sources": {
-    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic-v2/EPSG:3857/tile.json" },
-    "LINZ-Texture-Relief": { "maxzoom": 20, "minzoom": 0, "tileSize": 256, "tiles": ["/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp"], "type": "raster" }
+    "LINZ Basemaps": { "attribution": "© 2022 Toitū Te Whenua - CC BY 4.0", "type": "vector", "url": "/v1/tiles/topographic-v2/{tileMatrix}/tile.json" },
+    "LINZ-Texture-Relief": { "maxzoom": 20, "minzoom": 0, "tileSize": 256, "tiles": ["/v1/tiles/texturereliefshade/{tileMatrix}/{z}/{x}/{y}.webp"], "type": "raster" }
   },
   "sprite": "/v1/sprites/topographic",
   "version": 8


### PR DESCRIPTION
### Motivation

We only updated the source urls for topographic-v2 but not for topolite-v2 and labels-v2.

### Modifications
Update topolite-v2 and labels-v2 to support NZTM shortbread tiles.

### Verification

<!-- TODO: Say how you tested your changes. -->