### PR TITLE
fix: add back urban and rural for broken wmts links BM-1334

### DIFF
--- a/config/tileset/auckland/imagery/auckland-2010-2012-0.5m.json
+++ b/config/tileset/auckland/imagery/auckland-2010-2012-0.5m.json
@@ -9,11 +9,12 @@
     "alpha": 0
   },
   "category": "Rural Aerial Photos",
+  "aliases": ["auckland-rural-2010-2012-0.5m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2010-2012_0-50m_RGBA/01F66DT3ZBYZZM6R0AF9Q2989R/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2010-2012_0-50m_RGBA/01ED81BNAX2ESPMV59YPC3AQ2C/",
-      "name": "auckland-rural-2010-2012-0.5m",
+      "name": "auckland-2010-2012-0.5m",
       "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/auckland/imagery/auckland-2010-2012-0.5m.json
+++ b/config/tileset/auckland/imagery/auckland-2010-2012-0.5m.json
@@ -13,7 +13,7 @@
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2010-2012_0-50m_RGBA/01F66DT3ZBYZZM6R0AF9Q2989R/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2010-2012_0-50m_RGBA/01ED81BNAX2ESPMV59YPC3AQ2C/",
-      "name": "auckland-2010-2012-0.5m",
+      "name": "auckland-rural-2010-2012-0.5m",
       "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/auckland/imagery/auckland-2017-0.075m.json
+++ b/config/tileset/auckland/imagery/auckland-2017-0.075m.json
@@ -13,7 +13,7 @@
     {
       "2193": "s3://linz-basemaps/2193/auckland_urban_2017_0-075m/01F66DXCRR1CFTFQTE5R3525EJ/",
       "3857": "s3://linz-basemaps/3857/auckland_urban_2017_0-075m/01ED81HZRR86YBB8A0ZQRABP96/",
-      "name": "auckland-2017-0.075m",
+      "name": "auckland-urban-2017-0.075m",
       "title": "Auckland 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/auckland/imagery/auckland-2017-0.075m.json
+++ b/config/tileset/auckland/imagery/auckland-2017-0.075m.json
@@ -9,11 +9,12 @@
     "alpha": 0
   },
   "category": "Urban Aerial Photos",
+  "aliases": ["auckland-urban-2017-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/auckland_urban_2017_0-075m/01F66DXCRR1CFTFQTE5R3525EJ/",
       "3857": "s3://linz-basemaps/3857/auckland_urban_2017_0-075m/01ED81HZRR86YBB8A0ZQRABP96/",
-      "name": "auckland-urban-2017-0.075m",
+      "name": "auckland-2017-0.075m",
       "title": "Auckland 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/auckland/imagery/auckland-2020-0.075m.json
+++ b/config/tileset/auckland/imagery/auckland-2020-0.075m.json
@@ -9,11 +9,12 @@
     "alpha": 0
   },
   "category": "Rural Aerial Photos",
+  "aliases": ["auckland-rural-2020-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8/",
-      "name": "auckland-rural-2020-0.075m",
+      "name": "auckland-2020-0.075m",
       "title": "Auckland 0.075m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/auckland/imagery/auckland-2020-0.075m.json
+++ b/config/tileset/auckland/imagery/auckland-2020-0.075m.json
@@ -13,7 +13,7 @@
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2020_0-075m_RGB/01G4XPNP9JTGGPABCFRWC4N21E/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2020_0-075m_RGB/01G4XPQKF6VB9SXCQ93R2XC1W8/",
-      "name": "auckland-2020-0.075m",
+      "name": "auckland-rural-2020-0.075m",
       "title": "Auckland 0.075m Rural Aerial Photos (2020)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/auckland/imagery/auckland-2022-0.075m.json
+++ b/config/tileset/auckland/imagery/auckland-2022-0.075m.json
@@ -10,11 +10,12 @@
     "alpha": 0
   },
   "category": "Rural Aerial Photos",
+  "aliases": ["auckland-rural-2022-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2022_0-075m_RGB/01G6HJ9S4PGK6MTVEZWWHV56QN/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2022_0-075m_RGB/01G6HJBFJRBKJ7FQPHVRACKMNQ/",
-      "name": "auckland-rural-2022-0.075m",
+      "name": "auckland-2022-0.075m",
       "title": "Auckland 0.075m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/auckland/imagery/auckland-2022-0.075m.json
+++ b/config/tileset/auckland/imagery/auckland-2022-0.075m.json
@@ -14,7 +14,7 @@
     {
       "2193": "s3://linz-basemaps/2193/auckland_rural_2022_0-075m_RGB/01G6HJ9S4PGK6MTVEZWWHV56QN/",
       "3857": "s3://linz-basemaps/3857/auckland_rural_2022_0-075m_RGB/01G6HJBFJRBKJ7FQPHVRACKMNQ/",
-      "name": "auckland-2022-0.075m",
+      "name": "auckland-rural-2022-0.075m",
       "title": "Auckland 0.075m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-2020-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-2020-0.1m.json
@@ -14,7 +14,7 @@
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FVDF75ZM3KHXDYJES57AG/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FX6SQBKE27MWG6K3E86CM/",
-      "name": "bay-of-plenty-2020-0.1m",
+      "name": "bay-of-plenty-urban-2020-0.1m",
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-2020-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-2020-0.1m.json
@@ -10,11 +10,12 @@
     "alpha": 0
   },
   "category": "Urban Aerial Photos",
+  "aliases": ["bay-of-plenty-urban-2020-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FVDF75ZM3KHXDYJES57AG/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2020_0-1m_RGB/01FJ0FX6SQBKE27MWG6K3E86CM/",
-      "name": "bay-of-plenty-urban-2020-0.1m",
+      "name": "bay-of-plenty-2020-0.1m",
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-2021-0.2m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-2021-0.2m.json
@@ -10,11 +10,12 @@
     "alpha": 0
   },
   "category": "Rural Aerial Photos",
+  "aliases": ["bay-of-plenty-rural-2021-0.2m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2021_0-2m/01H3E4XFK8N1JYJCM8BHDQAJPQ/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2021_0-2m/01H3E4ZG0MJ0SABSSBW2MJXVNS/",
-      "name": "bay-of-plenty-rural-2021-0.2m",
+      "name": "bay-of-plenty-2021-0.2m",
       "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-2021-0.2m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-2021-0.2m.json
@@ -14,7 +14,7 @@
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2021_0-2m/01H3E4XFK8N1JYJCM8BHDQAJPQ/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2021_0-2m/01H3E4ZG0MJ0SABSSBW2MJXVNS/",
-      "name": "bay-of-plenty-2021-0.2m",
+      "name": "bay-of-plenty-rural-2021-0.2m",
       "title": "Bay of Plenty 0.2m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-2022-0.05m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-2022-0.05m.json
@@ -8,7 +8,7 @@
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK/",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94/",
-      "name": "hawkes-bay-2022-0.05m",
+      "name": "hawkes-bay-urban-2022-0.05m",
       "title": "Hawke's Bay 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-2022-0.05m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-2022-0.05m.json
@@ -4,11 +4,12 @@
   "title": "Hawke's Bay 0.05m Urban Aerial Photos (2022)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hawkes-bay-urban-2022-0.05m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBBC9BX6YD2BZYN0S00YK/",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.05m_RGB/01GD1VBRXY4647H7ATEXNSNZ94/",
-      "name": "hawkes-bay-urban-2022-0.05m",
+      "name": "hawkes-bay-2022-0.05m",
       "title": "Hawke's Bay 0.05m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-2022-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-2022-0.1m.json
@@ -8,7 +8,7 @@
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ/",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546/",
-      "name": "hawkes-bay-2022-0.1m",
+      "name": "hawkes-bay-urban-2022-0.1m",
       "title": "Hawke's Bay 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-2022-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-2022-0.1m.json
@@ -4,11 +4,12 @@
   "title": "Hawke's Bay 0.01m Urban Aerial Photos (2022)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hawkes-bay-urban-2022-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_urban_2022_0.1m_RGB/01GD1TW8AFTNCGHNG97P9MDFYZ/",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_urban_2022_0.1m_RGB/01GD1TXCTKWJ2TKJR8ZVKNA546/",
-      "name": "hawkes-bay-urban-2022-0.1m",
+      "name": "hawkes-bay-2022-0.1m",
       "title": "Hawke's Bay 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/otago/imagery/otago-2019-2021-0.3m.json
+++ b/config/tileset/otago/imagery/otago-2019-2021-0.3m.json
@@ -8,7 +8,7 @@
     {
       "2193": "s3://linz-basemaps/2193/otago_rural_2019-2021_0-3m_RGB/01FKP9RXGA4EXSFWBGKHKVTPMT/",
       "3857": "s3://linz-basemaps/3857/otago_rural_2019-2021_0-3m_RGB/01FKP9PAF9VNHC4FYGQRGHF593/",
-      "name": "otago-2019-2021-0.3m",
+      "name": "otago-rural-2019-2021-0.3m",
       "title": "Otago 0.3m Rural Aerial Photos (2019-2021)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/otago/imagery/otago-2019-2021-0.3m.json
+++ b/config/tileset/otago/imagery/otago-2019-2021-0.3m.json
@@ -4,11 +4,12 @@
   "title": "Otago 0.3m Rural Aerial Photos (2019-2021)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["otago-rural-2019-2021-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/otago_rural_2019-2021_0-3m_RGB/01FKP9RXGA4EXSFWBGKHKVTPMT/",
       "3857": "s3://linz-basemaps/3857/otago_rural_2019-2021_0-3m_RGB/01FKP9PAF9VNHC4FYGQRGHF593/",
-      "name": "otago-rural-2019-2021-0.3m",
+      "name": "otago-2019-2021-0.3m",
       "title": "Otago 0.3m Rural Aerial Photos (2019-2021)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-2022-0.3m.json
+++ b/config/tileset/tasman/imagery/tasman-2022-0.3m.json
@@ -10,11 +10,12 @@
     "alpha": 0
   },
   "category": "Rural Aerial Photos",
+  "aliases": ["tasman-rural-2022-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2022_0-3m_RGB/01G75YD43EBA980HFWVF6ZFV6B/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2022_0-3m_RGB/01G75YDG4KFEZ5BAGTPHMEAPP7/",
-      "name": "tasman-rural-2022-0.3m",
+      "name": "tasman-2022-0.3m",
       "title": "Tasman 0.3m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-2022-0.3m.json
+++ b/config/tileset/tasman/imagery/tasman-2022-0.3m.json
@@ -14,7 +14,7 @@
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2022_0-3m_RGB/01G75YD43EBA980HFWVF6ZFV6B/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2022_0-3m_RGB/01G75YDG4KFEZ5BAGTPHMEAPP7/",
-      "name": "tasman-2022-0.3m",
+      "name": "tasman-rural-2022-0.3m",
       "title": "Tasman 0.3m Rural Aerial Photos (2022)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-rural-2018-2019-0.3m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2018-2019-0.3m.json
@@ -14,7 +14,7 @@
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2018-19_0-3m/01F6P1VDEYFR0XB5XJMN9X6V1C/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2018-19_0-3m/01ED83DSMR8N1FQFVXM8JASBV2/",
-      "name": "tasman-2018-2019-0.3m",
+      "name": "tasman-rural-2018-2019-0.3m",
       "title": "Tasman 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-rural-2018-2019-0.3m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2018-2019-0.3m.json
@@ -10,11 +10,12 @@
     "alpha": 0
   },
   "category": "Rural Aerial Photos",
+  "aliases": ["tasman-rural-2018-2019-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2018-19_0-3m/01F6P1VDEYFR0XB5XJMN9X6V1C/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2018-19_0-3m/01ED83DSMR8N1FQFVXM8JASBV2/",
-      "name": "tasman-rural-2018-2019-0.3m",
+      "name": "tasman-2018-2019-0.3m",
       "title": "Tasman 0.3m Rural Aerial Photos (2018-2019)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/carterton-2021-0.075m.json
+++ b/config/tileset/wellington/imagery/carterton-2021-0.075m.json
@@ -4,11 +4,12 @@
   "title": "Carterton 0.075m Urban Aerial Photos (2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["carterton-urban-2021-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/carterton_urban_2021_0-075m_RGB/01FC534VYVGP4WMS19M8SV1E6S/",
       "3857": "s3://linz-basemaps/3857/carterton_urban_2021_0-075m_RGB/01FC53660FJRP02Z4GZAQPZJV6/",
-      "name": "carterton-urban-2021-0.075m",
+      "name": "carterton-2021-0.075m",
       "title": "Carterton 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/carterton-2021-0.075m.json
+++ b/config/tileset/wellington/imagery/carterton-2021-0.075m.json
@@ -8,7 +8,7 @@
     {
       "2193": "s3://linz-basemaps/2193/carterton_urban_2021_0-075m_RGB/01FC534VYVGP4WMS19M8SV1E6S/",
       "3857": "s3://linz-basemaps/3857/carterton_urban_2021_0-075m_RGB/01FC53660FJRP02Z4GZAQPZJV6/",
-      "name": "carterton-2021-0.075m",
+      "name": "carterton-urban-2021-0.075m",
       "title": "Carterton 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/masterton-2021-0.075m.json
+++ b/config/tileset/wellington/imagery/masterton-2021-0.075m.json
@@ -8,7 +8,7 @@
     {
       "2193": "s3://linz-basemaps/2193/masterton_urban_2021_0-075m_RGB/01FCYQ2P6RB18BWV5B8WTDGX4R/",
       "3857": "s3://linz-basemaps/3857/masterton_urban_2021_0-075m_RGB/01FCYQ5JV710MS355E84P574DV/",
-      "name": "masterton-2021-0.075m",
+      "name": "masterton-urban-2021-0.075m",
       "title": "Masterton 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/masterton-2021-0.075m.json
+++ b/config/tileset/wellington/imagery/masterton-2021-0.075m.json
@@ -4,11 +4,12 @@
   "title": "Masterton 0.075m Urban Aerial Photos (2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["masterton-urban-2021-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/masterton_urban_2021_0-075m_RGB/01FCYQ2P6RB18BWV5B8WTDGX4R/",
       "3857": "s3://linz-basemaps/3857/masterton_urban_2021_0-075m_RGB/01FCYQ5JV710MS355E84P574DV/",
-      "name": "masterton-urban-2021-0.075m",
+      "name": "masterton-2021-0.075m",
       "title": "Masterton 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,


### PR DESCRIPTION
### Motivation

Aerial Imagery PRs with the 'Aerial Imagery Deletes' messages are breaking existing WMTS links

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->