### PR TITLE
fix: revert topographic version upgrade to fix missing roads BM-1766

### DIFF
--- a/config/tileset/topographic.json
+++ b/config/tileset/topographic.json
@@ -6,7 +6,7 @@
   "format": "pbf",
   "layers": [
     {
-      "3857": "s3://linz-basemaps/vector/3857/topographic/01KVTTASNG18DG5SYC67KTZ8BV/topographic.tar.co",
+      "3857": "s3://linz-basemaps/vector/3857/topographic/01KV8SFT62TQM5FQDRXKPX9VMZ/topographic.tar.co",
       "name": "topographic",
       "title": "Topographic"
     }


### PR DESCRIPTION
This reverts commit c4c7351c30a693de4b3289c4eba871a2a899c4c3.

### Motivation

Some roads are missing in the latest topographic dataset

### Modifications

revert the change to a older version

### Verification

<!-- TODO: Say how you tested your changes. -->