### PR TITLE
build: Remove third party github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,7 @@ jobs:
           docker run --rm --network="host" -v $PWD:$PWD ${DOCKER_AWS_ENV} ${SCREENSHOT_CONTAINER} --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
-        uses: blacha/action-visual-snapshot@v2-next
+        uses: linz/action-visual-snapshot@v2.1
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -284,7 +284,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: blacha/action-visual-snapshot@v2-next
+        uses: linz/action-visual-snapshot@v2.1
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'


### PR DESCRIPTION
### Motivation

LINZ security team blocks all the third party github actions on 7th July

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->