### PR TITLE
fix: correct auckland dataset id formatting

### DIFF
--- a/config/tileset/auckland/imagery/auckland-2010-2012-0.5m.json
+++ b/config/tileset/auckland/imagery/auckland-2010-2012-0.5m.json
@@ -1,6 +1,6 @@
 {
   "type": "raster",
-  "id": "ts_auckland_2010-2012_0.50m",
+  "id": "ts-auckland-2010-2012-0.5m",
   "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
   "background": {
     "r": 0,
@@ -13,7 +13,7 @@
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2010-2012_0-50m_RGBA/01F66DT3ZBYZZM6R0AF9Q2989R/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2010-2012_0-50m_RGBA/01ED81BNAX2ESPMV59YPC3AQ2C/",
-      "name": "auckland_2010-2012_0.50m",
+      "name": "auckland-2010-2012-0.5m",
       "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/auckland/imagery/auckland-2010-2012-0.5m.json
+++ b/config/tileset/auckland/imagery/auckland-2010-2012-0.5m.json
@@ -1,6 +1,6 @@
 {
   "type": "raster",
-  "id": "ts-auckland-2010-2012-0.5m",
+  "id": "ts_auckland-2010-2012-0.5m",
   "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
   "background": {
     "r": 0,

--- a/config/tileset/auckland/imagery/auckland-2017-0.075m.json
+++ b/config/tileset/auckland/imagery/auckland-2017-0.075m.json
@@ -1,6 +1,6 @@
 {
   "type": "raster",
-  "id": "ts_auckland_2017_0.075m",
+  "id": "ts_auckland-2017-0.075m",
   "title": "Auckland 0.075m Urban Aerial Photos (2017)",
   "background": {
     "r": 0,
@@ -13,7 +13,7 @@
     {
       "2193": "s3://linz-basemaps/2193/auckland_urban_2017_0-075m/01F66DXCRR1CFTFQTE5R3525EJ/",
       "3857": "s3://linz-basemaps/3857/auckland_urban_2017_0-075m/01ED81HZRR86YBB8A0ZQRABP96/",
-      "name": "auckland_2017_0.075m",
+      "name": "auckland-2017-0.075m",
       "title": "Auckland 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,


### PR DESCRIPTION
Fixing cases of using underscores instead of dashes, as well a trailing 0 in the GSD.