### PR TITLE
config(vector): update the topographic-v2 config file

### DIFF
--- a/config/tileset/topographic-v2.json
+++ b/config/tileset/topographic-v2.json
@@ -6,8 +6,8 @@
   "format": "pbf",
   "layers": [
     {
-      "2193": "s3://linz-basemaps/vector/2193/topographic/01K6DT5Z7KMV7GYGKN161Q5GGG/topographic-v2.tar.co",
-      "3857": "s3://linz-basemaps/vector/3857/topographic/01K6DT6B9FGBCATPAWN0XQ6PWN/topographic-v2.tar.co",
+      "2193": "s3://linz-basemaps/vector/2193/topographic/01K6ZTY5QMBF1HHXPQHXTFTR0E/topographic-v2.tar.co",
+      "3857": "s3://linz-basemaps/vector/3857/topographic/01K708Q5X6J0TY04QF8104495A/topographic-v2.tar.co",
       "name": "topographic-v2",
       "title": "Topographic V2"
     }


### PR DESCRIPTION
### Context

- The `2193` branch of this morning's [weekly] Vector ETL succeeded. However, the `3857` branch failed.
- A [re-run] of the Vector ETL's `3857` branch succeeded.

### Modifications

- I've captured the `2193` and `3857` outputs together to update the `topographic-v2` config file.

[weekly]: https://argo.linzaccess.com/workflows/argo/cron-vector-etl-topographic-shortbread-1759856400
[re-run]: https://argo.linzaccess.com/workflows/argo/basemaps-vector-etl-shortbread-5zdbc