### PR TITLE
chore: update id, name, alias of individual layers to match dataset slug on ODR

### DIFF
--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2011-2012-0.25m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2011-2012-0.25m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_bay-of-plenty-rural-2011-2012-0.25m",
+  "id": "ts_bay-of-plenty-2011-2012-0.25m",
   "title": "Bay of Plenty 0.25m Rural Aerial Photos (2011-2012)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["bay-of-plenty-rural-2011-2012-0.25m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2011-2012_0-25m_RGBA/01F66E1BB777Z4GN4PAW44FGFA/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2011-2012_0-25m_RGBA/01EDMTQXYCBANNYTKD4VK6C2GK/",
-      "name": "bay-of-plenty-rural-2011-2012-0.25m",
+      "name": "bay-of-plenty-2011-2012-0.25m",
       "title": "Bay of Plenty 0.25m Rural Aerial Photos (2011-2012)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2015-2017-0.25m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2015-2017-0.25m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_bay-of-plenty-rural-2015-2017-0.25m",
+  "id": "ts_bay-of-plenty-2015-2017-0.25m",
   "title": "Bay of Plenty 0.25m Rural Aerial Photos (2015-2017)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["bay-of-plenty-rural-2015-2017-0.25m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2015-17_0-25m/01F66E2MGVQY9F4WXRYDRWRGPE/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2015-17_0-25m/01ED81P0KGVWJP2XHDKJJRYNQM/",
-      "name": "bay-of-plenty-rural-2015-2017-0.25m",
+      "name": "bay-of-plenty-2015-2017-0.25m",
       "title": "Bay of Plenty 0.25m Rural Aerial Photos (2015-2017)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2016-2017-0.3m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2016-2017-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_bay-of-plenty-rural-2016-2017-0.3m",
+  "id": "ts_bay-of-plenty-2016-2017-0.3m",
   "title": "Bay of Plenty 0.3m Rural Aerial Photos (2016-2017)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["bay-of-plenty-rural-2016-2017-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2016-17_0-3m/01F66E3G0Z8DNKWXG5M55QNW9G/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2016-17_0-3m/01ED81Q2AS5K0RPNRCRQ33YAYW/",
-      "name": "bay-of-plenty-rural-2016-2017-0.3m",
+      "name": "bay-of-plenty-2016-2017-0.3m",
       "title": "Bay of Plenty 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2019-0.3m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-rural-2019-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_bay-of-plenty-rural-2019-0.3m",
+  "id": "ts_bay-of-plenty-2019-0.3m",
   "title": "Bay of Plenty 0.3m Rural Aerial Photos (2019)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["bay-of-plenty-rural-2019-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_rural_2019_0-3m/01F66E4BR5XTJENFTSACWB55DM/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_rural_2019_0-3m/01ED81R5BX4EB3W7TB3Z8ZE89S/",
-      "name": "bay-of-plenty-rural-2019-0.3m",
+      "name": "bay-of-plenty-2019-0.3m",
       "title": "Bay of Plenty 0.3m Rural Aerial Photos (2019)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2014-2015-0.125m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2014-2015-0.125m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_bay-of-plenty-urban-2014-2015-0.125m",
+  "id": "ts_bay-of-plenty-2014-2015-0.125m",
   "title": "Bay of Plenty 0.125m Urban Aerial Photos (2014-2015)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["bay-of-plenty-urban-2014-2015-0.125m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2014-15_0-125m/01F66E4JBVW1AW4VKGRN95SDGZ/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2014-15_0-125m/01ED81RPD7YEYNTPM2WZZK3X1A/",
-      "name": "bay-of-plenty-urban-2014-2015-0.125m",
+      "name": "bay-of-plenty-2014-2015-0.125m",
       "title": "Bay of Plenty 0.125m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2015-2016-0.125m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2015-2016-0.125m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_bay-of-plenty-urban-2015-2016-0.125m",
+  "id": "ts_bay-of-plenty-2015-2016-0.125m",
   "title": "Bay of Plenty 0.125m Urban Aerial Photos (2015-2016)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["bay-of-plenty-urban-2015-2016-0.125m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2015-16_0-125m/01F66E63QY3BR3W3ARXRBPK1NP/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2015-16_0-125m/01ED81TJP9G5Q6VJKG921RT0QS/",
-      "name": "bay-of-plenty-urban-2015-2016-0.125m",
+      "name": "bay-of-plenty-2015-2016-0.125m",
       "title": "Bay of Plenty 0.125m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2015-2016-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2015-2016-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_bay-of-plenty-urban-2015-2016-0.1m",
+  "id": "ts_bay-of-plenty-2015-2016-0.1m",
   "title": "Bay of Plenty 0.1m Urban Aerial Photos (2015-2016)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["bay-of-plenty-urban-2015-2016-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2015-16_0-1m/01F66E757Y78C33NKN50W9PW5C/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2015-16_0-1m/01ED81VN7AJ586W5HK2BSPHAPH/",
-      "name": "bay-of-plenty-urban-2015-2016-0.1m",
+      "name": "bay-of-plenty-2015-2016-0.1m",
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2018-2019-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/bay-of-plenty-urban-2018-2019-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_bay-of-plenty-urban-2018-2019-0.1m",
+  "id": "ts_bay-of-plenty-2018-2019-0.1m",
   "title": "Bay of Plenty 0.1m Urban Aerial Photos (2018-2019)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["bay-of-plenty-urban-2018-2019-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/bay-of-plenty_urban_2018-19_0-1m/01F66E7K4ESMSWZ1CNMCQ8B700/",
       "3857": "s3://linz-basemaps/3857/bay-of-plenty_urban_2018-19_0-1m/01ED81W4KDQQRW9PEQ9KS7T8DV/",
-      "name": "bay-of-plenty-urban-2018-2019-0.1m",
+      "name": "bay-of-plenty-2018-2019-0.1m",
       "title": "Bay of Plenty 0.1m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/tauranga-city-urban-2022-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/tauranga-city-urban-2022-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tauranga-city-urban-2022-0.1m",
+  "id": "ts_tauranga-2022-0.1m",
   "title": "Tauranga 0.1m Urban Aerial Photos (2022)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["tauranga-city-urban-2022-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tauranga-city_urban_2022_0.1m_RGB/01GD1V79CP27V3FD5XFWGCTPEM/",
       "3857": "s3://linz-basemaps/3857/tauranga-city_urban_2022_0.1m_RGB/01GD1V81RYJDH8NWK7C33PVNWR/",
-      "name": "tauranga-city-urban-2022-0.1m",
+      "name": "tauranga-2022-0.1m",
       "title": "Tauranga 0.1m Urban Aerial Photos (2022)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/bay-of-plenty/imagery/tauranga-urban-2017-0.1m.json
+++ b/config/tileset/bay-of-plenty/imagery/tauranga-urban-2017-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tauranga-urban-2017-0.1m",
+  "id": "ts_tauranga-2017-0.1m",
   "title": "Tauranga 0.1m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["tauranga-urban-2017-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tauranga_urban_2017_0-1m/01F6P1W5KQ18HM9ZM9N35CXJ91/",
       "3857": "s3://linz-basemaps/3857/tauranga_urban_2017_0-1m/01ED83FS8PC1YC7Y7WKJ90P5TN/",
-      "name": "tauranga-urban-2017-0.1m",
+      "name": "tauranga-2017-0.1m",
       "title": "Tauranga 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/ashburton-urban-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/ashburton-urban-2020-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_ashburton-urban-2020-0.075m",
+  "id": "ts_ashburton-2020-0.075m",
   "title": "Ashburton 0.075m Urban Aerial Photos (2020)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["ashburton-urban-2020-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/ashburton_urban_2020_0-075m_RGB/01FPV7HMJN6RQNSANMZ2SRY0BK/",
       "3857": "s3://linz-basemaps/3857/ashburton_urban_2020_0-075m_RGB/01FPV7ABAWS4ZCWN91VR7SDK0A/",
-      "name": "ashburton-urban-2020-0.075m",
+      "name": "ashburton-2020-0.075m",
       "title": "Ashburton 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/ashburton-urban-2021-2022-0.075m.json
+++ b/config/tileset/canterbury/imagery/ashburton-urban-2021-2022-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_ashburton-urban-2021-2022-0.075m",
+  "id": "ts_ashburton-2021-2022-0.075m",
   "title": "Ashburton 0.075m Urban Aerial Photos (2021-2022)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["ashburton-urban-2021-2022-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/ashburton_urban_2021-2022_0.075m/01GM796A98A5WRYAKBJXRN57Z4/",
       "3857": "s3://linz-basemaps/3857/ashburton_urban_2021-2022_0.075m/01GM79743023G6STTDG08J4GV8/",
-      "name": "ashburton-urban-2021-2022-0.075m",
+      "name": "ashburton-2021-2022-0.075m",
       "title": "Ashburton 0.075m Urban Aerial Photos (2021-2022)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/banks-peninsula-urban-2019-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/banks-peninsula-urban-2019-2020-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_banks-peninsula-urban-2019-2020-0.075m",
+  "id": "ts_banks-peninsula-2019-2020-0.075m",
   "title": "Banks Peninsula 0.075m Urban Aerial Photos (2019-2020)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["banks-peninsula-urban-2019-2020-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2R7RYJHP0DVXJMZ3M0QDY/",
       "3857": "s3://linz-basemaps/3857/banks-peninsula_urban_2019-2020_0-075m_RGB/01FMK2SN9GVFBEW48N4V5E41ZQ/",
-      "name": "banks-peninsula-urban-2019-2020-0.075m",
+      "name": "banks-peninsula-2019-2020-0.075m",
       "title": "Banks Peninsula 0.075m Urban Aerial Photos (2019-2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/canterbury-rural-2012-2013-0.4m.json
+++ b/config/tileset/canterbury/imagery/canterbury-rural-2012-2013-0.4m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_canterbury-rural-2012-2013-0.4m",
+  "id": "ts_canterbury-2012-2013-0.4m",
   "title": "Canterbury 0.4m Rural Aerial Photos (2012-2013)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["canterbury-rural-2012-2013-0.4m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/canterbury_rural_2012-2013_0-40m_RGBA/01F66E9294YKPYAJP7SXTVY2EM/",
       "3857": "s3://linz-basemaps/3857/canterbury_rural_2012-2013_0-40m_RGBA/01ED81XK539QM497AYHM1X70JQ/",
-      "name": "canterbury-rural-2012-2013-0.4m",
+      "name": "canterbury-2012-2013-0.4m",
       "title": "Canterbury 0.4m Rural Aerial Photos (2012-2013)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/christchurch-urban-2015-2016-0.075m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2015-2016-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_christchurch-urban-2015-2016-0.075m",
+  "id": "ts_christchurch-2015-2016-0.075m",
   "title": "Christchurch 0.075m Urban Aerial Photos (2015-2016)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["christchurch-urban-2015-2016-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/christchurch_urban_2015-2016_0-075m_RGBA/01F6P0KPJJK4MJ3JZVS0DJK0Q7/",
       "3857": "s3://linz-basemaps/3857/christchurch_urban_2015-2016_0-075m_RGBA/01EWEQ26HDCMDQKTZ1RHSXPBEW/",
-      "name": "christchurch-urban-2015-2016-0.075m",
+      "name": "christchurch-2015-2016-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/christchurch-urban-2018-0.075m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2018-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_christchurch-urban-2018-0.075m",
+  "id": "ts_christchurch-2018-0.075m",
   "title": "Christchurch 0.075m Urban Aerial Photos (2018)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["christchurch-urban-2018-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/christchurch_urban_2018_0-075m/01F6P0NTCAD62YAXJ1DKKK2AY3/",
       "3857": "s3://linz-basemaps/3857/christchurch_urban_2018_0-075m/01ED825VGXM6K9YX52DP7SMXQE/",
-      "name": "christchurch-urban-2018-0.075m",
+      "name": "christchurch-2018-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/christchurch-urban-2018-2019-0.075m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2018-2019-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_christchurch-urban-2018-2019-0.075m",
+  "id": "ts_christchurch-2018-2019-0.075m",
   "title": "Christchurch 0.075m Urban Aerial Photos (2018-2019)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["christchurch-urban-2018-2019-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/christchurch_urban_2018-2019_0-075m_RGB/01F6P0MJKAVT7XTXXPS19FQP81/",
       "3857": "s3://linz-basemaps/3857/christchurch_urban_2018-2019_0-075m_RGB/01EMFHZ28DMWDCJ7VEE15HTYPZ/",
-      "name": "christchurch-urban-2018-2019-0.075m",
+      "name": "christchurch-2018-2019-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/christchurch-urban-2020-2021-0.075m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2020-2021-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_christchurch-urban-2020-2021-0.075m",
+  "id": "ts_christchurch-2020-2021-0.075m",
   "title": "Christchurch 0.075m Urban Aerial Photos (2020-2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["christchurch-urban-2020-2021-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/christchurch_urban_2020-2021_0-075m_RGB/01FPXB0T4ZCASWGX1X1GVEHDQZ/",
       "3857": "s3://linz-basemaps/3857/christchurch_urban_2020-2021_0-075m_RGB/01FPXB36CCAK3FC6FWCMK1D156/",
-      "name": "christchurch-urban-2020-2021-0.075m",
+      "name": "christchurch-2020-2021-0.075m",
       "title": "Christchurch 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/christchurch-urban-2021-0.05m.json
+++ b/config/tileset/canterbury/imagery/christchurch-urban-2021-0.05m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_christchurch-urban-2021-0.05m",
+  "id": "ts_christchurch-2021-0.05m",
   "title": "Christchurch 0.05m Urban Aerial Photos (2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["christchurch-urban-2021-0.05m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/christchurch_urban_2021_0-05m_RGB/01FPXAY15VB9MES5WQ0N2SPEG6/",
       "3857": "s3://linz-basemaps/3857/christchurch_urban_2021_0-05m_RGB/01FPXB6TVAQZV4W9KXWQ7H5ZQA/",
-      "name": "christchurch-urban-2021-0.05m",
+      "name": "christchurch-2021-0.05m",
       "title": "Christchurch 0.05m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/hurunui-urban-2013-0.125m.json
+++ b/config/tileset/canterbury/imagery/hurunui-urban-2013-0.125m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hurunui-urban-2013-0.125m",
+  "id": "ts_hurunui-2013-0.125m",
   "title": "Hurunui 0.125m Urban Aerial Photos (2013)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hurunui-urban-2013-0.125m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hurunui_urban_2013_0-125m_RGBA/01F6P1965MX7W515NM9VR90V67/",
       "3857": "s3://linz-basemaps/3857/hurunui_urban_2013_0-125m_RGBA/01ED82CK977V2ZJ095QZDGSME6/",
-      "name": "hurunui-urban-2013-0.125m",
+      "name": "hurunui-2013-0.125m",
       "title": "Hurunui 0.125m Urban Aerial Photos (2013)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/mackenzie-urban-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/mackenzie-urban-2020-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_mackenzie-urban-2020-0.075m",
+  "id": "ts_mackenzie-2020-0.075m",
   "title": "Mackenzie 0.075m Urban Aerial Photos (2020)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["mackenzie-urban-2020-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/mackenzie_urban_2020_0-075m_RGB/01FPV7GGNZ008JBH25F35KXC71/",
       "3857": "s3://linz-basemaps/3857/mackenzie_urban_2020_0-075m_RGB/01FPV7C0KD6R4FD8TTE3S43ETF/",
-      "name": "mackenzie-urban-2020-0.075m",
+      "name": "mackenzie-2020-0.075m",
       "title": "Mackenzie 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/manawatu-urban-2019-0.125m.json
+++ b/config/tileset/canterbury/imagery/manawatu-urban-2019-0.125m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_manawatu-urban-2019-0.125m",
+  "id": "ts_manawatu-2019-0.125m",
   "title": "Manawatu 0.125m Urban Aerial Photos (2019)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["manawatu-urban-2019-0.125m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/manawatu_urban_2019_0-125m/01F6P1C55PMBG08K4W549J8EQ8/",
       "3857": "s3://linz-basemaps/3857/manawatu_urban_2019_0-125m/01ED82GV8E3DRWQ86D80SN1FPW/",
-      "name": "manawatu-urban-2019-0.125m",
+      "name": "manawatu-2019-0.125m",
       "title": "Manawatu 0.125m Urban Aerial Photos (2019)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/selwyn-urban-2012-2013-0.125m.json
+++ b/config/tileset/canterbury/imagery/selwyn-urban-2012-2013-0.125m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_selwyn-urban-2012-2013-0.125m",
+  "id": "ts_selwyn-2012-2013-0.125m",
   "title": "Selwyn 0.125m Urban Aerial Photos (2012-2013)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["selwyn-urban-2012-2013-0.125m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2012-2013_0-125m_RGBA/01F6P1Q0MQC2FXNDVZJGT88CC2/",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2012-2013_0-125m_RGBA/01ED8355C00DRTSNAQ04AHJDDZ/",
-      "name": "selwyn-urban-2012-2013-0.125m",
+      "name": "selwyn-2012-2013-0.125m",
       "title": "Selwyn 0.125m Urban Aerial Photos (2012-2013)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/selwyn-urban-2018-2019-0.075m.json
+++ b/config/tileset/canterbury/imagery/selwyn-urban-2018-2019-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_selwyn-urban-2018-2019-0.075m",
+  "id": "ts_selwyn-2018-2019-0.075m",
   "title": "Selwyn 0.075m Urban Aerial Photos (2018-2019)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["selwyn-urban-2018-2019-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2018-2019_0-075m_RGB/01F6P1Q9FCCZ9EH7HE7X2SK2Q1/",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2018-2019_0-075m_RGB/01ESPVY6HBS1SH79ZH24RW7ZSQ/",
-      "name": "selwyn-urban-2018-2019-0.075m",
+      "name": "selwyn-2018-2019-0.075m",
       "title": "Selwyn 0.075m Urban Aerial Photos (2018-2019)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/selwyn-urban-2019-0.075m.json
+++ b/config/tileset/canterbury/imagery/selwyn-urban-2019-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_selwyn-urban-2019-0.075m",
+  "id": "ts_selwyn-2019-0.075m",
   "title": "Selwyn 0.075m Urban Aerial Photos (2019)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["selwyn-urban-2019-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2019_0-075m_RGB/01FMJQBZ1H9F9KBFK8VH5THM2K/",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2019_0-075m_RGB/01FMJQANZJNCWB6SZAYG7P11ZT/",
-      "name": "selwyn-urban-2019-0.075m",
+      "name": "selwyn-2019-0.075m",
       "title": "Selwyn 0.075m Urban Aerial Photos (2019)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/selwyn-urban-2020-2021-0.075m.json
+++ b/config/tileset/canterbury/imagery/selwyn-urban-2020-2021-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_selwyn-urban-2020-2021-0.075m",
+  "id": "ts_selwyn-2020-2021-0.075m",
   "title": "Selwyn 0.075m Urban Aerial Photos (2020-2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["selwyn-urban-2020-2021-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/selwyn_urban_2020-2021_0-075m_RGB/01FSWMZ640BA2YD74DDGA1A62X/",
       "3857": "s3://linz-basemaps/3857/selwyn_urban_2020-2021_0-075m_RGB/01FSWN35JY2PC7GMHEBXYART77/",
-      "name": "selwyn-urban-2020-2021-0.075m",
+      "name": "selwyn-2020-2021-0.075m",
       "title": "Selwyn 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/timaru-2022-2023-0.1m.json
+++ b/config/tileset/canterbury/imagery/timaru-2022-2023-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_timaru-2022-2023-0.1m",
+  "id": "ts_timaru-2022-2023-0.075m",
   "title": "Timaru 0.075m Urban Aerial Photos (2022-2023)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["timaru-2022-2023-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/timaru_2022-2023_0.1m/01HFASBR6S6H0PKSGJYDF5EN3Z/",
       "3857": "s3://linz-basemaps/3857/timaru_2022-2023_0.1m/01HFART8EK8PX5B5HYFRXR0G92/",
-      "name": "timaru-2022-2023-0.1m",
+      "name": "timaru-2022-2023-0.075m",
       "title": "Timaru 0.075m Urban Aerial Photos (2022-2023)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/timaru-urban-2012-2013-0.075m.json
+++ b/config/tileset/canterbury/imagery/timaru-urban-2012-2013-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_timaru-urban-2012-2013-0.075m",
+  "id": "ts_timaru-2012-2013-0.075m",
   "title": "Timaru 0.075m Urban Aerial Photos (2012-2013)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["timaru-urban-2012-2013-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/timaru_urban_2012-2013_0-075m_RGBA/01F6P1XAGNDZVM0DH9JCFSE7QB/",
       "3857": "s3://linz-basemaps/3857/timaru_urban_2012-2013_0-075m_RGBA/01ED83HWB82K047N1KYK9A5SKD/",
-      "name": "timaru-urban-2012-2013-0.075m",
+      "name": "timaru-2012-2013-0.075m",
       "title": "Timaru 0.075m Urban Aerial Photos (2012-2013)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/timaru-urban-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/timaru-urban-2020-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_timaru-urban-2020-0.075m",
+  "id": "ts_timaru-2020-0.075m",
   "title": "Timaru 0.075m Urban Aerial Photos (2020)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["timaru-urban-2020-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/timaru_urban_2020_0-075m_RGB/01FPV7FD7SX1JKW7TK25ESMYN1/",
       "3857": "s3://linz-basemaps/3857/timaru_urban_2020_0-075m_RGB/01FPV7DVA9TW7XQCR64SSB12DA/",
-      "name": "timaru-urban-2020-0.075m",
+      "name": "timaru-2020-0.075m",
       "title": "Timaru 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/waimakariri-urban-2013-2014-0.075m.json
+++ b/config/tileset/canterbury/imagery/waimakariri-urban-2013-2014-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waimakariri-urban-2013-2014-0.075m",
+  "id": "ts_waimakariri-2013-2014-0.075m",
   "title": "Waimakariri 0.075m Urban Aerial Photos (2013-2014)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["waimakariri-urban-2013-2014-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waimakariri_urban_2013-2014_0-075m_RGBA/01F6P20317FNJJSB1KJFH7Y35Y/",
       "3857": "s3://linz-basemaps/3857/waimakariri_urban_2013-2014_0-075m_RGBA/01ED83PPQFH8Z8HNY1WV7W4SS5/",
-      "name": "waimakariri-urban-2013-2014-0.075m",
+      "name": "waimakariri-2013-2014-0.075m",
       "title": "Waimakariri 0.075m Urban Aerial Photos (2013-2014)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/waimakariri-urban-2015-2016-0.075m.json
+++ b/config/tileset/canterbury/imagery/waimakariri-urban-2015-2016-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waimakariri-urban-2015-2016-0.075m",
+  "id": "ts_waimakariri-2015-2016-0.075m",
   "title": "Waimakariri 0.075m Urban Aerial Photos (2015-2016)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["waimakariri-urban-2015-2016-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waimakariri_urban_2015-2016_0-075m_RGBA/01F6P20ANWJDXNWCTHBTK3MJNF/",
       "3857": "s3://linz-basemaps/3857/waimakariri_urban_2015-2016_0-075m_RGBA/01ED83QD75BDF3D46932B3ZKZD/",
-      "name": "waimakariri-urban-2015-2016-0.075m",
+      "name": "waimakariri-2015-2016-0.075m",
       "title": "Waimakariri 0.075m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/waimakariri-urban-2021-0.05m.json
+++ b/config/tileset/canterbury/imagery/waimakariri-urban-2021-0.05m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waimakariri-urban-2021-0.05m",
+  "id": "ts_waimakariri-2021-0.05m",
   "title": "Waimakariri 0.05m Urban Aerial Photos (2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["waimakariri-urban-2021-0.05m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waimakariri_urban_2021_0-05m_RGB/01FKHMHNJ130J9DF3J9CSYZ41V/",
       "3857": "s3://linz-basemaps/3857/waimakariri_urban_2021_0-05m_RGB/01FKHMK3VK9GRFB762B8JW33HW/",
-      "name": "waimakariri-urban-2021-0.05m",
+      "name": "waimakariri-2021-0.05m",
       "title": "Waimakariri 0.05m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/waimakariri_2024_0.25m.json
+++ b/config/tileset/canterbury/imagery/waimakariri_2024_0.25m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waimakariri_2024_0.25m",
+  "id": "ts_waimakariri-2024-0.25m",
   "title": "Waimakariri 0.25m Rural Aerial Photos (2024)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["waimakariri_2024_0.25m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waimakariri_2024_0.25m/01J1RESR6CDNEHH4A2DXTP1G0X/",
       "3857": "s3://linz-basemaps/3857/waimakariri_2024_0.25m/01J1RESR6C1MNR0A8SH34PKHAF/",
-      "name": "waimakariri_2024_0.25m",
+      "name": "waimakariri-2024-0.25m",
       "title": "Waimakariri 0.25m Rural Aerial Photos (2024)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/waimate-urban-2018-0.075m.json
+++ b/config/tileset/canterbury/imagery/waimate-urban-2018-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waimate-urban-2018-0.075m",
+  "id": "ts_waimate-2018-0.075m",
   "title": "Waimate 0.075m Urban Aerial Photos (2018)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["waimate-urban-2018-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waimate_urban_2018_0-075m_RGB/01F6P20H4Y55WG0SW5RXNP6Y9J/",
       "3857": "s3://linz-basemaps/3857/waimate_urban_2018_0-075m_RGB/01ESF5HA3BXN5E50Z0608KJGTG/",
-      "name": "waimate-urban-2018-0.075m",
+      "name": "waimate-2018-0.075m",
       "title": "Waimate 0.075m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/waimate-urban-2020-0.075m.json
+++ b/config/tileset/canterbury/imagery/waimate-urban-2020-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waimate-urban-2020-0.075m",
+  "id": "ts_waimate-2020-0.075m",
   "title": "Waimate 0.075m Urban Aerial Photos (2020)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["waimate-urban-2020-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waimate_urban_2020_0-075m_RGB/01FJB8FDBCP2R3VT7TJC1NWGFD/",
       "3857": "s3://linz-basemaps/3857/waimate_urban_2020_0-075m_RGB/01FJB8KPXHR48ZVDHE7M9PK6RH/",
-      "name": "waimate-urban-2020-0.075m",
+      "name": "waimate-2020-0.075m",
       "title": "Waimate 0.075m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/canterbury/imagery/waitaki-urban-2020-2021-0.075m.json
+++ b/config/tileset/canterbury/imagery/waitaki-urban-2020-2021-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waitaki-urban-2020-2021-0.075m",
+  "id": "ts_waitaki-2020-2021-0.075m",
   "title": "Waitaki 0.075m Urban Aerial Photos (2020-2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["waitaki-urban-2020-2021-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waitaki_urban_2020-2021_0-075m_RGB/01FSWMVSKCNWK9H4J3JP6RAQ0S/",
       "3857": "s3://linz-basemaps/3857/waitaki_urban_2020-2021_0-075m_RGB/01FSWMXCT9AF67HW8BQKV9WM0K/",
-      "name": "waitaki-urban-2020-2021-0.075m",
+      "name": "waitaki-2020-2021-0.075m",
       "title": "Waitaki 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/gisborne/imagery/gisborne-rural-2012-2013-0.4m.json
+++ b/config/tileset/gisborne/imagery/gisborne-rural-2012-2013-0.4m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_gisborne-rural-2012-2013-0.4m",
+  "id": "ts_gisborne-2012-2013-0.4m",
   "title": "Gisborne 0.4m Rural Aerial Photos (2012-2013)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["gisborne-rural-2012-2013-0.4m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/gisborne_rural_2012-2013_0-40m_RGBA/01F6P153BFK34RSZZWPX9PRKS8/",
       "3857": "s3://linz-basemaps/3857/gisborne_rural_2012-2013_0-40m_RGBA/01EDMTSQF19FQB09MS46ZFWWRM/",
-      "name": "gisborne-rural-2012-2013-0.4m",
+      "name": "gisborne-2012-2013-0.4m",
       "title": "Gisborne 0.4m Rural Aerial Photos (2012-2013)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/gisborne/imagery/gisborne-rural-2017-2019-0.3m.json
+++ b/config/tileset/gisborne/imagery/gisborne-rural-2017-2019-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_gisborne-rural-2017-2019-0.3m",
+  "id": "ts_gisborne-2017-2019-0.3m",
   "title": "Gisborne 0.3m Rural Aerial Photos (2017-2019)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["gisborne-rural-2017-2019-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/gisborne_rural_2017-2019_0-3m_RGB/01F6P15VGNRA3N06S2NEY9PFAX/",
       "3857": "s3://linz-basemaps/3857/gisborne_rural_2017-2019_0-3m_RGB/01EZWZGMW2Q53VNC65X2X4VFRZ/",
-      "name": "gisborne-rural-2017-2019-0.3m",
+      "name": "gisborne-2017-2019-0.3m",
       "title": "Gisborne 0.3m Rural Aerial Photos (2017-2019)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/gisborne/imagery/gisborne-rural-2021-2023-0.2m.json
+++ b/config/tileset/gisborne/imagery/gisborne-rural-2021-2023-0.2m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_gisborne-rural-2021-2023-0.2m",
+  "id": "ts_gisborne-2021-2023-0.2m",
   "title": "Gisborne 0.2m Rural Aerial Photos (2021-2023)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["gisborne-rural-2021-2023-0.2m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/gisborne_rural_2021-2023_0.2m/01H2S2ADDFREPQC2797VEN5RAE/",
       "3857": "s3://linz-basemaps/3857/gisborne_rural_2021-2023_0.2m/01H2S2CJTQKXXY2NHZ88D4TP2X/",
-      "name": "gisborne-rural-2021-2023-0.2m",
+      "name": "gisborne-2021-2023-0.2m",
       "title": "Gisborne 0.2m Rural Aerial Photos (2021-2023)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/gisborne/imagery/gisborne-urban-2017-2018-0.1m.json
+++ b/config/tileset/gisborne/imagery/gisborne-urban-2017-2018-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_gisborne-urban-2017-2018-0.1m",
+  "id": "ts_gisborne-2017-2018-0.1m",
   "title": "Gisborne 0.1m Urban Aerial Photos (2017-2018)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["gisborne-urban-2017-2018-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/gisborne_urban_2017-18_0-1m/01F6P168K626GCA0RY790XHRVY/",
       "3857": "s3://linz-basemaps/3857/gisborne_urban_2017-18_0-1m/01ECTS33A3VYA5A8ZBHCDFYFR8/",
-      "name": "gisborne-urban-2017-2018-0.1m",
+      "name": "gisborne-2017-2018-0.1m",
       "title": "Gisborne 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/central-hawkes-bay-urban-2017-2018-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/central-hawkes-bay-urban-2017-2018-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_central-hawkes-bay-urban-2017-2018-0.1m",
+  "id": "ts_central-hawkes-bay-2017-2018-0.1m",
   "title": "Central Hawke's Bay 0.1m Urban Aerial Photos (2017-2018)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["central-hawkes-bay-urban-2017-2018-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/central-hawkes-bay_urban_2017-18_0-1m/01F66EDQC993D73W17EG40HJ2N/",
       "3857": "s3://linz-basemaps/3857/central-hawkes-bay_urban_2017-18_0-1m/01ED823PTAVX9DQ7GE9WBACX8C/",
-      "name": "central-hawkes-bay-urban-2017-2018-0.1m",
+      "name": "central-hawkes-bay-2017-2018-0.1m",
       "title": "Central Hawke's Bay 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hastings-district-urban-2014-2015-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/hastings-district-urban-2014-2015-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hastings-district-urban-2014-2015-0.1m",
+  "id": "ts_hastings-district-2014-2015-0.1m",
   "title": "Hastings District 0.1m Urban Aerial Photos (2014-2015)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hastings-district-urban-2014-2015-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hastings-district_urban_2014-2015_0-10m_RGB/01F6P172EQ3JF930CN3XNVVVJ9/",
       "3857": "s3://linz-basemaps/3857/hastings-district_urban_2014-2015_0-10m_RGB/01EDN0YH2TM1B5NWHR4RHGBMPF/",
-      "name": "hastings-district-urban-2014-2015-0.1m",
+      "name": "hastings-district-2014-2015-0.1m",
       "title": "Hastings District 0.1m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hastings-district-urban-2017-2018-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/hastings-district-urban-2017-2018-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hastings-district-urban-2017-2018-0.1m",
+  "id": "ts_hastings-2017-2018-0.1m",
   "title": "Hastings 0.1m Urban Aerial Photos (2017-2018)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hastings-district-urban-2017-2018-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hastings-district_urban_2017-18_0-1m/01F6P17PSJ1SWNYV2V28922WKY/",
       "3857": "s3://linz-basemaps/3857/hastings-district_urban_2017-18_0-1m/01ED82A7KFS8RMNPRYDQ60MCQ1/",
-      "name": "hastings-district-urban-2017-2018-0.1m",
+      "name": "hastings-2017-2018-0.1m",
       "title": "Hastings 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-2021-2022-0.3m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-2021-2022-0.3m.json
@@ -1,7 +1,7 @@
 {
   "type": "raster",
-  "id": "ts_hawkes-bay-rural-2021-2022-0.3m",
-  "name": "hawkes-bay-rural-2021-2022-0.3m",
+  "id": "ts_hawkes-bay-2021-2022-0.3m",
+  "name": "hawkes-bay-2021-2022-0.3m",
   "title": "Hawke's Bay 0.3m Rural Aerial Photos (2021-2022)",
   "background": {
     "r": 0,
@@ -10,12 +10,12 @@
     "alpha": 0
   },
   "category": "Rural Aerial Photos",
-  "aliases": ["hawkes-bay-2021-2022-0.3m"],
+  "aliases": ["hawkes-bay-rural-2021-2022-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH2Y0Q4PENH4T22PGJB521/",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2021-2022_0-3m_RGB/01GBPH42RKHGCSHRB3EMZVZD91/",
-      "name": "hawkes-bay-rural-2021-2022-0.3m",
+      "name": "hawkes-bay-2021-2022-0.3m",
       "title": "Hawke's Bay 0.3m Rural Aerial Photos (2021-2022)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-rural-2014-2015-0.3m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-rural-2014-2015-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hawkes-bay-rural-2014-2015-0.3m",
+  "id": "ts_hawkes-bay-2014-2015-0.3m",
   "title": "Hawke's Bay 0.3m Rural Aerial Photos (2014-2015)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["hawkes-bay-rural-2014-2015-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2014-2015_0-30m_RGBA/01F6P182DFPVC4HCAKPP42PCWN/",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2014-2015_0-30m_RGBA/01ED82B3R581HMXNDS7HP3ATQ2/",
-      "name": "hawkes-bay-rural-2014-2015-0.3m",
+      "name": "hawkes-bay-2014-2015-0.3m",
       "title": "Hawke's Bay 0.3m Rural Aerial Photos (2014-2015)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/hawkes-bay-rural-2019-2020-0.3m.json
+++ b/config/tileset/hawkes-bay/imagery/hawkes-bay-rural-2019-2020-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hawkes-bay-rural-2019-2020-0.3m",
+  "id": "ts_hawkes-bay-2019-2020-0.3m",
   "title": "Hawke's Bay 0.3m Rural Aerial Photos (2019-2020)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["hawkes-bay-rural-2019-2020-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hawkes-bay_rural_2019-2020_0-3m_RGB/01FC200TCKR7ZTJEN6Q8ZJAET1/",
       "3857": "s3://linz-basemaps/3857/hawkes-bay_rural_2019-2020_0-3m_RGB/01FC1ZY5V4XCEXDSWT3FE3A8VM/",
-      "name": "hawkes-bay-rural-2019-2020-0.3m",
+      "name": "hawkes-bay-2019-2020-0.3m",
       "title": "Hawke's Bay 0.3m Rural Aerial Photos (2019-2020)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/napier-city-urban-2017-2018-0.05m.json
+++ b/config/tileset/hawkes-bay/imagery/napier-city-urban-2017-2018-0.05m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_napier-city-urban-2017-2018-0.05m",
+  "id": "ts_napier-2017-2018-0.05m",
   "title": "Napier 0.05m Urban Aerial Photos (2017-2018)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["napier-city-urban-2017-2018-0.05m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-05m/01F6P1F7BT85M2T5S01FXWAPPD/",
       "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-05m/01ED82S7R88B0CGQWZKH4V7R2H/",
-      "name": "napier-city-urban-2017-2018-0.05m",
+      "name": "napier-2017-2018-0.05m",
       "title": "Napier 0.05m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/napier-city-urban-2017-2018-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/napier-city-urban-2017-2018-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_napier-city-urban-2017-2018-0.1m",
+  "id": "ts_napier-2017-2018-0.1m",
   "title": "Napier 0.1m Urban Aerial Photos (2017-2018)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["napier-city-urban-2017-2018-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/napier-city_urban_2017-18_0-1m/01F6P1FCJZWD8JY7DJEDEB45K7/",
       "3857": "s3://linz-basemaps/3857/napier-city_urban_2017-18_0-1m/01ED82SKPVV12M4RYHRK08DWG4/",
-      "name": "napier-city-urban-2017-2018-0.1m",
+      "name": "napier-2017-2018-0.1m",
       "title": "Napier 0.1m Urban Aerial Photos (2017-2018)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/hawkes-bay/imagery/wairoa-urban-2014-2015-0.1m.json
+++ b/config/tileset/hawkes-bay/imagery/wairoa-urban-2014-2015-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_wairoa-urban-2014-2015-0.1m",
+  "id": "ts_wairoa-2014-2015-0.1m",
   "title": "Wairoa 0.1m Urban Aerial Photos (2014-2015)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["wairoa-urban-2014-2015-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/wairoa_urban_2014-2015_0-10m_RGBA/01F6P20PT6TN7XVJGPSA7NPQ93/",
       "3857": "s3://linz-basemaps/3857/wairoa_urban_2014-2015_0-10m_RGBA/01ED83R64ZX665P14R805CJVE2/",
-      "name": "wairoa-urban-2014-2015-0.1m",
+      "name": "wairoa-2014-2015-0.1m",
       "title": "Wairoa 0.1m Urban Aerial Photos (2014-2015)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-rural-2015-2016-0.3m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-rural-2015-2016-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_manawatu-whanganui-rural-2015-2016-0.3m",
+  "id": "ts_manawatu-whanganui-2015-2016-0.3m",
   "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2015-2016)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["manawatu-whanganui-rural-2015-2016-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2015-16_0-3m/01F6P1B7SH0X2FETDDT3RWT9Q9/",
       "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2015-16_0-3m/01ED82HKA5T8V6S1KZ4WN9EFNN/",
-      "name": "manawatu-whanganui-rural-2015-2016-0.3m",
+      "name": "manawatu-whanganui-2015-2016-0.3m",
       "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-rural-2016-2017-0.3m.json
+++ b/config/tileset/manawatu-whanganui/imagery/manawatu-whanganui-rural-2016-2017-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_manawatu-whanganui-rural-2016-2017-0.3m",
+  "id": "ts_manawatu-whanganui-2016-2017-0.3m",
   "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2016-2017)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["manawatu-whanganui-rural-2016-2017-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/manawatu-whanganui_rural_2016-17_0-3m/01F6P1BSQ6V27WZK0KM56M4Z1C/",
       "3857": "s3://linz-basemaps/3857/manawatu-whanganui_rural_2016-17_0-3m/01ED82JQASJDFZ6XEM018RJQN0/",
-      "name": "manawatu-whanganui-rural-2016-2017-0.3m",
+      "name": "manawatu-whanganui-2016-2017-0.3m",
       "title": "Manawatū-Whanganui 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/manawatu-whanganui/imagery/palmerston-north-city-urban-2014-2015-0.125m.json
+++ b/config/tileset/manawatu-whanganui/imagery/palmerston-north-city-urban-2014-2015-0.125m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_palmerston-north-city-urban-2014-2015-0.125m",
+  "id": "ts_palmerston-north-2015-0.125m",
   "title": "Palmerston North 0.125m Urban Aerial Photos (2015)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["palmerston-north-city-urban-2014-2015-0.125m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/palmerston-north-city_urban_2014-15_0-125m/01F6P1P22165F058BN82D3ZY8Q/",
       "3857": "s3://linz-basemaps/3857/palmerston-north-city_urban_2014-15_0-125m/01ED8346J2H15Z24G6P9SZ7S0P/",
-      "name": "palmerston-north-city-urban-2014-2015-0.125m",
+      "name": "palmerston-north-2015-0.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2015)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/manawatu-whanganui/imagery/palmerston-north-urban-2016-2017-1.125m.json
+++ b/config/tileset/manawatu-whanganui/imagery/palmerston-north-urban-2016-2017-1.125m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_palmerston-north-urban-2016-2017-1.125m",
+  "id": "ts_palmerston-north-2017-0.125m",
   "title": "Palmerston North 0.125m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["palmerston-north-urban-2016-2017-1.125m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2016-17_1-125m/01F6P1P8H7KNRQQR0ADDKQRJ6S/",
       "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2016-17_1-125m/01ED833N7FD05YRW6ZR5799SAZ/",
-      "name": "palmerston-north-urban-2016-2017-1.125m",
+      "name": "palmerston-north-2017-0.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/manawatu-whanganui/imagery/palmerston-north-urban-2018-2019-0.125m.json
+++ b/config/tileset/manawatu-whanganui/imagery/palmerston-north-urban-2018-2019-0.125m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_palmerston-north-urban-2018-2019-0.125m",
+  "id": "ts_palmerston-north-2018-0.125m",
   "title": "Palmerston North 0.125m Urban Aerial Photos (2018)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["palmerston-north-urban-2018-2019-0.125m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/palmerston-north_urban_2018-2019_0-125m_RGB/01F6P1PF375AH4BPQ9PTQA7GYD/",
       "3857": "s3://linz-basemaps/3857/palmerston-north_urban_2018-2019_0-125m_RGB/01ESF5MHFP5RCKQW94Z2947CES/",
-      "name": "palmerston-north-urban-2018-2019-0.125m",
+      "name": "palmerston-north-2018-0.125m",
       "title": "Palmerston North 0.125m Urban Aerial Photos (2018)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/manawatu-whanganui/imagery/whanganui-urban-2015-2016-0.1m.json
+++ b/config/tileset/manawatu-whanganui/imagery/whanganui-urban-2015-2016-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_whanganui-urban-2015-2016-0.1m",
+  "id": "ts_whanganui-2015-2016-0.1m",
   "title": "Whanganui 0.1m Urban Aerial Photos (2015-2016)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["whanganui-urban-2015-2016-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/whanganui_urban_2015-16_0-1m/01F63WK62MCAAH3Q1RQ21EGHJ1/",
       "3857": "s3://linz-basemaps/3857/whanganui_urban_2015-16_0-1m/01ED83WV5VV20JWAP0MT3D7W4W/",
-      "name": "whanganui-urban-2015-2016-0.1m",
+      "name": "whanganui-2015-2016-0.1m",
       "title": "Whanganui 0.1m Urban Aerial Photos (2015-2016)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/manawatu-whanganui/imagery/whanganui-urban-2017-2018-0.075m.json
+++ b/config/tileset/manawatu-whanganui/imagery/whanganui-urban-2017-2018-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_whanganui-urban-2017-2018-0.075m",
+  "id": "ts_whanganui-2017-0.075m",
   "title": "Whanganui 0.075m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["whanganui-urban-2017-2018-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/whanganui_urban_2017-18_0-075m/01F6P22D2ENZ889MYXP3WN950N/",
       "3857": "s3://linz-basemaps/3857/whanganui_urban_2017-18_0-075m/01ED83XAAFYRNDQFZJRBSH21TF/",
-      "name": "whanganui-urban-2017-2018-0.075m",
+      "name": "whanganui-2017-0.075m",
       "title": "Whanganui 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/marlborough/imagery/marlborough-rural-2011-2012-0.4m.json
+++ b/config/tileset/marlborough/imagery/marlborough-rural-2011-2012-0.4m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_marlborough-rural-2011-2012-0.4m",
+  "id": "ts_marlborough-2011-2012-0.4m",
   "title": "Marlborough 0.4m Rural Aerial Photos (2011-2012)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["marlborough-rural-2011-2012-0.4m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/marlborough_rural_2011-2012_0-40m_RGBA/01F6P1CMT137757Y7M473TP4MG/",
       "3857": "s3://linz-basemaps/3857/marlborough_rural_2011-2012_0-40m_RGBA/01ED82KF10YWWCA59936P87R9B/",
-      "name": "marlborough-rural-2011-2012-0.4m",
+      "name": "marlborough-2011-2012-0.4m",
       "title": "Marlborough 0.4m Rural Aerial Photos (2011-2012)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/marlborough/imagery/marlborough-rural-2015-2016-0.2m.json
+++ b/config/tileset/marlborough/imagery/marlborough-rural-2015-2016-0.2m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_marlborough-rural-2015-2016-0.2m",
+  "id": "ts_marlborough-2015-2016-0.2m",
   "title": "Marlborough 0.2m Rural Aerial Photos (2015-2016)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["marlborough-rural-2015-2016-0.2m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/marlborough_rural_2015-2016_0-20m_RGBA/01F6P1D8DJGBN4QNAB2Y64DVV3/",
       "3857": "s3://linz-basemaps/3857/marlborough_rural_2015-2016_0-20m_RGBA/01ED82MG0Q6A8VFAJSY7Q543N5/",
-      "name": "marlborough-rural-2015-2016-0.2m",
+      "name": "marlborough-2015-2016-0.2m",
       "title": "Marlborough 0.2m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/marlborough/imagery/marlborough-urban-2017-2018-0.1m.json
+++ b/config/tileset/marlborough/imagery/marlborough-urban-2017-2018-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_marlborough-urban-2017-2018-0.1m",
+  "id": "ts_marlborough-2017-0.1m",
   "title": "Marlborough 0.1m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["marlborough-urban-2017-2018-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/marlborough_urban_2017-18_0-1m/01F6P1EM0AK6GZN9TG913VB6CH/",
       "3857": "s3://linz-basemaps/3857/marlborough_urban_2017-18_0-1m/01ED82QS0GBHX38Z6B1YHQNZM0/",
-      "name": "marlborough-urban-2017-2018-0.1m",
+      "name": "marlborough-2017-0.1m",
       "title": "Marlborough 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/marlborough/imagery/marlborough-urban-2020-2021-0.1m.json
+++ b/config/tileset/marlborough/imagery/marlborough-urban-2020-2021-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_marlborough-urban-2020-2021-0.1m",
+  "id": "ts_marlborough-2020-2021-0.1m",
   "title": "Marlborough 0.1m Urban Aerial Photos (2020-2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["marlborough-urban-2020-2021-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/marlborough_urban_2020-2021_0-1m_RGB/01FCKSW2KY42Z0HA11BJ4RMZ0S/",
       "3857": "s3://linz-basemaps/3857/marlborough_urban_2020-2021_0-1m_RGB/01FCKSYT6Y3ZJJ4SAKKB4GEK52/",
-      "name": "marlborough-urban-2020-2021-0.1m",
+      "name": "marlborough-2020-2021-0.1m",
       "title": "Marlborough 0.1m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/new-zealand/imagery/north-island-2023-10m.json
+++ b/config/tileset/new-zealand/imagery/north-island-2023-10m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_north-island-2023-10m",
+  "id": "ts_north-island-20230220-10m",
   "title": "Cyclone Gabrielle North Island 10m Satellite Imagery (18-21 February 2023)",
   "background": "#00000000",
   "category": "Event",
+  "aliases": ["north-island-2023-10m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/north-island_2023_10m/01GV1YW3PFVAD8089Q96W69WYT/",
       "3857": "s3://linz-basemaps/3857/north-island_2023_10m/01GV1YWSQ3V9F2ZQ7KYCT6VR72/",
-      "name": "north-island-2023-10m",
+      "name": "north-island-20230220-10m",
       "title": "Cyclone Gabrielle North Island 10m Satellite Imagery (18-21 February 2023)",
       "category": "Event",
       "minZoom": 0,

--- a/config/tileset/new-zealand/imagery/north-island-pre-cyclone-gabrielle-2022-10m.json
+++ b/config/tileset/new-zealand/imagery/north-island-pre-cyclone-gabrielle-2022-10m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_north-island-pre-cyclone-gabrielle-2022-10m",
+  "id": "ts_north-island-20221122-10m",
   "title": "Cyclone Gabrielle [Before] North Island 10m Satellite Imagery (22 November 2022)",
   "background": "#00000000",
   "category": "Event",
+  "aliases": ["north-island-pre-cyclone-gabrielle-2022-10m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/north-island-pre-cyclone-gabrielle_2022_10m/01GTFV298JMC5EDMA3YVJEPBEX/",
       "3857": "s3://linz-basemaps/3857/north-island-pre-cyclone-gabrielle_2022_10m/01GTFV2P4GH36AS9P3AZ88ABYY/",
-      "name": "north-island-pre-cyclone-gabrielle-2022-10m",
+      "name": "north-island-20221122-10m",
       "title": "Cyclone Gabrielle [Before] North Island 10m Satellite Imagery (22 November 2022)",
       "category": "Event",
       "minZoom": 0,

--- a/config/tileset/new-zealand/imagery/nz-satellite-2020-2021-10m.json
+++ b/config/tileset/new-zealand/imagery/nz-satellite-2020-2021-10m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_nz-satellite-2020-2021-10m",
+  "id": "ts_new-zealand-2020-2021-10m",
   "title": "New Zealand 10m Satellite Imagery (2020-2021)",
   "background": "#00000000",
   "category": "Satellite Imagery",
+  "aliases": ["nz-satellite-2020-2021-10m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2020-2021_10m_RGB/01FHV9VX322F20JYYZ90ZPPM3R/",
       "3857": "s3://linz-basemaps/3857/nz_satellite_2020-2021_10m_RGB/01FHV461P0C5H79T2VXE4T201J/",
-      "name": "nz-satellite-2020-2021-10m",
+      "name": "new-zealand-2020-2021-10m",
       "title": "New Zealand 10m Satellite Imagery (2020-2021)",
       "category": "Satellite Imagery",
       "minZoom": 0,

--- a/config/tileset/new-zealand/imagery/nz_satellite_2021-2022_10m.json
+++ b/config/tileset/new-zealand/imagery/nz_satellite_2021-2022_10m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_nz-satellite-2021-2022-10m",
+  "id": "ts_new-zealand-2021-2022-10m",
   "title": "New Zealand 10m Satellite Imagery (2021-2022)",
   "background": "#00000000",
   "category": "Satellite Imagery",
+  "aliases": ["nz-satellite-2021-2022-10m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/nz_satellite_2021-2022_10m_RGB/01G73E4AMSQ91TXQ3KC90NNPA0/",
       "3857": "s3://linz-basemaps/3857/nz_satellite_2021-2022_10m_RGB/01G73E5DZKE9NSW6E41QQRT28T/",
-      "name": "nz-satellite-2021-2022-10m",
+      "name": "new-zealand-2021-2022-10m",
       "title": "New Zealand 10m Satellite Imagery (2021-2022)",
       "category": "Satellite Imagery",
       "minZoom": 0,

--- a/config/tileset/otago/imagery/dunedin-rural-2013-0.4m.json
+++ b/config/tileset/otago/imagery/dunedin-rural-2013-0.4m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_dunedin-rural-2013-0.4m",
+  "id": "ts_dunedin-2013-0.4m",
   "title": "Dunedin 0.4m Rural Aerial Photos (2013)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["dunedin-rural-2013-0.4m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/dunedin_rural_2013_0-40m_RGBA/01F6P12CMF8AKCDGVCGRB06B0G/",
       "3857": "s3://linz-basemaps/3857/dunedin_rural_2013_0-40m_RGBA/01ED8265AEHZM2DHB43GBFE5BG/",
-      "name": "dunedin-rural-2013-0.4m",
+      "name": "dunedin-2013-0.4m",
       "title": "Dunedin 0.4m Rural Aerial Photos (2013)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/otago/imagery/otago-rural-2013-2014-0.4m.json
+++ b/config/tileset/otago/imagery/otago-rural-2013-2014-0.4m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_otago-rural-2013-2014-0.4m",
+  "id": "ts_otago-2013-2014-0.4m",
   "title": "Otago 0.4m Rural Aerial Photos (2013-2014)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["otago-rural-2013-2014-0.4m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/otago_rural_2013-2014_0-40m_RGBA/01F6P1MWWWTB2CE6FSCWPX6AKR/",
       "3857": "s3://linz-basemaps/3857/otago_rural_2013-2014_0-40m_RGBA/01ED8312YJGXG5195GMTGY9MNK/",
-      "name": "otago-rural-2013-2014-0.4m",
+      "name": "otago-2013-2014-0.4m",
       "title": "Otago 0.4m Rural Aerial Photos (2013-2014)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/southland/imagery/invercargill-urban-2016-0.05m.json
+++ b/config/tileset/southland/imagery/invercargill-urban-2016-0.05m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_invercargill-urban-2016-0.05m",
+  "id": "ts_invercargill-2016-0.05m",
   "title": "Invercargill 0.05m Urban Aerial Photos (2016)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["invercargill-urban-2016-0.05m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-05m/01F6P1A2VKHHFQW764DRW93G4Y/",
       "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-05m/01ED82DPKVVWA818DY9QQ9GS0J/",
-      "name": "invercargill-urban-2016-0.05m",
+      "name": "invercargill-2016-0.05m",
       "title": "Invercargill 0.05m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/southland/imagery/invercargill-urban-2016-0.1m.json
+++ b/config/tileset/southland/imagery/invercargill-urban-2016-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_invercargill-urban-2016-0.1m",
+  "id": "ts_invercargill-2016-0.1m",
   "title": "Invercargill 0.1m Urban Aerial Photos (2016)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["invercargill-urban-2016-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/invercargill_urban_2016_0-1m/01F6P1A7YH7JXE247G85F25WG6/",
       "3857": "s3://linz-basemaps/3857/invercargill_urban_2016_0-1m/01ED82E60KN099T9A8V11KCSK0/",
-      "name": "invercargill-urban-2016-0.1m",
+      "name": "invercargill-2016-0.1m",
       "title": "Invercargill 0.1m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/taranaki/imagery/new-plymouth-urban-2017-0.1m.json
+++ b/config/tileset/taranaki/imagery/new-plymouth-urban-2017-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_new-plymouth-urban-2017-0.1m",
+  "id": "ts_new-plymouth-2017-0.1m",
   "title": "New Plymouth 0.10m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["new-plymouth-urban-2017-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/new-plymouth_urban_2017_0-10m/01F6P1FPAFD6D8SRHZX3GFJFWY/",
       "3857": "s3://linz-basemaps/3857/new-plymouth_urban_2017_0-10m/01ED82VQR8M1STH3EPMF3E8KFQ/",
-      "name": "new-plymouth-urban-2017-0.1m",
+      "name": "new-plymouth-2017-0.1m",
       "title": "New Plymouth 0.10m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/taranaki/imagery/taranaki-rural-2016-2017-0.3m.json
+++ b/config/tileset/taranaki/imagery/taranaki-rural-2016-2017-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_taranaki-rural-2016-2017-0.3m",
+  "id": "ts_taranaki-2016-2018-0.3m",
   "title": "Taranaki 0.3m Rural Aerial Photos (2016-2018)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["taranaki-rural-2016-2017-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/taranaki_rural_2016-17_0-3m/01F6P1SZXEN3X5SDKT7XRQHEGY/",
       "3857": "s3://linz-basemaps/3857/taranaki_rural_2016-17_0-3m/01ED83B7TAK5SBKVYFJZMTE9AV/",
-      "name": "taranaki-rural-2016-2017-0.3m",
+      "name": "taranaki-2016-2018-0.3m",
       "title": "Taranaki 0.3m Rural Aerial Photos (2016-2018)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-rural-2001-2002-1m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2001-2002-1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tasman-rural-2001-2002-1m",
+  "id": "ts_tasman-2001-2002-1m",
   "title": "Tasman 1m Rural Aerial Photos (2001-2002)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["tasman-rural-2001-2002-1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2001-2002_1m_RGB/01F6P1TJ28B0HSRV2MNTBFSMKA/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2001-2002_1m_RGB/01EE9646WHWA7X46KDRATVWY9Z/",
-      "name": "tasman-rural-2001-2002-1m",
+      "name": "tasman-2001-2002-1m",
       "title": "Tasman 1m Rural Aerial Photos (2001-2002)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-rural-2009-2010-0.5m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2009-2010-0.5m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tasman-rural-2009-2010-0.5m",
+  "id": "ts_tasman-2009-2010-0.5m",
   "title": "Tasman 0.5m Rural Aerial Photos (2009-2010)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["tasman-rural-2009-2010-0.5m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2009-2010_0-50m_RGBA/01F6P1TWRFSGJ65V9Z0YXX4DHY/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2009-2010_0-50m_RGBA/01ED83CJ5ZT8SAGQKFT9MM59XR/",
-      "name": "tasman-rural-2009-2010-0.5m",
+      "name": "tasman-2009-2010-0.5m",
       "title": "Tasman 0.5m Rural Aerial Photos (2009-2010)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-rural-2015-2016-0.3m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2015-2016-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tasman-rural-2015-2016-0.3m",
+  "id": "ts_tasman-2015-2016-0.3m",
   "title": "Tasman 0.3m Rural Aerial Photos (2015-2016)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["tasman-rural-2015-2016-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2015-16_0-3m/01F6P1V269CD5Z3Z5EC0Q8P7V6/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2015-16_0-3m/01ED83CXGMGPXTF67SETE7YBWP/",
-      "name": "tasman-rural-2015-2016-0.3m",
+      "name": "tasman-2015-2016-0.3m",
       "title": "Tasman 0.3m Rural Aerial Photos (2015-2016)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-rural-2016-2017-0.3m.json
+++ b/config/tileset/tasman/imagery/tasman-rural-2016-2017-0.3m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tasman-rural-2016-2017-0.3m",
+  "id": "ts_tasman-2016-2017-0.3m",
   "title": "Tasman 0.3m Rural Aerial Photos (2016-2017)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["tasman-rural-2016-2017-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_rural_2016-17_0-3m/01F6P1V84P2HJ1YB0D5X1CSWJH/",
       "3857": "s3://linz-basemaps/3857/tasman_rural_2016-17_0-3m/01ED83DC7MCMBCRNN45E07HCHH/",
-      "name": "tasman-rural-2016-2017-0.3m",
+      "name": "tasman-2016-2017-0.3m",
       "title": "Tasman 0.3m Rural Aerial Photos (2016-2017)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-urban-2017-0.075m.json
+++ b/config/tileset/tasman/imagery/tasman-urban-2017-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tasman-urban-2017-0.075m",
+  "id": "ts_tasman-2017-0.075m",
   "title": "Tasman 0.075m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["tasman-urban-2017-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_urban_2017_0-075m/01F6P1VT8BV5T0DPVSG1VEJX0Y/",
       "3857": "s3://linz-basemaps/3857/tasman_urban_2017_0-075m/01ED83ENCYFX7KFVKH0S7SK92W/",
-      "name": "tasman-urban-2017-0.075m",
+      "name": "tasman-2017-0.075m",
       "title": "Tasman 0.075m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-urban-2017-0.1m.json
+++ b/config/tileset/tasman/imagery/tasman-urban-2017-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tasman-urban-2017-0.1m",
+  "id": "ts_tasman-2017-0.1m",
   "title": "Tasman 0.1m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["tasman-urban-2017-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_urban_2017_0-1m/01F6P1VW99KC0PEBYPDAZ3RNKK/",
       "3857": "s3://linz-basemaps/3857/tasman_urban_2017_0-1m/01ED83F2SBS02QP80KSQ3GRR92/",
-      "name": "tasman-urban-2017-0.1m",
+      "name": "tasman-2017-0.1m",
       "title": "Tasman 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-urban-2020-0.1m.json
+++ b/config/tileset/tasman/imagery/tasman-urban-2020-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tasman-urban-2020-0.1m",
+  "id": "ts_tasman-2020-0.1m",
   "title": "Tasman 0.1m Urban Aerial Photos (2020)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["tasman-urban-2020-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_urban_2020_0-1m_RGB/01FDQV9ZW9ETAQB2VJG26WGHP3/",
       "3857": "s3://linz-basemaps/3857/tasman_urban_2020_0-1m_RGB/01FDQVCGEJA1YQJBT14AVZ3TJC/",
-      "name": "tasman-urban-2020-0.1m",
+      "name": "tasman-2020-0.1m",
       "title": "Tasman 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/tasman/imagery/tasman-urban-2020-2021-0.075m.json
+++ b/config/tileset/tasman/imagery/tasman-urban-2020-2021-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_tasman-urban-2020-2021-0.075m",
+  "id": "ts_tasman-2020-2021-0.075m",
   "title": "Tasman 0.075m Urban Aerial Photos (2020-2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["tasman-urban-2020-2021-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/tasman_urban_2020-2021_0-075m_RGB/01FDTG4HYDSJ0E4SNV54E3CCJM/",
       "3857": "s3://linz-basemaps/3857/tasman_urban_2020-2021_0-075m_RGB/01FDTG1HG7S4HBR2BQPTE7ZRWJ/",
-      "name": "tasman-urban-2020-2021-0.075m",
+      "name": "tasman-2020-2021-0.075m",
       "title": "Tasman 0.075m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/waikato/imagery/hamilton-urban-2016-2017-0.1m.json
+++ b/config/tileset/waikato/imagery/hamilton-urban-2016-2017-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hamilton-urban-2016-2017-0.1m",
+  "id": "ts_hamilton-2016-2017-0.1m",
   "title": "Hamilton 0.1m Urban Aerial Photos (2016-2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hamilton-urban-2016-2017-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hamilton_urban_2016-17_0-1m/01F6P16P7FMHSDAWX2VM3PKAHS/",
       "3857": "s3://linz-basemaps/3857/hamilton_urban_2016-17_0-1m/01EDAN1CYCXAEMG21PB6VCD0KX/",
-      "name": "hamilton-urban-2016-2017-0.1m",
+      "name": "hamilton-2016-2017-0.1m",
       "title": "Hamilton 0.1m Urban Aerial Photos (2016-2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/waikato/imagery/hamilton-urban-2019-0.1m.json
+++ b/config/tileset/waikato/imagery/hamilton-urban-2019-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hamilton-urban-2019-0.1m",
+  "id": "ts_hamilton-2019-0.1m",
   "title": "Hamilton 0.1m Urban Aerial Photos (2019)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hamilton-urban-2019-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hamilton_urban_2019_0-1m/01F6P16V72XPFJK2X5V68YYM0X/",
       "3857": "s3://linz-basemaps/3857/hamilton_urban_2019_0-1m/01ED8284FFT9RYZ0F7XTKD64D4/",
-      "name": "hamilton-urban-2019-0.1m",
+      "name": "hamilton-2019-0.1m",
       "title": "Hamilton 0.1m Urban Aerial Photos (2019)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/waikato/imagery/hamilton-urban-2020-2021-0.05m.json
+++ b/config/tileset/waikato/imagery/hamilton-urban-2020-2021-0.05m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hamilton-urban-2020-2021-0.05m",
+  "id": "ts_hamilton-2020-2021-0.05m",
   "title": "Hamilton 0.05m Urban Aerial Photos (2020-2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hamilton-urban-2020-2021-0.05m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hamilton_urban_2020-2021_0-05m_RGB/01GASE5J7NJSZRVD92X9J655TQ/",
       "3857": "s3://linz-basemaps/3857/hamilton_urban_2020-2021_0-05m_RGB/01GASE6HES5VTVKV66G5S82KV3/",
-      "name": "hamilton-urban-2020-2021-0.05m",
+      "name": "hamilton-2020-2021-0.05m",
       "title": "Hamilton 0.05m Urban Aerial Photos (2020-2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/waikato/imagery/otorohanga-2021-0.1m.json
+++ b/config/tileset/waikato/imagery/otorohanga-2021-0.1m.json
@@ -1,7 +1,7 @@
 {
   "type": "raster",
   "id": "ts_otorohanga-2021-0.1m",
-  "name": "ōtorohanga-urban-2021-0.1m",
+  "name": "otorohanga-2021-0.1m",
   "title": "Ōtorohanga 0.1m Urban Aerial Photos (2021)",
   "background": {
     "r": 0,
@@ -10,12 +10,12 @@
     "alpha": 0
   },
   "category": "Urban Aerial Photos",
-  "aliases": ["otorohanga-2021-0.1m"],
+  "aliases": ["ōtorohanga-urban-2021-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/ōtorohanga_urban_2021_0-1m_RGB/01FYWKAJ86W9P7RWM1VB62KD0H/",
       "3857": "s3://linz-basemaps/3857/ōtorohanga_urban_2021_0-1m_RGB/01FYWKATAEK2ZTJQ2PX44Y0XNT/",
-      "name": "ōtorohanga-urban-2021-0.1m",
+      "name": "otorohanga-2021-0.1m",
       "title": "Ōtorohanga 0.1m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/waikato/imagery/thames-coromandel-urban-2015-0.05m.json
+++ b/config/tileset/waikato/imagery/thames-coromandel-urban-2015-0.05m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_thames-coromandel-urban-2015-0.05m",
+  "id": "ts_thames-coromandel-2015-0.05m",
   "title": "Thames-Coromandel 0.05m Urban Aerial Photos (2015)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["thames-coromandel-urban-2015-0.05m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/thames-coromandel_urban_2015_0-05m/01F6P1WD2YV0SQ3WE62RZ0RJY5/",
       "3857": "s3://linz-basemaps/3857/thames-coromandel_urban_2015_0-05m/01ED83GB3JEMR4D72PFD8JVCV6/",
-      "name": "thames-coromandel-urban-2015-0.05m",
+      "name": "thames-coromandel-2015-0.05m",
       "title": "Thames-Coromandel 0.05m Urban Aerial Photos (2015)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/waikato/imagery/waikato-rural-2012-2013-0.5m.json
+++ b/config/tileset/waikato/imagery/waikato-rural-2012-2013-0.5m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waikato-rural-2012-2013-0.5m",
+  "id": "ts_waikato-2012-2013-0.5m",
   "title": "Waikato 0.5m Rural Aerial Photos (2012-2013)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
+  "aliases": ["waikato-rural-2012-2013-0.5m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waikato_rural_2012-2013_0-50m_RGBA/01F6P1XPDV00F86GA8J626Y3BM/",
       "3857": "s3://linz-basemaps/3857/waikato_rural_2012-2013_0-50m_RGBA/01ED83K3YEJ0FSG0DHCFTVBEF7/",
-      "name": "waikato-rural-2012-2013-0.5m",
+      "name": "waikato-2012-2013-0.5m",
       "title": "Waikato 0.5m Rural Aerial Photos (2012-2013)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/waikato/imagery/waikato-urban-2014-0.1m.json
+++ b/config/tileset/waikato/imagery/waikato-urban-2014-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_waikato-urban-2014-0.1m",
+  "id": "ts_waikato-district-2014-0.1m",
   "title": "Waikato District 0.1m Urban Aerial Photos (2014)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["waikato-urban-2014-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/waikato_urban_2014_0-10m_RGBA/01F6P1ZQZ4X5GHHX544CJJ3NNH/",
       "3857": "s3://linz-basemaps/3857/waikato_urban_2014_0-10m_RGBA/01ED83NZS98MYTMWM4D1EVZ07T/",
-      "name": "waikato-urban-2014-0.1m",
+      "name": "waikato-district-2014-0.1m",
       "title": "Waikato District 0.1m Urban Aerial Photos (2014)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/hutt-city-urban-2017-0.1m.json
+++ b/config/tileset/wellington/imagery/hutt-city-urban-2017-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hutt-city-urban-2017-0.1m",
+  "id": "ts_hutt-city-2017-0.1m",
   "title": "Hutt City 0.10m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hutt-city-urban-2017-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hutt-city_urban_2017_0-10m/01F6P19XT96PPWHAABTAGXGV3N/",
       "3857": "s3://linz-basemaps/3857/hutt-city_urban_2017_0-10m/01ED82D0F9NBGVM9WRRT46AV1V/",
-      "name": "hutt-city-urban-2017-0.1m",
+      "name": "hutt-city-2017-0.1m",
       "title": "Hutt City 0.10m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/hutt-city-urban-2021-0.075m.json
+++ b/config/tileset/wellington/imagery/hutt-city-urban-2021-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_hutt-city-urban-2021-0.075m",
+  "id": "ts_hutt-city-2021-0.075m",
   "title": "Hutt City 0.075m Urban Aerial Photos (2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["hutt-city-urban-2021-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/hutt-city_urban_2021_0-075m_RGB/01FFGK6PT74ZGK3VFX3PY50S0S/",
       "3857": "s3://linz-basemaps/3857/hutt-city_urban_2021_0-075m_RGB/01FFGK7ZHHJ4SCYWMET8J4K3J1/",
-      "name": "hutt-city-urban-2021-0.075m",
+      "name": "hutt-city-2021-0.075m",
       "title": "Hutt City 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/kapiti-coast-2017-0.10m.json
+++ b/config/tileset/wellington/imagery/kapiti-coast-2017-0.10m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_kapiti-coast-2017-0.10m",
+  "id": "ts_kapiti-coast-2017-0.1m",
   "title": "Kapiti Coast 0.10m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["kapiti-coast-2017-0.10m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/kapiti-coast_2017_0.10m/01GYDZV2MK43PJNEVXPZSHDZ4F/",
       "3857": "s3://linz-basemaps/3857/kapiti-coast_2017_0.10m/01GYDZVZ557KRJP17670MJZ1T7/",
-      "name": "kapiti-coast-2017-0.10m",
+      "name": "kapiti-coast-2017-0.1m",
       "title": "Kapiti Coast 0.10m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/porirua-urban-2016-0.075m.json
+++ b/config/tileset/wellington/imagery/porirua-urban-2016-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_porirua-urban-2016-0.075m",
+  "id": "ts_porirua-2016-0.075m",
   "title": "Porirua 0.075m Urban Aerial Photos (2016)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["porirua-urban-2016-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/porirua_urban_2016_0-075m/01F6P1PP0S3T9HTDTDJW7ADAEH/",
       "3857": "s3://linz-basemaps/3857/porirua_urban_2016_0-075m/01ED834RYVP97AYQVDDQ6MJECY/",
-      "name": "porirua-urban-2016-0.075m",
+      "name": "porirua-2016-0.075m",
       "title": "Porirua 0.075m Urban Aerial Photos (2016)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/porirua-urban-2020-0.1m.json
+++ b/config/tileset/wellington/imagery/porirua-urban-2020-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_porirua-urban-2020-0.1m",
+  "id": "ts_porirua-2020-0.1m",
   "title": "Porirua 0.1m Urban Aerial Photos (2020)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["porirua-urban-2020-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/porirua_urban_2020_0-10m_RGB/01F6P1PTH5SBS82G5VVKYHFR63/",
       "3857": "s3://linz-basemaps/3857/porirua_urban_2020_0-10m_RGB/01ESM35CSPVJD54ZMT4T5FVV29/",
-      "name": "porirua-urban-2020-0.1m",
+      "name": "porirua-2020-0.1m",
       "title": "Porirua 0.1m Urban Aerial Photos (2020)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/upper-hutt-urban-2017-0.1m.json
+++ b/config/tileset/wellington/imagery/upper-hutt-urban-2017-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_upper-hutt-urban-2017-0.1m",
+  "id": "ts_upper-hutt-2017-0.1m",
   "title": "Upper Hutt 0.1m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["upper-hutt-urban-2017-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/upper-hutt_urban_2017_0-10m/01F6P1XK2AVYDJ66NY2MKSEXW1/",
       "3857": "s3://linz-basemaps/3857/upper-hutt_urban_2017_0-10m/01ED83JPKMXF5TVKFD4RP91ZRB/",
-      "name": "upper-hutt-urban-2017-0.1m",
+      "name": "upper-hutt-2017-0.1m",
       "title": "Upper Hutt 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/upper-hutt-urban-2021-0.075m.json
+++ b/config/tileset/wellington/imagery/upper-hutt-urban-2021-0.075m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_upper-hutt-urban-2021-0.075m",
+  "id": "ts_upper-hutt-2021-0.075m",
   "title": "Upper Hutt 0.075m Urban Aerial Photos (2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["upper-hutt-urban-2021-0.075m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/upper-hutt_urban_2021_0-075m_RGB/01FFH545V69N2SC5K4PSH7VZCV/",
       "3857": "s3://linz-basemaps/3857/upper-hutt_urban_2021_0-075m_RGB/01FFH51T317TVK35J75ZRZV0PN/",
-      "name": "upper-hutt-urban-2021-0.075m",
+      "name": "upper-hutt-2021-0.075m",
       "title": "Upper Hutt 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/wellington-city-urban-2021-0.075m.json
+++ b/config/tileset/wellington/imagery/wellington-city-urban-2021-0.075m.json
@@ -1,6 +1,6 @@
 {
   "type": "raster",
-  "id": "ts_wellington-city-urban-2021-0.075m",
+  "id": "ts_wellington-2021-0.075m",
   "title": "Wellington City 0.075m Urban Aerial Photos (2021)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
@@ -9,7 +9,7 @@
     {
       "2193": "s3://linz-basemaps/2193/wellington-city_urban_2021_0-075m_RGB/01GBRRFSNR0V1N50WP0H1E7SDP/",
       "3857": "s3://linz-basemaps/3857/wellington-city_urban_2021_0-075m_RGB/01GBRRG6Z6Q8SJNECE7K49M88R/",
-      "name": "wellington-city-urban-2021-0.075m",
+      "name": "wellington-2021-0.075m",
       "title": "Wellington City 0.075m Urban Aerial Photos (2021)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,

--- a/config/tileset/wellington/imagery/wellington-rural-2021-0.3m.json
+++ b/config/tileset/wellington/imagery/wellington-rural-2021-0.3m.json
@@ -4,16 +4,16 @@
   "title": "Wellington 0.3m Rural Aerial Photos (2021)",
   "background": "#00000000",
   "category": "Rural Aerial Photos",
-  "aliases": ["wellington-2021-0.3m"],
+  "aliases": ["wellington-rural-2021-0.3m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/wellington_rural_2021_0-3m_RGB/01FB82NZY0ASDQBKT28DSXS8XC/",
       "3857": "s3://linz-basemaps/3857/wellington_rural_2021_0-3m_RGB/01FB82QKPWEHV0FWN7KBXM6NDM/",
-      "name": "wellington-rural-2021-0.3m",
+      "name": "wellington-2021-0.3m",
       "title": "Wellington 0.3m Rural Aerial Photos (2021)",
       "category": "Rural Aerial Photos",
       "minZoom": 0,
-	  "maxZoom": 32
+      "maxZoom": 32
     }
   ]
 }

--- a/config/tileset/wellington/imagery/wellington-urban-2017-0.1m.json
+++ b/config/tileset/wellington/imagery/wellington-urban-2017-0.1m.json
@@ -1,14 +1,15 @@
 {
   "type": "raster",
-  "id": "ts_wellington-urban-2017-0.1m",
+  "id": "ts_wellington-2017-0.1m",
   "title": "Wellington 0.1m Urban Aerial Photos (2017)",
   "background": "#00000000",
   "category": "Urban Aerial Photos",
+  "aliases": ["wellington-urban-2017-0.1m"],
   "layers": [
     {
       "2193": "s3://linz-basemaps/2193/wellington_urban_2017_0-10m/01F6P21F387PCQQB757VZ4E6GS/",
       "3857": "s3://linz-basemaps/3857/wellington_urban_2017_0-10m/01ED83SQ85A7B1MJ42BK13EGCQ/",
-      "name": "wellington-urban-2017-0.1m",
+      "name": "wellington-2017-0.1m",
       "title": "Wellington 0.1m Urban Aerial Photos (2017)",
       "category": "Urban Aerial Photos",
       "minZoom": 0,


### PR DESCRIPTION
### Motivation

Some of the layers have names which do not align with the slug in the source dataset's collection.json which is stored on the ODR.
In order to automate the creation of an imagery survey index in the future, a relationship needs to be established between the dataset on the ODR and the corresponding layer in Basemaps. This will create that relationship.
The focus of this update is individual layers only. The layers in the aerial.json will be dealt with separately. 

### Modifications

Update the id and name where it does not match the slug on the ODR. Make old name as an alias.

