### PR TITLE
feat: add dsm hillshade layers BM-1277

### DIFF
--- a/config/tileset/hillshade.dsm.json
+++ b/config/tileset/hillshade.dsm.json
@@ -1,5 +1,5 @@
 {
-  "id": "ts_hillshade_dsm",
+  "id": "ts_hillshade-dsm",
   "name": "hillshade-dsm",
   "type": "raster",
   "description": "New Zealand DSM Hillshade Standard",

--- a/config/tileset/hillshade.dsm.json
+++ b/config/tileset/hillshade.dsm.json
@@ -1,0 +1,41 @@
+{
+  "id": "ts_hillshade_dsm",
+  "name": "hillshade-dsm",
+  "type": "raster",
+  "description": "New Zealand Dsm Hillshade Standard",
+  "title": "Hillshade Standard Dsm",
+  "category": "Elevation",
+  "layers": [
+    {
+      "2193": "s3://linz-basemaps/2193/new-zealand/01K0N4C5D7596XMPZZS6E451YA/",
+      "3857": "s3://linz-basemaps/3857/new-zealand/01K0N4E51JX22XMK6QZMDRC64P/",
+      "title": "New Zealand DSM Hillshade Overview",
+      "name": "new-zealand_dsm_hillshade_overview",
+      "maxZoom": 10
+    },
+    {
+      "2193": "s3://nz-elevation/new-zealand/new-zealand/dsm-hillshade/2193/",
+      "3857": "s3://linz-basemaps/3857/new-zealand/01K0NGX8JFMV7TDN9FHJDR4JQE/",
+      "title": "New Zealand DSM Hillshade",
+      "name": "new-zealand_dsm_hillshade",
+      "minZoom": 11
+    }
+  ],
+  "outputs": [
+    {
+      "title": "Color ramp",
+      "name": "color-ramp",
+      "pipeline": [
+        {
+          "type": "color-ramp"
+        }
+      ],
+      "background": {
+        "r": 182,
+        "g": 182,
+        "b": 182,
+        "alpha": 1
+      }
+    }
+  ]
+}

--- a/config/tileset/hillshade.dsm.json
+++ b/config/tileset/hillshade.dsm.json
@@ -2,8 +2,8 @@
   "id": "ts_hillshade_dsm",
   "name": "hillshade-dsm",
   "type": "raster",
-  "description": "New Zealand Dsm Hillshade Standard",
-  "title": "Hillshade Standard Dsm",
+  "description": "New Zealand DSM Hillshade Standard",
+  "title": "Hillshade Standard DSM",
   "category": "Elevation",
   "layers": [
     {

--- a/config/tileset/hillshade.igor.dsm.json
+++ b/config/tileset/hillshade.igor.dsm.json
@@ -1,0 +1,41 @@
+{
+  "id": "ts_hillshade-igor-dsm",
+  "name": "hillshade-igor-dsm",
+  "type": "raster",
+  "description": "New Zealand Dsm Hillshade Igor",
+  "title": "Hillshade Igor Dsm",
+  "category": "Elevation",
+  "layers": [
+    {
+      "2193": "s3://linz-basemaps/3857/new-zealand/01K0N5VVCN4YW6R7R8QSASPCSB/",
+      "3857": "s3://linz-basemaps/2193/new-zealand/01K0N5W9YGX6P1X1KG1BRF4014/",
+      "title": "New Zealand DSM Hillshade Igor Overview",
+      "name": "new-zealand_dsm_hillshade_igor_overview",
+      "maxZoom": 10
+    },
+    {
+      "2193": "s3://nz-elevation/new-zealand/new-zealand/dsm-hillshade-igor/2193/",
+      "3857": "s3://linz-basemaps/3857/new-zealand/01K0QB7KHJZB0QA4G5A6C4057N/",
+      "title": "New Zealand DSM Hillshade Igor",
+      "name": "new-zealand_dsm_hillshade_igor",
+      "minZoom": 11
+    }
+  ],
+  "outputs": [
+    {
+      "title": "Color ramp",
+      "name": "color-ramp",
+      "pipeline": [
+        {
+          "type": "color-ramp"
+        }
+      ],
+      "background": {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "alpha": 1
+      }
+    }
+  ]
+}

--- a/config/tileset/hillshade.igor.dsm.json
+++ b/config/tileset/hillshade.igor.dsm.json
@@ -2,8 +2,8 @@
   "id": "ts_hillshade-igor-dsm",
   "name": "hillshade-igor-dsm",
   "type": "raster",
-  "description": "New Zealand Dsm Hillshade Igor",
-  "title": "Hillshade Igor Dsm",
+  "description": "New Zealand DSM Hillshade Igor",
+  "title": "Hillshade Igor DSM",
   "category": "Elevation",
   "layers": [
     {

--- a/config/tileset/hillshade.igor.dsm.json
+++ b/config/tileset/hillshade.igor.dsm.json
@@ -7,8 +7,8 @@
   "category": "Elevation",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/3857/new-zealand/01K0N5VVCN4YW6R7R8QSASPCSB/",
-      "3857": "s3://linz-basemaps/2193/new-zealand/01K0N5W9YGX6P1X1KG1BRF4014/",
+      "2193": "s3://linz-basemaps/2193/new-zealand/01K0N5W9YGX6P1X1KG1BRF4014/",
+      "3857": "s3://linz-basemaps/3857/new-zealand/01K0N5VVCN4YW6R7R8QSASPCSB/",
       "title": "New Zealand DSM Hillshade Igor Overview",
       "name": "new-zealand_dsm_hillshade_igor_overview",
       "maxZoom": 10


### PR DESCRIPTION
### Motivation

Two new national DSM hillshade layers have been published in AWS ODR. We want these layers to be published via basemaps for individual use and combined use in our various configs (Aerial, Topographic v2, NZ Topo). 

Layers will be published and regularly updated in ODR in 2193. From there, we must consume the data and create a 3857 version.

### Modifications

dsm: https://argo.linzaccess.com/workflows/argo/basemaps-imagery-import-cogify-9ntcn?tab=summary&uid=2869aaa1-aad7-45e8-863d-0a40879fec93

dsm igor: https://argo.linzaccess.com/workflows/argo/basemaps-imagery-import-cogify-z55f9?tab=summary&uid=cbb70f60-5848-4220-8733-862483c27d0c

dsm overview?: https://argo.linzaccess.com/workflows/argo/basemaps-imagery-import-cogify-gh8fb?tab=summary&uid=7cf64b4e-3236-4f14-a295-cfbf9eab0436

dsm igor overview?: https://argo.linzaccess.com/workflows/argo/basemaps-imagery-import-cogify-tr5k5?tab=summary&uid=30e6882c-2fad-41d4-9797-2bfd84372140

